### PR TITLE
fix: include labels in issue view output

### DIFF
--- a/src/api/jira/issues.rs
+++ b/src/api/jira/issues.rs
@@ -48,7 +48,7 @@ impl JiraClient {
     /// Get a single issue by key.
     pub async fn get_issue(&self, key: &str) -> Result<Issue> {
         let path = format!(
-            "/rest/api/3/issue/{}?fields=summary,status,issuetype,priority,assignee,project,description",
+            "/rest/api/3/issue/{}?fields=summary,status,issuetype,priority,assignee,project,description,labels",
             urlencoding::encode(key)
         );
         self.get(&path).await

--- a/src/cli/issue.rs
+++ b/src/cli/issue.rs
@@ -340,6 +340,16 @@ async fn handle_view(key: &str, output_format: &OutputFormat, client: &JiraClien
                         .map(|p| format!("{} ({})", p.name.as_deref().unwrap_or(""), p.key))
                         .unwrap_or_default(),
                 ],
+                vec![
+                    "Labels".into(),
+                    issue
+                        .fields
+                        .labels
+                        .as_ref()
+                        .filter(|l| !l.is_empty())
+                        .map(|l| l.join(", "))
+                        .unwrap_or_else(|| "(none)".into()),
+                ],
                 vec!["Description".into(), desc_text],
             ];
 

--- a/src/types/jira/issue.rs
+++ b/src/types/jira/issue.rs
@@ -19,6 +19,8 @@ pub struct IssueFields {
     pub priority: Option<Priority>,
     pub assignee: Option<User>,
     pub project: Option<IssueProject>,
+    #[serde(default)]
+    pub labels: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
## Summary

- Add `labels` to the `?fields=` query in `get_issue()` so the API returns them
- Add `labels: Option<Vec<String>>` to `IssueFields` struct
- Display labels row in `jr issue view` table output (shows comma-separated list or "(none)")
- Labels included in `--output json` for AI agent consumption

## Test plan

- [x] `jr issue view KEY-123` — shows Labels row in table
- [x] `jr issue view KEY-123 --output json` — labels field present in JSON
- [x] Added test label, verified it displays, removed test label
- [x] 63 unit tests pass, clippy clean