### PR TITLE
chore: add CODEOWNERS for project owner review requirements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Project owners — required reviewers for all PRs
+* @Zious11


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` designating @Zious11 as project owner
- All PRs to `main` and `develop` require code owner approval
- Admins (project owners) can bypass protection to merge anywhere

## Branch protection rules
| Branch | PR Review | CI Required | Admin Bypass |
|---|---|---|---|
| `main` | Code owner approval required | All 6 checks | Yes |
| `develop` | Code owner approval required | All 6 checks | Yes |