### PR TITLE
docs: update README and CLAUDE.md for v0.2.0 features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,9 @@ src/
 │       ├── fields.rs    # list fields, story points field discovery
 │       ├── links.rs     # create/delete issue links, list link types
 │       ├── teams.rs     # org metadata (GraphQL), list teams
-│       └── worklogs.rs  # add/list worklogs
+│       ├── worklogs.rs  # add/list worklogs
+│       ├── projects.rs  # project details
+│       └── users.rs     # current user, assignable users
 ├── types/jira/          # Serde structs for API responses (Issue, Board, Sprint, User, Team, etc.)
 ├── cache.rs             # XDG cache (~/.cache/jr/) — team list with 7-day TTL
 ├── config.rs            # Global (~/.config/jr/config.toml) + per-project (.jr.toml), figment layering
@@ -61,7 +63,7 @@ cargo deny check                     # License + vulnerability audit
 
 - **Commits:** Conventional Commits format (`feat:`, `fix:`, `docs:`, `chore:`, `ci:`, `test:`)
 - **Branches:** `type/short-description` (e.g., `feat/issue-commands`, `fix/auth-flow`). Default branch is `develop`. Feature branches → PR to `develop` → PR to `main` for releases.
-- **Protected branches:** `main` and `develop` require CI to pass. PRs require code owner approval. Admins can bypass.
+- **Protected branches:** `main` and `develop` require CI to pass and code owner approval on PRs. Admins can bypass.
 - **Errors:** Always suggest what to do next. Map to exit codes via `JrError::exit_code()`
 - **Output:** `--output json` returns structured JSON for both success and errors. Human text is default.
 - **Non-interactive:** `--no-input` disables prompts (auto-enabled when stdin is not a TTY). Commands must have fully non-interactive flag equivalents.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jr
 
-A fast, agent-friendly CLI for Jira Cloud, written in Rust. Built for both humans and AI agents — every command returns structured output, actionable error messages with suggested next steps, and operates fully non-interactively for automation workflows.
+A fast, agent-friendly CLI for Jira Cloud, written in Rust. Built for both humans and AI agents — commands support structured JSON output, actionable error messages with suggested next steps, and `--no-input` mode for fully non-interactive automation.
 
 ## Install
 


### PR DESCRIPTION
## Summary
- Update README intro to highlight agent-friendly design
- Fix incorrect short flags in quick start (`-p`/`-t`/`-s` → `--project`/`--type`/`--summary`)
- Add issue linking commands to README commands table
- Expand CLAUDE.md architecture tree with `api/jira/` modules
- Document branching model and branch protection rules in CLAUDE.md

## Test plan
- [x] No code changes — docs only