### PR TITLE
fix: warn when --points flag lacks story points config

### DIFF
--- a/docs/superpowers/plans/2026-03-23-explicit-flag-config-warning.md
+++ b/docs/superpowers/plans/2026-03-23-explicit-flag-config-warning.md
@@ -4,7 +4,7 @@
 
 **Goal:** Warn on stderr when `--points` flag is used but `story_points_field_id` is not configured, instead of silently skipping (closes GitHub issue #18).
 
-**Architecture:** Extract a pure function `resolve_show_points` that encapsulates the flag+config resolution with warning. Replace the inline ternary in `handle_list`. Add 3 unit tests covering all branches.
+**Architecture:** Extract a helper function `resolve_show_points` that encapsulates the flag+config resolution and emits the warning to stderr. Replace the inline ternary in `handle_list`. Add 3 unit tests covering all branches.
 
 **Tech Stack:** Rust, anyhow
 
@@ -75,7 +75,7 @@ fn resolve_show_points<'a>(show_points: bool, sp_field_id: Option<&'a str>) -> O
             None => {
                 eprintln!(
                     "warning: --points ignored. Story points field not configured. \
-                     Run \"jr init\" or set story_points_field_id in ~/.config/jr/config.toml"
+                     Run \"jr init\" or set [fields].story_points_field_id in ~/.config/jr/config.toml"
                 );
                 None
             }

--- a/docs/superpowers/specs/2026-03-23-explicit-flag-config-warning-design.md
+++ b/docs/superpowers/specs/2026-03-23-explicit-flag-config-warning-design.md
@@ -16,7 +16,7 @@ This violates the CLAUDE.md convention: "Errors: Always suggest what to do next.
 
 ### Extract `resolve_show_points` helper
 
-Extract the `show_points` + `sp_field_id` resolution into a pure function in `src/cli/issue/list.rs` so it can be unit tested:
+Extract the `show_points` + `sp_field_id` resolution into a small helper function in `src/cli/issue/list.rs` so it can be unit tested:
 
 ```rust
 /// Resolve whether to show story points. Returns the field ID if points should be shown,
@@ -28,7 +28,7 @@ fn resolve_show_points<'a>(show_points: bool, sp_field_id: Option<&'a str>) -> O
             None => {
                 eprintln!(
                     "warning: --points ignored. Story points field not configured. \
-                     Run \"jr init\" or set story_points_field_id in ~/.config/jr/config.toml"
+                     Run \"jr init\" or set [fields].story_points_field_id in ~/.config/jr/config.toml"
                 );
                 None
             }

--- a/src/cli/issue/list.rs
+++ b/src/cli/issue/list.rs
@@ -136,7 +136,7 @@ fn resolve_show_points(show_points: bool, sp_field_id: Option<&str>) -> Option<&
             None => {
                 eprintln!(
                     "warning: --points ignored. Story points field not configured. \
-                     Run \"jr init\" or set story_points_field_id in ~/.config/jr/config.toml"
+                     Run \"jr init\" or set [fields].story_points_field_id in ~/.config/jr/config.toml"
                 );
                 None
             }


### PR DESCRIPTION
## Summary

- `jr issue list --points` without `story_points_field_id` configured now emits a stderr warning instead of silently skipping the points column
- Command still succeeds (exit 0) with degraded output
- Extracted `resolve_show_points` helper with 3 unit tests covering all branches

Closes #18

## Changes

- New `resolve_show_points(show_points, sp_field_id) -> Option<&str>` function in `list.rs`
- Warning message: `warning: --points ignored. Story points field not configured. Run "jr init" or set story_points_field_id in ~/.config/jr/config.toml`
- Warning goes to stderr, clean JSON on stdout when using `--output json`
- Warning fires regardless of `--no-input` mode (AI agents need it)

## Test plan

- [x] `cargo test` — all 113 tests pass
- [x] `cargo clippy --all --all-features --tests -- -D warnings` — zero warnings
- [x] `cargo fmt --all -- --check` — clean
- [x] Manual: `jr issue list --points` without config → warning + list without points
- [x] Manual: `jr issue list --points --project MSSCI` with config → points column shown
- [x] Manual: `jr issue list --points --output json` without config → warning on stderr, clean JSON on stdout