### PR TITLE
chore: bump version to 0.4.0-dev.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.4.0-dev.3"
+version = "0.4.0-dev.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.4.0-dev.3"
+version = "0.4.0-dev.4"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary
- Bump version from `0.4.0-dev.3` to `0.4.0-dev.4` for next dev release

## Test plan
- [x] All 295 tests pass
- [x] `cargo check` updates Cargo.lock