### PR TITLE
chore: bump version to 0.4.0-dev.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.4.0-dev.4"
+version = "0.4.0-dev.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.4.0-dev.4"
+version = "0.4.0-dev.5"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary

- Bump version to `0.4.0-dev.5` for next dev pre-release

## Changes since v0.4.0-dev.4

- feat: add --limit and --all flags to sprint current (#72)
- feat: add --assignee, --reporter, --recent flags with unified JQL composition (#44)
- feat: add resolve_user helper for --assignee/--reporter name resolution
- feat: add search_users API method for user name lookup
- feat: add --project and --status input validation for issue list (#71)
- fix: add JR_AUTH_HEADER and JR_BASE_URL env var overrides for CLI integration tests