### PR TITLE
feat: show asset name only in issue list table (#102)

### DIFF
--- a/src/types/assets/linked.rs
+++ b/src/types/assets/linked.rs
@@ -30,7 +30,7 @@ impl LinkedAsset {
         }
     }
 
-    /// Name-only display for list tables: "Acme Corp", "OBJ-1", or "#12345 (run \"jr init\" to resolve asset names)".
+    /// Name-only display for list tables: "Acme Corp", "OBJ-1", or "#12345 (run `jr init` to resolve asset names)".
     pub fn display_name_only(&self) -> String {
         self.name
             .as_deref()


### PR DESCRIPTION
## Summary
- Add `display_name_only()` method to `LinkedAsset` with name-preferring fallback chain (name → key → ID hint → unknown)
- Update `format_linked_assets_short` to use it, so `issue list` table shows "Acme Corp" instead of "OBJ-1 (Acme Corp)"
- `issue view` detail display unchanged — still shows "KEY (Name)" via existing `display()` method

## Test plan
- [x] 5 new unit tests for `display_name_only()` covering all fallback cases
- [x] 2 existing `format_linked_assets_short` test assertions updated
- [x] All 457 tests passing, zero clippy warnings
- [x] Manual verification with `jr issue list --assets` against live instance