### PR TITLE
test: add case-insensitive duplicate queue name integration test (#131)

### DIFF
--- a/tests/queue.rs
+++ b/tests/queue.rs
@@ -232,7 +232,8 @@ async fn resolve_queue_duplicate_names_error_message() {
 async fn resolve_queue_mixed_case_duplicate_names_error_message() {
     let server = MockServer::start().await;
 
-    // Two queues with the same name but different casing
+    // Two queues whose names differ only in casing — unlike the exact-duplicate
+    // test above, this exercises the to_lowercase() normalization path
     Mock::given(method("GET"))
         .and(path("/rest/servicedeskapi/servicedesk/15/queue"))
         .and(query_param("includeCount", "true"))
@@ -253,8 +254,8 @@ async fn resolve_queue_mixed_case_duplicate_names_error_message() {
 
     let client =
         jr::api::client::JiraClient::new_for_test(server.uri(), "Basic dGVzdDp0ZXN0".into());
-    // Lowercase input — matches neither stored name exactly,
-    // forcing both sides of to_lowercase() to do work
+    // Lowercase input — differs in casing from both stored names,
+    // so to_lowercase() must normalize both input and candidates
     let result = jr::cli::queue::resolve_queue_by_name("15", "triage", &client).await;
 
     let err = result.unwrap_err();


### PR DESCRIPTION
## Summary

- Adds integration test `resolve_queue_mixed_case_duplicate_names_error_message` to `tests/queue.rs`
- Mocks two queues with different casing ("Triage" and "TRIAGE"), calls `resolve_queue_by_name` with lowercase "triage"
- Exercises the `to_lowercase()` filter at `src/cli/queue.rs:155-158` which was untested by the existing same-casing duplicate test

## Test plan

- [x] New test passes: `cargo test --test queue resolve_queue_mixed_case`
- [x] All 459 tests pass: `cargo test`
- [x] Clippy clean: `cargo clippy -- -D warnings`
- [x] Fmt clean: `cargo fmt --all -- --check`

Closes #131