### PR TITLE
docs: mention "me" keyword in Assign --to doc comment

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -311,7 +311,7 @@ pub enum IssueCommand {
     Assign {
         /// Issue key
         key: String,
-        /// Assign to this user (omit to assign to self)
+        /// Assign to this user (name/email, or "me" for self; omit to assign to self)
         #[arg(long, conflicts_with = "account_id")]
         to: Option<String>,
         /// Assign to this Jira accountId directly (bypasses name search)


### PR DESCRIPTION
## Summary

- Updates `Assign` variant's `--to` doc comment from `(omit to assign to self)` to `(name/email, or "me" for self; omit to assign to self)` for consistency with the `Create` variant's equivalent flag

Closes #138

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `jr issue assign --help` renders updated description correctly