### PR TITLE
test: add clap conflicts_with smoke tests for all untested flag conflicts (#140)

### DIFF
--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -163,3 +163,145 @@ fn test_assets_schema_help() {
         .stdout(predicate::str::contains("Show attributes"))
         .stdout(predicate::str::contains("--schema"));
 }
+
+// --- conflicts_with smoke tests ---
+
+#[test]
+fn test_assign_to_and_account_id_conflict() {
+    Command::cargo_bin("jr")
+        .unwrap()
+        .args([
+            "issue",
+            "assign",
+            "FOO-1",
+            "--to",
+            "Jane",
+            "--account-id",
+            "abc123",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn test_assign_account_id_and_unassign_conflict() {
+    Command::cargo_bin("jr")
+        .unwrap()
+        .args([
+            "issue",
+            "assign",
+            "FOO-1",
+            "--account-id",
+            "abc123",
+            "--unassign",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn test_create_to_and_account_id_conflict() {
+    Command::cargo_bin("jr")
+        .unwrap()
+        .args([
+            "issue",
+            "create",
+            "-p",
+            "FOO",
+            "-t",
+            "Task",
+            "-s",
+            "Test",
+            "--to",
+            "Jane",
+            "--account-id",
+            "abc123",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn test_create_description_and_description_stdin_conflict() {
+    Command::cargo_bin("jr")
+        .unwrap()
+        .args([
+            "issue",
+            "create",
+            "-p",
+            "FOO",
+            "-t",
+            "Task",
+            "-s",
+            "Test",
+            "--description",
+            "text",
+            "--description-stdin",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn test_issue_list_all_and_limit_conflict() {
+    Command::cargo_bin("jr")
+        .unwrap()
+        .args(["issue", "list", "--all", "--limit", "10"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn test_issue_list_open_and_status_conflict() {
+    Command::cargo_bin("jr")
+        .unwrap()
+        .args(["issue", "list", "--open", "--status", "Done"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn test_edit_points_and_no_points_conflict() {
+    Command::cargo_bin("jr")
+        .unwrap()
+        .args(["issue", "edit", "FOO-1", "--points", "5", "--no-points"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn test_project_list_all_and_limit_conflict() {
+    Command::cargo_bin("jr")
+        .unwrap()
+        .args(["project", "list", "--all", "--limit", "10"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn test_board_view_all_and_limit_conflict() {
+    Command::cargo_bin("jr")
+        .unwrap()
+        .args(["board", "view", "--all", "--limit", "10"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn test_sprint_current_all_and_limit_conflict() {
+    Command::cargo_bin("jr")
+        .unwrap()
+        .args(["sprint", "current", "--all", "--limit", "10"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}


### PR DESCRIPTION
## Summary

- Adds 10 new smoke tests to `tests/cli_smoke.rs` covering every `conflicts_with` / `conflicts_with_all` declaration that wasn't already tested
- All 13 conflict pairs in `src/cli/mod.rs` now have corresponding smoke tests (3 pre-existing + 10 new)

### New tests

| Test | Conflict pair |
|------|--------------|
| `test_assign_to_and_account_id_conflict` | `issue assign --to` vs `--account-id` |
| `test_assign_account_id_and_unassign_conflict` | `issue assign --account-id` vs `--unassign` |
| `test_create_to_and_account_id_conflict` | `issue create --to` vs `--account-id` |
| `test_create_description_and_description_stdin_conflict` | `issue create --description` vs `--description-stdin` |
| `test_issue_list_all_and_limit_conflict` | `issue list --all` vs `--limit` |
| `test_issue_list_open_and_status_conflict` | `issue list --open` vs `--status` |
| `test_edit_points_and_no_points_conflict` | `issue edit --points` vs `--no-points` |
| `test_project_list_all_and_limit_conflict` | `project list --all` vs `--limit` |
| `test_board_view_all_and_limit_conflict` | `board view --all` vs `--limit` |
| `test_sprint_current_all_and_limit_conflict` | `sprint current --all` vs `--limit` |

Closes #140

## Test plan

- [x] `cargo test --test cli_smoke` — all 25 tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --all -- --check` — clean