### PR TITLE
test: add error propagation test for invalid accountId (#141)

### DIFF
--- a/tests/issue_commands.rs
+++ b/tests/issue_commands.rs
@@ -1675,11 +1675,16 @@ async fn test_assign_issue_invalid_account_id_returns_error() {
     let result = client.assign_issue("ERR-1", Some("bogus-account-id")).await;
 
     let err = result.unwrap_err();
-    let msg = err.to_string();
+
+    // Verify correct error variant and status code structurally
     assert!(
-        msg.contains("404"),
-        "Expected status 404 in error, got: {msg}"
+        err.downcast_ref::<jr::error::JrError>()
+            .is_some_and(|e| matches!(e, jr::error::JrError::ApiError { status: 404, .. })),
+        "Expected JrError::ApiError with status 404, got: {err}"
     );
+
+    // Verify Jira error message was extracted from the JSON body
+    let msg = err.to_string();
     assert!(
         msg.contains("does not exist"),
         "Expected Jira error message in error, got: {msg}"


### PR DESCRIPTION
## Summary

- Adds an integration test verifying that `assign_issue` with an invalid accountId propagates the Jira API error (404 + `errorMessages` JSON body) correctly through `parse_error` into `JrError::ApiError`
- Uses `downcast_ref` for structurally typed assertion on the error variant, matching the existing pattern in `tests/input_validation.rs`
- Verifies both the status code (404) and that the Jira error message ("does not exist") survives the error chain

Closes #141

## Test plan

- [x] `cargo test --test issue_commands test_assign_issue_invalid_account_id_returns_error` — passes
- [x] `cargo test` — all tests pass, no regressions
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --all -- --check` — clean