### PR TITLE
test: add handler-level integration tests for issue assign and create (#139)

### DIFF
--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -20,7 +20,7 @@ fn jr_cmd(server_uri: &str) -> Command {
     cmd
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_handler_assign_with_account_id() {
     let server = MockServer::start().await;
 
@@ -55,7 +55,7 @@ async fn test_handler_assign_with_account_id() {
         ));
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_handler_assign_with_to_name_search() {
     let server = MockServer::start().await;
 
@@ -97,7 +97,7 @@ async fn test_handler_assign_with_to_name_search() {
         .stdout(predicate::str::contains("\"changed\": true"));
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_handler_assign_self() {
     let server = MockServer::start().await;
 
@@ -135,7 +135,7 @@ async fn test_handler_assign_self() {
         .stdout(predicate::str::contains("\"changed\": true"));
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_handler_assign_unassign() {
     let server = MockServer::start().await;
 
@@ -157,7 +157,7 @@ async fn test_handler_assign_unassign() {
         .stdout(predicate::str::contains("\"changed\": true"));
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_handler_assign_idempotent() {
     let server = MockServer::start().await;
 
@@ -189,7 +189,7 @@ async fn test_handler_assign_idempotent() {
         .stdout(predicate::str::contains("\"changed\": false"));
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_handler_create_with_account_id() {
     let server = MockServer::start().await;
 
@@ -230,7 +230,7 @@ async fn test_handler_create_with_account_id() {
         .stdout(predicate::str::contains("/browse/HDL-100"));
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_handler_create_with_to_name_search() {
     let server = MockServer::start().await;
 
@@ -284,7 +284,7 @@ async fn test_handler_create_with_to_name_search() {
         .stdout(predicate::str::contains("\"key\": \"HDL-101\""));
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_handler_create_basic() {
     let server = MockServer::start().await;
 


### PR DESCRIPTION
## Summary

- Creates new `tests/cli_handler.rs` with 8 handler-level integration tests using `assert_cmd` + `wiremock`
- Tests invoke the `jr` binary as a child process, verifying the full path: clap parsing → handler dispatch → API call → JSON output
- Uses `JR_BASE_URL` and `JR_AUTH_HEADER` env vars for test isolation (no config files or keychain needed)
- Uses `#[tokio::test(flavor = "multi_thread")]` to prevent deadlock between assert_cmd (blocking) and wiremock (async)

### Tests added

**Assign (5 tests):**
| Test | Handler branch |
|------|---------------|
| `test_handler_assign_with_account_id` | `--account-id` path, no user search |
| `test_handler_assign_with_to_name_search` | `--to` path, assignable user search |
| `test_handler_assign_self` | No flags, `get_myself` fallback |
| `test_handler_assign_unassign` | `--unassign` early return |
| `test_handler_assign_idempotent` | Already assigned, `.expect(0)` on PUT |

**Create (3 tests):**
| Test | Handler branch |
|------|---------------|
| `test_handler_create_with_account_id` | `--account-id` path, no search |
| `test_handler_create_with_to_name_search` | `--to` path, multi-project user search |
| `test_handler_create_basic` | No assignee, verifies URL output |

Closes #139

## Test plan

- [x] `cargo test --test cli_handler` — all 8 tests pass
- [x] `cargo test` — full suite passes, no regressions
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --all -- --check` — clean