### PR TITLE
fix: add missing conflicts_with between --to and --unassign on issue assign

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -312,13 +312,13 @@ pub enum IssueCommand {
         /// Issue key
         key: String,
         /// Assign to this user (name/email, or "me" for self; omit to assign to self)
-        #[arg(long, conflicts_with = "account_id")]
+        #[arg(long, conflicts_with_all = ["account_id", "unassign"])]
         to: Option<String>,
         /// Assign to this Jira accountId directly (bypasses name search)
         #[arg(long, conflicts_with_all = ["to", "unassign"])]
         account_id: Option<String>,
         /// Remove assignee
-        #[arg(long)]
+        #[arg(long, conflicts_with_all = ["to", "account_id"])]
         unassign: bool,
     },
     /// Add a comment

--- a/tests/cli_smoke.rs
+++ b/tests/cli_smoke.rs
@@ -185,6 +185,16 @@ fn test_assign_to_and_account_id_conflict() {
 }
 
 #[test]
+fn test_assign_to_and_unassign_conflict() {
+    Command::cargo_bin("jr")
+        .unwrap()
+        .args(["issue", "assign", "FOO-1", "--to", "Jane", "--unassign"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
 fn test_assign_account_id_and_unassign_conflict() {
     Command::cargo_bin("jr")
         .unwrap()


### PR DESCRIPTION
## Summary
- `--to` and `--unassign` on `issue assign` were accepted together by clap, with `--unassign` silently winning. Now all three assign flags (`--to`, `--account-id`, `--unassign`) declare `conflicts_with_all` against each other, making the conflict matrix fully symmetric.
- Added smoke test for the `--to` + `--unassign` combination, completing the pairwise triangle with the two existing conflict tests.

Closes #146

## Test plan
- [x] `cargo test --test cli_smoke test_assign_to_and_unassign_conflict` — new test passes
- [x] `cargo test --test cli_smoke` — all 26 smoke tests pass
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — full suite passes