### PR TITLE
fix: preserve original error in parse_error fallback

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -244,7 +244,7 @@ impl JiraClient {
                     body
                 }
             }
-            Err(_) => "Unknown error".to_string(),
+            Err(e) => format!("Could not read error response: {e}"),
         };
 
         JrError::ApiError { status, message }.into()


### PR DESCRIPTION
## Summary
- The `parse_error` method's `Err(_)` branch discarded the actual error (e.g., connection reset, timeout) and showed `"Unknown error"`. Now captures the error and includes it in the message: `"Could not read error response: {e}"`.
- Improves debuggability for rare body-read failures without changing the error structure.

Closes #142

## Test plan
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test` — full suite passes
- [x] Code review — no issues found