### PR TITLE
refactor: extract shared user disambiguation logic from resolve helpers

### DIFF
--- a/src/cli/issue/helpers.rs
+++ b/src/cli/issue/helpers.rs
@@ -262,10 +262,12 @@ pub(super) async fn resolve_user(
             "No active user found matching \"{}\". The user may be deactivated.",
             name
         ),
-        |_all_names| format!(
-            "No active user found matching \"{}\". The user may be deactivated.",
-            name
-        ),
+        |_all_names| {
+            format!(
+                "No active user found matching \"{}\". The user may be deactivated.",
+                name
+            )
+        },
     )?;
     Ok(account_id)
 }
@@ -298,10 +300,14 @@ pub(super) async fn resolve_assignee(
             "No assignable user matching \"{}\" on issue {}. The user may not exist or may lack permission for this project. Try a different name or check spelling.",
             name, issue_key,
         ),
-        |all_names| format!(
-            "No assignable user with a name matching \"{}\" on issue {}. Found: {}",
-            name, issue_key, all_names.join(", "),
-        ),
+        |all_names| {
+            format!(
+                "No assignable user with a name matching \"{}\" on issue {}. Found: {}",
+                name,
+                issue_key,
+                all_names.join(", "),
+            )
+        },
     )
 }
 
@@ -339,10 +345,14 @@ pub(super) async fn resolve_assignee_by_project(
             "No assignable user matching \"{}\" in project {}. The user may not exist or may lack permission for this project. Try a different name or check spelling.",
             name, project_key,
         ),
-        |all_names| format!(
-            "No assignable user with a name matching \"{}\" in project {}. Found: {}",
-            name, project_key, all_names.join(", "),
-        ),
+        |all_names| {
+            format!(
+                "No assignable user with a name matching \"{}\" in project {}. Found: {}",
+                name,
+                project_key,
+                all_names.join(", "),
+            )
+        },
     )
 }
 


### PR DESCRIPTION
## Summary
- `resolve_user`, `resolve_assignee`, and `resolve_assignee_by_project` shared ~75 lines of identical disambiguation logic (empty check, single result, partial_match with 4 branches, interactive prompt). Extracted a private `disambiguate_user` helper that all three delegate to.
- Net reduction: 243 deletions, 100 insertions (-143 lines).
- No behavioral change — all error messages preserved, including the "may be deactivated" hint in `resolve_user`'s None branch.
- Restored the explanatory comment about why `resolve_assignee_by_project` doesn't filter active users (multiProjectSearch endpoint excludes them server-side).

Closes #123

## Test plan
- [x] `cargo clippy --tests -- -D warnings` — zero warnings
- [x] `cargo test` — full suite passes (318 unit + all integration)
- [x] Code review — 2 issues found and fixed (error message preservation, comment restoration)