### PR TITLE
feat: add jr api raw HTTP passthrough command (#111)

### DIFF
--- a/docs/superpowers/plans/2026-04-08-api-passthrough.md
+++ b/docs/superpowers/plans/2026-04-08-api-passthrough.md
@@ -1,0 +1,1578 @@
+# Raw API Passthrough Command (`jr api`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `jr api` command — an escape hatch for making arbitrary authenticated HTTP requests to the Jira REST API using stored credentials.
+
+**Architecture:** Thin wrapper that reuses existing `JiraClient::request()` for URL/auth construction. A new `JiraClient::send_raw()` method preserves non-2xx responses (unlike `send()` which converts them to errors). A new `src/cli/api.rs` module houses the CLI helpers and handler. Body input follows curl's `@file`/`@-` conventions. Custom headers use `HeaderMap::insert` semantics (replace, not append).
+
+**Tech Stack:** Rust, clap (derive API), reqwest, tokio, wiremock (tests), assert_cmd (subprocess handler tests), serde_json.
+
+**Spec:** `docs/superpowers/specs/2026-04-08-api-passthrough-design.md`
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|------|--------|----------------|
+| `src/cli/api.rs` | **Create** | `HttpMethod` enum, `handle_api()` function, `parse_header`/`normalize_path`/`resolve_body` helpers, unit tests |
+| `src/cli/mod.rs` | Modify | Register `pub mod api;` and add `Api { path, method, data, header }` variant to `Command` enum |
+| `src/api/client.rs` | Modify | Add `send_raw()` method; extract `extract_error_message(body: &[u8]) -> String` helper (refactor `parse_error` to use it) |
+| `src/main.rs` | Modify | Dispatch `Command::Api { .. }` to `cli::api::handle_api()` |
+| `tests/api_client.rs` | Modify | Add tests for `send_raw` (2xx, 4xx, 429 retry) and `extract_error_message` (errorMessages, message, fallback) |
+| `tests/cli_handler.rs` | Modify | Add subprocess handler tests for `jr api` (GET, POST body, PUT method, custom headers, error passthrough, path normalization, stdin body) |
+
+---
+
+## Task 1: Extract `extract_error_message` helper
+
+**Files:**
+- Modify: `src/api/client.rs` (lines ~218–251 currently contain `parse_error`)
+- Test: `tests/api_client.rs`
+
+**Context:** The existing `parse_error` method at `src/api/client.rs:219` takes a `reqwest::Response`, reads its body, and extracts an error summary from JSON (`errorMessages` array or `message` string) or falls back to the raw body. For `jr api`, we've already consumed the body as bytes in the handler, so we need the same extraction logic exposed as a standalone helper that takes `&[u8]`.
+
+**Refactor:** Add `extract_error_message(body: &[u8]) -> String` as a free function (or `impl JiraClient` associated function). Update `parse_error` to call it.
+
+- [ ] **Step 1.1: Write failing tests for `extract_error_message`**
+
+Add to `tests/api_client.rs`:
+
+```rust
+use jr::api::client::extract_error_message;
+
+#[test]
+fn test_extract_error_message_from_error_messages_array() {
+    let body = br#"{"errorMessages":["Issue does not exist","Or you lack permission"],"errors":{}}"#;
+    let result = extract_error_message(body);
+    assert_eq!(result, "Issue does not exist; Or you lack permission");
+}
+
+#[test]
+fn test_extract_error_message_from_message_field() {
+    let body = br#"{"message":"Property with key not found"}"#;
+    let result = extract_error_message(body);
+    assert_eq!(result, "Property with key not found");
+}
+
+#[test]
+fn test_extract_error_message_prefers_error_messages_over_message() {
+    let body = br#"{"errorMessages":["first"],"message":"second"}"#;
+    let result = extract_error_message(body);
+    assert_eq!(result, "first");
+}
+
+#[test]
+fn test_extract_error_message_empty_error_messages_falls_back_to_body() {
+    let body = br#"{"errorMessages":[]}"#;
+    let result = extract_error_message(body);
+    assert_eq!(result, r#"{"errorMessages":[]}"#);
+}
+
+#[test]
+fn test_extract_error_message_plain_text_body() {
+    let body = b"Internal Server Error";
+    let result = extract_error_message(body);
+    assert_eq!(result, "Internal Server Error");
+}
+
+#[test]
+fn test_extract_error_message_empty_body() {
+    let body = b"";
+    let result = extract_error_message(body);
+    assert_eq!(result, "");
+}
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+```bash
+cargo test --test api_client extract_error_message
+```
+
+Expected: FAIL with `unresolved import jr::api::client::extract_error_message` or similar.
+
+- [ ] **Step 1.3: Add `extract_error_message` helper to client.rs**
+
+Add as a `pub` free function (or `impl` associated function) near `parse_error` in `src/api/client.rs`:
+
+```rust
+/// Extract a human-readable error message from a Jira error response body.
+/// Matches the behavior of the old `parse_error` body handling:
+/// 1. Try `errorMessages` array → join with "; "
+/// 2. Try `message` string
+/// 3. Fall back to the raw body string
+pub fn extract_error_message(body: &[u8]) -> String {
+    let body_str = match std::str::from_utf8(body) {
+        Ok(s) => s,
+        Err(_) => return String::from_utf8_lossy(body).into_owned(),
+    };
+
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(body_str) {
+        if let Some(msgs) = json.get("errorMessages").and_then(|v| v.as_array()) {
+            let messages: Vec<&str> = msgs.iter().filter_map(|m| m.as_str()).collect();
+            if !messages.is_empty() {
+                return messages.join("; ");
+            }
+        }
+        if let Some(msg) = json.get("message").and_then(|v| v.as_str()) {
+            return msg.to_string();
+        }
+    }
+
+    body_str.to_string()
+}
+```
+
+- [ ] **Step 1.4: Refactor `parse_error` to use `extract_error_message`**
+
+Replace the body-parsing block inside `parse_error` (currently lines ~226-248 in `src/api/client.rs`):
+
+```rust
+/// Parse an error response into a `JrError`.
+async fn parse_error(response: Response) -> anyhow::Error {
+    let status = response.status().as_u16();
+
+    if status == 401 {
+        return JrError::NotAuthenticated.into();
+    }
+
+    let message = match response.bytes().await {
+        Ok(body) => extract_error_message(&body),
+        Err(e) => format!("Could not read error response: {e}"),
+    };
+
+    JrError::ApiError { status, message }.into()
+}
+```
+
+- [ ] **Step 1.5: Run tests to verify they pass**
+
+```bash
+cargo test --test api_client extract_error_message
+cargo test --test api_client  # full file — ensures parse_error still works
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 1.6: Run full test suite to ensure no regressions**
+
+```bash
+cargo test
+```
+
+Expected: all tests PASS (existing tests depending on `parse_error` behavior should still pass since the logic is preserved).
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add src/api/client.rs tests/api_client.rs
+git commit -m "refactor: extract_error_message helper from parse_error (#111)"
+```
+
+---
+
+## Task 2: Add `send_raw()` to JiraClient
+
+**Files:**
+- Modify: `src/api/client.rs`
+- Test: `tests/api_client.rs`
+
+**Context:** The existing `send()` method converts non-2xx responses to errors via `parse_error`, destroying the raw body. For `jr api`, we need to return the `reqwest::Response` regardless of status so the handler can print the body as-is. We still want 429 retry (consistent with other `jr` commands) so we reuse the retry loop logic.
+
+`send_raw` takes a pre-built `reqwest::Request` (not a `RequestBuilder`) because the handler builds the request manually to control header insert semantics.
+
+- [ ] **Step 2.1: Write failing tests for `send_raw`**
+
+Add to `tests/api_client.rs`:
+
+```rust
+use reqwest::Method;
+
+#[tokio::test]
+async fn test_send_raw_returns_response_for_2xx() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"accountId":"abc"}"#))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(
+        server.uri(),
+        "Basic dGVzdDp0ZXN0".to_string(),
+    );
+
+    let req = client
+        .request(Method::GET, "/rest/api/3/myself")
+        .build()
+        .unwrap();
+    let response = client.send_raw(req).await.unwrap();
+
+    assert_eq!(response.status().as_u16(), 200);
+    let body = response.text().await.unwrap();
+    assert_eq!(body, r#"{"accountId":"abc"}"#);
+}
+
+#[tokio::test]
+async fn test_send_raw_returns_response_for_404() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/MISSING-1"))
+        .respond_with(
+            ResponseTemplate::new(404)
+                .set_body_string(r#"{"errorMessages":["Issue does not exist"],"errors":{}}"#),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(
+        server.uri(),
+        "Basic dGVzdDp0ZXN0".to_string(),
+    );
+
+    let req = client
+        .request(Method::GET, "/rest/api/3/issue/MISSING-1")
+        .build()
+        .unwrap();
+    let response = client.send_raw(req).await.unwrap();
+
+    // Critical: 404 is NOT converted to an error
+    assert_eq!(response.status().as_u16(), 404);
+    let body = response.text().await.unwrap();
+    assert!(body.contains("Issue does not exist"));
+}
+
+#[tokio::test]
+async fn test_send_raw_retries_429_then_succeeds() {
+    let server = MockServer::start().await;
+    // First call returns 429
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "0"))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    // Second call returns 200
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"ok":true}"#))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(
+        server.uri(),
+        "Basic dGVzdDp0ZXN0".to_string(),
+    );
+
+    let req = client
+        .request(Method::GET, "/rest/api/3/myself")
+        .build()
+        .unwrap();
+    let response = client.send_raw(req).await.unwrap();
+
+    assert_eq!(response.status().as_u16(), 200);
+}
+
+#[tokio::test]
+async fn test_send_raw_returns_429_after_exhausting_retries() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "0"))
+        .expect(4) // initial + 3 retries (MAX_RETRIES)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(
+        server.uri(),
+        "Basic dGVzdDp0ZXN0".to_string(),
+    );
+
+    let req = client
+        .request(Method::GET, "/rest/api/3/myself")
+        .build()
+        .unwrap();
+    let response = client.send_raw(req).await.unwrap();
+
+    // Caller receives the 429 response — not an error
+    assert_eq!(response.status().as_u16(), 429);
+}
+```
+
+- [ ] **Step 2.2: Run tests to verify they fail**
+
+```bash
+cargo test --test api_client send_raw
+```
+
+Expected: FAIL with `no method named send_raw found for struct JiraClient`.
+
+- [ ] **Step 2.3: Implement `send_raw`**
+
+Add to `src/api/client.rs` inside `impl JiraClient` (near `send()`):
+
+```rust
+/// Send a pre-built request without parsing non-2xx responses into errors.
+/// Retries 429 up to MAX_RETRIES times. Returns the raw Response for ANY status.
+///
+/// Used by `jr api` (the raw passthrough command) where the caller needs
+/// the full response body regardless of HTTP status. Auth header is already
+/// set on the request by `client.request()`.
+pub async fn send_raw(&self, request: reqwest::Request) -> anyhow::Result<Response> {
+    let mut last_response: Option<Response> = None;
+
+    for attempt in 0..=MAX_RETRIES {
+        let req = request
+            .try_clone()
+            .expect("request should be cloneable (no streaming body)");
+
+        if self.verbose {
+            eprintln!("[verbose] {} {}", req.method(), req.url());
+        }
+
+        let response = match self.client.execute(req).await {
+            Ok(r) => r,
+            Err(e) => {
+                let url = e
+                    .url()
+                    .map(|u| u.host_str().unwrap_or("unknown").to_string())
+                    .unwrap_or_else(|| "unknown".to_string());
+                return Err(JrError::NetworkError(url).into());
+            }
+        };
+
+        if response.status() == StatusCode::TOO_MANY_REQUESTS && attempt < MAX_RETRIES {
+            let rate_info = RateLimitInfo::from_headers(response.headers());
+            let delay = rate_info.retry_after_secs.unwrap_or(DEFAULT_RETRY_SECS);
+            if self.verbose {
+                eprintln!(
+                    "[verbose] Rate limited (429). Retrying in {delay}s (attempt {}/{})",
+                    attempt + 1,
+                    MAX_RETRIES
+                );
+            }
+            tokio::time::sleep(Duration::from_secs(delay)).await;
+            last_response = Some(response);
+            continue;
+        }
+
+        // Return the response for ANY status (including 4xx/5xx) — no error parsing
+        return Ok(response);
+    }
+
+    // Exhausted retries — return the last 429 response to the caller
+    Ok(last_response.expect("retry loop always sets last_response on 429"))
+}
+```
+
+- [ ] **Step 2.4: Run tests to verify they pass**
+
+```bash
+cargo test --test api_client send_raw
+```
+
+Expected: all 4 `send_raw` tests PASS.
+
+- [ ] **Step 2.5: Run full test suite**
+
+```bash
+cargo test
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add src/api/client.rs tests/api_client.rs
+git commit -m "feat: add send_raw method to JiraClient (#111)"
+```
+
+---
+
+## Task 3: Create `src/cli/api.rs` module with `HttpMethod` enum and `normalize_path`
+
+**Files:**
+- Create: `src/cli/api.rs`
+- Modify: `src/cli/mod.rs` (add `pub mod api;`)
+
+**Context:** This task lays the foundation for the new module. We create an empty `api.rs` with a `HttpMethod` enum (clap `ValueEnum`) and a `normalize_path` helper. No handler logic yet — just the scaffolding and the first helper with its tests.
+
+- [ ] **Step 3.1: Create `src/cli/api.rs` with `HttpMethod` enum**
+
+```rust
+//! `jr api` — raw API passthrough command.
+//!
+//! Provides an escape hatch for calling the Jira REST API directly with
+//! stored credentials, modeled on `gh api`. Supports method override,
+//! request body (inline / file / stdin), and custom headers.
+
+use crate::error::JrError;
+use anyhow::Result;
+use clap::ValueEnum;
+use reqwest::Method;
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug, ValueEnum)]
+pub enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+}
+
+impl From<HttpMethod> for Method {
+    fn from(method: HttpMethod) -> Self {
+        match method {
+            HttpMethod::Get => Method::GET,
+            HttpMethod::Post => Method::POST,
+            HttpMethod::Put => Method::PUT,
+            HttpMethod::Patch => Method::PATCH,
+            HttpMethod::Delete => Method::DELETE,
+        }
+    }
+}
+
+/// Normalize a user-provided API path:
+/// - Accept absolute paths like `/rest/api/3/myself`
+/// - Prepend `/` if missing (e.g. `rest/api/3/myself` → `/rest/api/3/myself`)
+/// - Reject absolute URLs (starting with `http://` or `https://`)
+pub(crate) fn normalize_path(raw: &str) -> Result<String> {
+    let trimmed = raw.trim();
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        return Err(JrError::UserError(
+            "Use a path like /rest/api/3/... — do not include the instance URL".into(),
+        )
+        .into());
+    }
+    if trimmed.starts_with('/') {
+        Ok(trimmed.to_string())
+    } else {
+        Ok(format!("/{trimmed}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_path_with_slash() {
+        let result = normalize_path("/rest/api/3/myself").unwrap();
+        assert_eq!(result, "/rest/api/3/myself");
+    }
+
+    #[test]
+    fn test_normalize_path_without_slash() {
+        let result = normalize_path("rest/api/3/myself").unwrap();
+        assert_eq!(result, "/rest/api/3/myself");
+    }
+
+    #[test]
+    fn test_normalize_path_trims_whitespace() {
+        let result = normalize_path("  /rest/api/3/myself  ").unwrap();
+        assert_eq!(result, "/rest/api/3/myself");
+    }
+
+    #[test]
+    fn test_normalize_path_rejects_http_url() {
+        let err = normalize_path("http://site.atlassian.net/rest/api/3/myself").unwrap_err();
+        assert!(err.to_string().contains("do not include the instance URL"));
+    }
+
+    #[test]
+    fn test_normalize_path_rejects_https_url() {
+        let err = normalize_path("https://site.atlassian.net/rest/api/3/myself").unwrap_err();
+        assert!(err.to_string().contains("do not include the instance URL"));
+    }
+}
+```
+
+- [ ] **Step 3.2: Register the module in `src/cli/mod.rs`**
+
+Add to the top of `src/cli/mod.rs`:
+
+```rust
+pub mod api;
+```
+
+Place it in alphabetical order with the existing `pub mod` declarations (after `pub mod assets;`, before `pub mod auth;` — actually `api` comes first alphabetically, so before `assets`).
+
+The module list should become:
+
+```rust
+pub mod api;
+pub mod assets;
+pub mod auth;
+pub mod board;
+pub mod init;
+pub mod issue;
+pub mod project;
+pub mod queue;
+pub mod sprint;
+pub mod team;
+pub mod worklog;
+```
+
+- [ ] **Step 3.3: Run unit tests**
+
+```bash
+cargo test --lib cli::api::tests::test_normalize_path
+```
+
+Expected: all 5 `normalize_path` tests PASS.
+
+- [ ] **Step 3.4: Run full build to verify clippy is clean**
+
+```bash
+cargo clippy -- -D warnings
+```
+
+Expected: no warnings.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add src/cli/api.rs src/cli/mod.rs
+git commit -m "feat: add HttpMethod enum and normalize_path helper (#111)"
+```
+
+---
+
+## Task 4: Add `parse_header` helper
+
+**Files:**
+- Modify: `src/cli/api.rs`
+
+**Context:** Parse user-supplied `-H "Key: Value"` strings into `(HeaderName, HeaderValue)` pairs. Reject the `Authorization` header to prevent credential override. Split on the FIRST colon only (so values like `Bearer abc:def` work correctly).
+
+- [ ] **Step 4.1: Add failing tests for `parse_header`**
+
+Add to the existing `#[cfg(test)] mod tests { ... }` block in `src/cli/api.rs`:
+
+```rust
+#[test]
+fn test_parse_header_valid() {
+    let (name, value) = parse_header("X-Foo: bar").unwrap();
+    assert_eq!(name.as_str(), "x-foo");
+    assert_eq!(value.to_str().unwrap(), "bar");
+}
+
+#[test]
+fn test_parse_header_no_colon() {
+    let err = parse_header("X-Foo bar").unwrap_err();
+    assert!(err.to_string().contains("Key: Value"));
+}
+
+#[test]
+fn test_parse_header_empty_key() {
+    let err = parse_header(": bar").unwrap_err();
+    assert!(err.to_string().contains("empty"));
+}
+
+#[test]
+fn test_parse_header_trims_whitespace() {
+    let (name, value) = parse_header("  X-Foo  :   bar  ").unwrap();
+    assert_eq!(name.as_str(), "x-foo");
+    assert_eq!(value.to_str().unwrap(), "bar");
+}
+
+#[test]
+fn test_parse_header_value_with_colon() {
+    // Value contains a colon — should split on FIRST colon only
+    let (name, value) = parse_header("X-Request-Id: abc:def:ghi").unwrap();
+    assert_eq!(name.as_str(), "x-request-id");
+    assert_eq!(value.to_str().unwrap(), "abc:def:ghi");
+}
+
+#[test]
+fn test_parse_header_rejects_authorization() {
+    let err = parse_header("Authorization: Bearer foo").unwrap_err();
+    assert!(err.to_string().contains("Authorization"));
+}
+
+#[test]
+fn test_parse_header_rejects_authorization_case_insensitive() {
+    let err = parse_header("authorization: Bearer foo").unwrap_err();
+    assert!(err.to_string().contains("Authorization"));
+    let err = parse_header("AUTHORIZATION: Bearer foo").unwrap_err();
+    assert!(err.to_string().contains("Authorization"));
+}
+```
+
+- [ ] **Step 4.2: Run tests to verify they fail**
+
+```bash
+cargo test --lib cli::api::tests::test_parse_header
+```
+
+Expected: FAIL with `cannot find function parse_header`.
+
+- [ ] **Step 4.3: Implement `parse_header`**
+
+Add to `src/cli/api.rs` (above the `#[cfg(test)] mod tests` block):
+
+```rust
+use reqwest::header::{HeaderName, HeaderValue};
+
+/// Parse a user-supplied header string in `Key: Value` format.
+/// Rejects `Authorization` (case-insensitive) to prevent credential override.
+pub(crate) fn parse_header(raw: &str) -> Result<(HeaderName, HeaderValue)> {
+    let (key, value) = raw
+        .split_once(':')
+        .ok_or_else(|| {
+            JrError::UserError(format!(
+                "Header must be in 'Key: Value' format (got: {raw})"
+            ))
+        })?;
+
+    let key = key.trim();
+    let value = value.trim();
+
+    if key.is_empty() {
+        return Err(JrError::UserError("Header key cannot be empty".into()).into());
+    }
+
+    if key.eq_ignore_ascii_case("authorization") {
+        return Err(JrError::UserError(
+            "Cannot override the Authorization header — auth is managed by jr".into(),
+        )
+        .into());
+    }
+
+    let name = HeaderName::from_bytes(key.as_bytes())
+        .map_err(|e| JrError::UserError(format!("Invalid header name '{key}': {e}")))?;
+    let value = HeaderValue::from_str(value)
+        .map_err(|e| JrError::UserError(format!("Invalid header value '{value}': {e}")))?;
+
+    Ok((name, value))
+}
+```
+
+- [ ] **Step 4.4: Run tests to verify they pass**
+
+```bash
+cargo test --lib cli::api::tests::test_parse_header
+```
+
+Expected: all 7 `parse_header` tests PASS.
+
+- [ ] **Step 4.5: Clippy clean**
+
+```bash
+cargo clippy -- -D warnings
+```
+
+Expected: no warnings.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add src/cli/api.rs
+git commit -m "feat: add parse_header helper with Authorization rejection (#111)"
+```
+
+---
+
+## Task 5: Add `resolve_body` helper
+
+**Files:**
+- Modify: `src/cli/api.rs`
+
+**Context:** Resolve the `--data` argument into the actual body string. Supports inline JSON, `@file` (read from file), and `@-` (read from stdin). Takes a `Read` trait parameter for stdin so unit tests can inject a `Cursor`. Validates that the final body is valid JSON.
+
+- [ ] **Step 5.1: Add failing tests for `resolve_body`**
+
+Add to the `#[cfg(test)] mod tests` block in `src/cli/api.rs`:
+
+```rust
+use std::io::Cursor;
+
+#[test]
+fn test_resolve_body_none() {
+    let stdin: Cursor<&[u8]> = Cursor::new(b"");
+    let result = resolve_body(None, stdin).unwrap();
+    assert_eq!(result, None);
+}
+
+#[test]
+fn test_resolve_body_inline_json() {
+    let stdin: Cursor<&[u8]> = Cursor::new(b"");
+    let result = resolve_body(Some(r#"{"a":1}"#), stdin).unwrap();
+    assert_eq!(result, Some(r#"{"a":1}"#.to_string()));
+}
+
+#[test]
+fn test_resolve_body_invalid_json_errors() {
+    let stdin: Cursor<&[u8]> = Cursor::new(b"");
+    let err = resolve_body(Some("not json"), stdin).unwrap_err();
+    assert!(err.to_string().contains("Request body is not valid JSON"));
+}
+
+#[test]
+fn test_resolve_body_at_file_reads_contents() {
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), r#"{"from":"file"}"#).unwrap();
+    let arg = format!("@{}", tmp.path().display());
+
+    let stdin: Cursor<&[u8]> = Cursor::new(b"");
+    let result = resolve_body(Some(&arg), stdin).unwrap();
+    assert_eq!(result, Some(r#"{"from":"file"}"#.to_string()));
+}
+
+#[test]
+fn test_resolve_body_at_file_not_found() {
+    let stdin: Cursor<&[u8]> = Cursor::new(b"");
+    let err = resolve_body(Some("@/nonexistent/path/to/file.json"), stdin).unwrap_err();
+    // Propagated std::io::Error
+    assert!(err.to_string().to_lowercase().contains("no such file"));
+}
+
+#[test]
+fn test_resolve_body_at_dash_reads_stdin() {
+    let stdin_content = br#"{"from":"stdin"}"#;
+    let stdin = Cursor::new(&stdin_content[..]);
+    let result = resolve_body(Some("@-"), stdin).unwrap();
+    assert_eq!(result, Some(r#"{"from":"stdin"}"#.to_string()));
+}
+```
+
+- [ ] **Step 5.2: Verify `tempfile` is available as a dev-dependency**
+
+```bash
+grep tempfile Cargo.toml
+```
+
+Expected: `tempfile = "3"` under `[dev-dependencies]` (already present as of 2026-04-08). If missing for some reason, add it under `[dev-dependencies]` in `Cargo.toml`.
+
+- [ ] **Step 5.3: Run tests to verify they fail**
+
+```bash
+cargo test --lib cli::api::tests::test_resolve_body
+```
+
+Expected: FAIL with `cannot find function resolve_body`.
+
+- [ ] **Step 5.4: Implement `resolve_body`**
+
+Add to `src/cli/api.rs` (above the `#[cfg(test)] mod tests` block):
+
+```rust
+use std::io::Read;
+
+/// Resolve the `--data` argument into an actual request body.
+/// - `None` → `None`
+/// - `Some("@-")` → read from `stdin` parameter
+/// - `Some("@filename")` → read from file
+/// - `Some(inline)` → use as-is
+///
+/// Validates that the resulting body is valid JSON.
+pub(crate) fn resolve_body<R: Read>(arg: Option<&str>, mut stdin: R) -> Result<Option<String>> {
+    let body = match arg {
+        None => return Ok(None),
+        Some("@-") => {
+            let mut buf = String::new();
+            stdin.read_to_string(&mut buf)?;
+            buf
+        }
+        Some(s) if s.starts_with('@') => {
+            let path = &s[1..];
+            std::fs::read_to_string(path)?
+        }
+        Some(s) => s.to_string(),
+    };
+
+    // Validate JSON — Jira REST API always uses JSON, catch typos before network
+    serde_json::from_str::<serde_json::Value>(&body).map_err(|e| {
+        JrError::UserError(format!("Request body is not valid JSON: {e}"))
+    })?;
+
+    Ok(Some(body))
+}
+```
+
+- [ ] **Step 5.5: Run tests to verify they pass**
+
+```bash
+cargo test --lib cli::api::tests::test_resolve_body
+```
+
+Expected: all 6 `resolve_body` tests PASS.
+
+- [ ] **Step 5.6: Clippy clean**
+
+```bash
+cargo clippy -- -D warnings
+```
+
+Expected: no warnings.
+
+- [ ] **Step 5.7: Commit**
+
+```bash
+git add src/cli/api.rs Cargo.toml Cargo.lock
+git commit -m "feat: add resolve_body helper with stdin/file/inline support (#111)"
+```
+
+---
+
+## Task 6: Add `Api` variant to `Command` enum and wire up dispatch
+
+**Files:**
+- Modify: `src/cli/mod.rs`
+- Modify: `src/main.rs`
+- Modify: `src/cli/api.rs` (add stub `handle_api`)
+
+**Context:** Wire up the CLI plumbing: add the `Api { .. }` variant to the `Command` enum, dispatch it from `main.rs`, and add a placeholder `handle_api` that just returns `Ok(())`. We'll implement the real handler in Task 7.
+
+- [ ] **Step 6.1: Add `Api` variant to `Command` enum**
+
+Edit `src/cli/mod.rs`. Add a new variant to the `Command` enum (place it after `Queue { ... }` and before `Completion { ... }`):
+
+```rust
+    /// Make a raw authenticated HTTP request to the Jira REST API.
+    Api {
+        /// API path (leading slash optional). Example: /rest/api/3/myself
+        path: String,
+
+        /// HTTP method
+        #[arg(short = 'X', long, value_enum, default_value_t = api::HttpMethod::Get)]
+        method: api::HttpMethod,
+
+        /// Request body: inline JSON, @file to read from a file, or @- to read from stdin
+        #[arg(short = 'd', long)]
+        data: Option<String>,
+
+        /// Custom header in "Key: Value" format (repeatable)
+        #[arg(short = 'H', long = "header")]
+        header: Vec<String>,
+    },
+```
+
+- [ ] **Step 6.2: Add stub `handle_api` to `src/cli/api.rs`**
+
+Add to `src/cli/api.rs` (above the `#[cfg(test)]` block):
+
+```rust
+use crate::api::client::JiraClient;
+
+/// Main entry point for `jr api`.
+///
+/// Takes the parsed CLI arguments, performs validation, builds an HTTP request,
+/// sends it via `JiraClient::send_raw`, and prints the response body to stdout.
+pub async fn handle_api(
+    _path: String,
+    _method: HttpMethod,
+    _data: Option<String>,
+    _header: Vec<String>,
+    _client: &JiraClient,
+) -> Result<()> {
+    // Implemented in Task 7
+    Ok(())
+}
+```
+
+- [ ] **Step 6.3: Dispatch `Command::Api` in `src/main.rs`**
+
+Edit `src/main.rs`. Add a new match arm inside the `match cli.command { ... }` block (place it alongside the other command arms, after `cli::Command::Queue { command } => ...`):
+
+```rust
+            cli::Command::Api {
+                path,
+                method,
+                data,
+                header,
+            } => {
+                let config = config::Config::load()?;
+                let client = api::client::JiraClient::from_config(&config, cli.verbose)?;
+                cli::api::handle_api(path, method, data, header, &client).await
+            }
+```
+
+- [ ] **Step 6.4: Verify build succeeds**
+
+```bash
+cargo build
+```
+
+Expected: SUCCESS. No warnings.
+
+- [ ] **Step 6.5: Verify help output shows the new command**
+
+```bash
+cargo run -- api --help
+```
+
+Expected: Output showing `Make a raw authenticated HTTP request to the Jira REST API.` and the `-X`, `-d`, `-H` flags.
+
+- [ ] **Step 6.6: Run full test suite**
+
+```bash
+cargo test
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 6.7: Clippy clean**
+
+```bash
+cargo clippy -- -D warnings
+```
+
+Expected: no warnings.
+
+- [ ] **Step 6.8: Commit**
+
+```bash
+git add src/cli/mod.rs src/main.rs src/cli/api.rs
+git commit -m "feat: add Api variant to Command enum with stub handler (#111)"
+```
+
+---
+
+## Task 7: Implement `handle_api`
+
+**Files:**
+- Modify: `src/cli/api.rs`
+
+**Context:** This is the core handler. It:
+1. Normalizes the path
+2. Resolves the body (inline / file / stdin)
+3. Parses custom headers (filtering Authorization)
+4. Builds a `reqwest::Request` and applies headers with `insert()` semantics (not `append()`) to avoid duplicates
+5. Sends via `client.send_raw()`
+6. Writes the response body to stdout
+7. Returns success or an `ApiError` based on HTTP status
+
+- [ ] **Step 7.1: Implement `handle_api`**
+
+Replace the stub `handle_api` in `src/cli/api.rs` with the real implementation.
+
+First, update the imports at the top of `src/cli/api.rs`. After Tasks 3–6 the imports should be:
+
+```rust
+use crate::api::client::{JiraClient, extract_error_message};
+use crate::error::JrError;
+use anyhow::Result;
+use clap::ValueEnum;
+use reqwest::Method;
+use reqwest::header::{CONTENT_TYPE, HeaderName, HeaderValue};
+use std::io::{Read, Write};
+```
+
+(Add `extract_error_message`, `CONTENT_TYPE`, and `Write` to existing imports — merge them into the existing `use` statements rather than adding duplicates.)
+
+Then replace the stub `handle_api` body:
+
+```rust
+pub async fn handle_api(
+    path: String,
+    method: HttpMethod,
+    data: Option<String>,
+    header: Vec<String>,
+    client: &JiraClient,
+) -> Result<()> {
+    // 1. Normalize the path
+    let normalized_path = normalize_path(&path)?;
+
+    // 2. Resolve the body (reads real stdin in production)
+    let body = resolve_body(data.as_deref(), std::io::stdin().lock())?;
+
+    // 3. Parse custom headers (rejects Authorization)
+    let custom_headers: Vec<(HeaderName, HeaderValue)> = header
+        .iter()
+        .map(|h| parse_header(h))
+        .collect::<Result<Vec<_>>>()?;
+
+    // 4. Build the request using the shared client helper, then .build() to get
+    //    a concrete Request we can modify via headers_mut().insert().
+    //    This avoids RequestBuilder::header()'s append semantics which would
+    //    duplicate Content-Type when the user supplies their own.
+    let mut req = client
+        .request(method.into(), &normalized_path)
+        .build()?;
+
+    if let Some(ref body_str) = body {
+        *req.body_mut() = Some(body_str.clone().into());
+        req.headers_mut()
+            .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    }
+
+    for (name, value) in custom_headers {
+        req.headers_mut().insert(name, value);
+    }
+
+    // 5. Send via send_raw — preserves non-2xx responses
+    let response = client.send_raw(req).await?;
+    let status = response.status();
+    let body_bytes = response.bytes().await?;
+
+    // 6. Print response body to stdout (raw bytes, no reformatting).
+    //    Matches gh api behavior: no trailing newline added — preserves
+    //    exact server bytes for file redirection.
+    std::io::stdout().write_all(&body_bytes)?;
+
+    // 7. Handle status code
+    if status.is_success() {
+        Ok(())
+    } else if status.as_u16() == 401 {
+        Err(JrError::NotAuthenticated.into())
+    } else {
+        let message = extract_error_message(&body_bytes);
+        // Print a human error summary to stderr
+        crate::output::print_error(&format!("{message} (HTTP {})", status.as_u16()));
+        Err(JrError::ApiError {
+            status: status.as_u16(),
+            message,
+        }
+        .into())
+    }
+}
+```
+
+- [ ] **Step 7.2: Run existing unit tests to ensure they still pass**
+
+```bash
+cargo test --lib cli::api
+```
+
+Expected: all unit tests from Tasks 3, 4, 5 PASS (18 tests: 5 normalize_path + 7 parse_header + 6 resolve_body).
+
+- [ ] **Step 7.3: Build the binary**
+
+```bash
+cargo build
+```
+
+Expected: SUCCESS, no warnings.
+
+- [ ] **Step 7.4: Clippy clean**
+
+```bash
+cargo clippy -- -D warnings
+```
+
+Expected: no warnings.
+
+- [ ] **Step 7.5: Run full test suite**
+
+```bash
+cargo test
+```
+
+Expected: all tests PASS (no regressions).
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add src/cli/api.rs
+git commit -m "feat: implement jr api handler with raw response passthrough (#111)"
+```
+
+---
+
+## Task 8: Add handler integration tests
+
+**Files:**
+- Modify: `tests/cli_handler.rs`
+
+**Context:** Handler tests in this codebase are subprocess tests using `assert_cmd::Command::cargo_bin("jr")` with `JR_BASE_URL` and `JR_AUTH_HEADER` env vars to route traffic to a wiremock server and bypass keychain auth. The `jr_cmd(server_uri)` helper at `tests/cli_handler.rs:13` wraps this pattern.
+
+Important: the existing helper sets `--output json`. For `jr api` tests, we do NOT want that because `jr api` ignores `--output`. Build a separate command without that flag.
+
+- [ ] **Step 8.1: Add a helper function for `jr api` commands**
+
+Add to `tests/cli_handler.rs` (near the existing `jr_cmd` helper at line 13):
+
+```rust
+/// Build a `jr` command pre-configured for handler-level testing of `jr api`.
+/// Unlike `jr_cmd`, does not set `--output json` since `jr api` ignores it.
+fn jr_api_cmd(server_uri: &str) -> Command {
+    let mut cmd = Command::cargo_bin("jr").unwrap();
+    cmd.env("JR_BASE_URL", server_uri)
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .arg("--no-input");
+    cmd
+}
+```
+
+- [ ] **Step 8.2: Add handler test for `GET` success**
+
+Append to `tests/cli_handler.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_get_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            r#"{"accountId":"abc-123","displayName":"Test User"}"#,
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .args(["api", "/rest/api/3/myself"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"accountId\":\"abc-123\""))
+        .stdout(predicate::str::contains("\"displayName\":\"Test User\""));
+}
+```
+
+- [ ] **Step 8.3: Add handler test for POST with inline body — verify single Content-Type**
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_post_with_inline_data() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue"))
+        .and(body_partial_json(serde_json::json!({"fields": {"summary": "Test"}})))
+        .respond_with(ResponseTemplate::new(201).set_body_string(r#"{"key":"PROJ-1"}"#))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .args([
+            "api",
+            "/rest/api/3/issue",
+            "--method",
+            "post",
+            "--data",
+            r#"{"fields":{"summary":"Test"}}"#,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"key\":\"PROJ-1\""));
+
+    // Verify exactly one Content-Type header on the received request
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let content_type_count = requests[0]
+        .headers
+        .iter()
+        .filter(|(name, _)| name.as_str().eq_ignore_ascii_case("content-type"))
+        .count();
+    assert_eq!(
+        content_type_count, 1,
+        "expected exactly one Content-Type header, got {content_type_count}"
+    );
+}
+```
+
+- [ ] **Step 8.4: Add handler test for PUT method**
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_put_with_method_flag() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/api/3/issue/PROJ-1/assignee"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .args([
+            "api",
+            "/rest/api/3/issue/PROJ-1/assignee",
+            "-X",
+            "put",
+            "-d",
+            r#"{"accountId":"abc-123"}"#,
+        ])
+        .assert()
+        .success();
+}
+```
+
+- [ ] **Step 8.5: Add handler test for custom header passthrough**
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_custom_header_passes_through() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/servicedeskapi/servicedesk/1/organization"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"values":[]}"#))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .args([
+            "api",
+            "/rest/servicedeskapi/servicedesk/1/organization",
+            "-H",
+            "X-ExperimentalApi: opt-in",
+        ])
+        .assert()
+        .success();
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let has_experimental_header = requests[0]
+        .headers
+        .iter()
+        .any(|(name, value)| {
+            name.as_str().eq_ignore_ascii_case("x-experimentalapi")
+                && value.as_bytes() == b"opt-in"
+        });
+    assert!(has_experimental_header, "X-ExperimentalApi header missing");
+}
+```
+
+- [ ] **Step 8.6: Add handler test for custom Content-Type overrides auto-set**
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_custom_content_type_overrides_default() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/thing"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Note: body must still be valid JSON (we validate at resolve_body stage).
+    // The Content-Type override is tested separately from the JSON validation.
+    jr_api_cmd(&server.uri())
+        .args([
+            "api",
+            "/rest/api/3/thing",
+            "-X",
+            "post",
+            "-d",
+            r#"{"ok":true}"#,
+            "-H",
+            "Content-Type: application/vnd.atlassian.custom+json",
+        ])
+        .assert()
+        .success();
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let content_type_values: Vec<String> = requests[0]
+        .headers
+        .iter()
+        .filter(|(name, _)| name.as_str().eq_ignore_ascii_case("content-type"))
+        .map(|(_, value)| String::from_utf8_lossy(value.as_bytes()).to_string())
+        .collect();
+    assert_eq!(
+        content_type_values.len(),
+        1,
+        "expected exactly one Content-Type, got {content_type_values:?}"
+    );
+    assert_eq!(
+        content_type_values[0], "application/vnd.atlassian.custom+json",
+        "user-supplied Content-Type must override the default"
+    );
+}
+```
+
+- [ ] **Step 8.7: Add handler test for error response — body to stdout, exit non-zero**
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_error_response_body_to_stdout() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/MISSING-1"))
+        .respond_with(
+            ResponseTemplate::new(404)
+                .set_body_string(r#"{"errorMessages":["Issue does not exist"],"errors":{}}"#),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .args(["api", "/rest/api/3/issue/MISSING-1"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("Issue does not exist"))
+        .stderr(predicate::str::contains("HTTP 404"));
+}
+```
+
+- [ ] **Step 8.8: Add handler test for path normalization**
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_path_normalization_missing_slash() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"ok":true}"#))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // No leading slash — should still work
+    jr_api_cmd(&server.uri())
+        .args(["api", "rest/api/3/myself"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"ok\":true"));
+}
+```
+
+- [ ] **Step 8.9: Add handler test for rejecting absolute URLs**
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_rejects_absolute_url() {
+    let server = MockServer::start().await;
+    // No mock defined — if the handler tries to hit the network, it will fail
+
+    jr_api_cmd(&server.uri())
+        .args(["api", "https://example.atlassian.net/rest/api/3/myself"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("do not include the instance URL"));
+}
+```
+
+- [ ] **Step 8.10: Add handler test for Authorization header rejection**
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_rejects_authorization_header() {
+    let server = MockServer::start().await;
+
+    jr_api_cmd(&server.uri())
+        .args([
+            "api",
+            "/rest/api/3/myself",
+            "-H",
+            "Authorization: Bearer pwned",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Cannot override the Authorization header",
+        ));
+}
+```
+
+- [ ] **Step 8.11: Add handler test for stdin body (via `write_stdin`)**
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_stdin_body() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/thing"))
+        .and(body_partial_json(serde_json::json!({"from":"stdin"})))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .args(["api", "/rest/api/3/thing", "-X", "post", "-d", "@-"])
+        .write_stdin(r#"{"from":"stdin"}"#)
+        .assert()
+        .success();
+}
+```
+
+- [ ] **Step 8.12: Run all handler tests**
+
+```bash
+cargo test --test cli_handler test_handler_api
+```
+
+Expected: all 10 new `test_handler_api_*` tests PASS.
+
+- [ ] **Step 8.13: Run full test suite**
+
+```bash
+cargo test
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 8.14: Clippy clean**
+
+```bash
+cargo clippy -- -D warnings
+```
+
+Expected: no warnings.
+
+- [ ] **Step 8.15: Format check**
+
+```bash
+cargo fmt --all -- --check
+```
+
+Expected: no output (clean). If output appears, run `cargo fmt --all` and include the formatting changes in the commit.
+
+- [ ] **Step 8.16: Commit**
+
+```bash
+git add tests/cli_handler.rs
+git commit -m "test: add handler integration tests for jr api (#111)"
+```
+
+---
+
+## Task 9: Manual smoke test against real Jira
+
+**Context:** Before finalizing, do a lightweight manual verification against a real Jira instance to confirm the end-to-end flow works with real auth and real responses. This catches any gaps the mock-based tests missed.
+
+**Note:** This is optional if the user doesn't have a configured Jira instance handy, but recommended when available.
+
+- [ ] **Step 9.1: Build release binary**
+
+```bash
+cargo build --release
+```
+
+- [ ] **Step 9.2: Test GET against the live instance**
+
+```bash
+./target/release/jr api /rest/api/3/myself
+```
+
+Expected: JSON response with the authenticated user's details. Exit code 0.
+
+- [ ] **Step 9.3: Test path without leading slash**
+
+```bash
+./target/release/jr api rest/api/3/myself
+```
+
+Expected: Same response as Step 9.2.
+
+- [ ] **Step 9.4: Test 404 error response**
+
+```bash
+./target/release/jr api /rest/api/3/issue/NOPE-99999
+```
+
+Expected: Error body on stdout, `Error: ... (HTTP 404)` on stderr, exit code 1.
+
+- [ ] **Step 9.5: Test piping to jq**
+
+```bash
+./target/release/jr api /rest/api/3/myself | jq .accountId
+```
+
+Expected: Just the accountId string.
+
+- [ ] **Step 9.6: Test rejection of absolute URL**
+
+```bash
+./target/release/jr api https://example.atlassian.net/rest/api/3/myself
+```
+
+Expected: Error on stderr: "Use a path like /rest/api/3/... — do not include the instance URL". Exit code 64.
+
+- [ ] **Step 9.7: Test Authorization rejection**
+
+```bash
+./target/release/jr api /rest/api/3/myself -H "Authorization: Bearer nope"
+```
+
+Expected: Error on stderr: "Cannot override the Authorization header". Exit code 64.
+
+No commit needed — this task is verification only.
+
+---
+
+## Task 10: Verify final state and prepare for PR
+
+- [ ] **Step 10.1: Run the full test suite one more time**
+
+```bash
+cargo test
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 10.2: Run clippy**
+
+```bash
+cargo clippy -- -D warnings
+```
+
+Expected: no warnings.
+
+- [ ] **Step 10.3: Run format check**
+
+```bash
+cargo fmt --all -- --check
+```
+
+Expected: no output.
+
+- [ ] **Step 10.4: Verify git log looks clean**
+
+```bash
+git log --oneline origin/develop..HEAD
+```
+
+Expected: ~8 commits, each with a conventional commit prefix referencing `#111`.
+
+- [ ] **Step 10.5: Check for any leftover TODO markers**
+
+```bash
+grep -rn "TODO\|FIXME\|XXX" src/cli/api.rs src/api/client.rs
+```
+
+Expected: no matches (other than pre-existing ones not introduced by this PR).
+
+---
+
+## Spec Coverage Checklist
+
+- [x] `--method` flag with GET/POST/PUT/PATCH/DELETE → Task 3 (`HttpMethod` enum), Task 6 (wire-up)
+- [x] `--data` with inline/`@file`/`@-` → Task 5 (`resolve_body`)
+- [x] `--header` repeatable flag → Task 4 (`parse_header`), Task 7 (`handle_api` application)
+- [x] Path normalization (leading slash, reject absolute URLs) → Task 3 (`normalize_path`), Task 8.8, Task 8.9
+- [x] `send_raw()` preserving non-2xx responses → Task 2
+- [x] 429 retry consistent with `send()` → Task 2 Step 2.3
+- [x] Body → stdout, errors → stderr → Task 7 Step 7.1
+- [x] Exit codes: 0 success, 64 UserError, 2 NotAuthenticated, 1 ApiError/Io/Network → Task 7 Step 7.1
+- [x] Authorization header rejection → Task 4 Step 4.3, Task 8.10
+- [x] Exactly one Content-Type header when body + custom Content-Type → Task 7 (insert semantics), Task 8.3, Task 8.6
+- [x] `extract_error_message` shared helper → Task 1
+- [x] Test data: synthetic only (no real project keys/IDs/URLs) → all test tasks use `PROJ-1`, `abc-123`, etc.
+
+---
+
+## Notes for the Implementer
+
+- **Error variant mapping (important):** The codebase uses `JrError::UserError(String)` for bad-input errors (exit 64), NOT `JrError::BadInput`. File read errors propagate via `?` as `JrError::Io` (exit 1). `NotAuthenticated` exits with code 2, not 1. See `src/error.rs:34`.
+
+- **Clippy `too_many_arguments`:** `handle_api` takes 5 arguments which is under the default clippy threshold of 7. If a future refactor bumps it past 7, refactor — do NOT add `#[allow(clippy::too_many_arguments)]` (per `CLAUDE.md`).
+
+- **Header append footgun:** `reqwest::RequestBuilder::header()` uses `HeaderMap::append()` which produces duplicates. The handler must `.build()?` the request first and then manipulate `req.headers_mut()` with `insert()`. Task 7 does this correctly.
+
+- **`request()` method already sets auth:** The existing `JiraClient::request()` at `src/api/client.rs:334` already adds the `Authorization` header. The handler does not need to set it.
+
+- **stdout flushing:** Writing raw bytes to `std::io::stdout()` may buffer — not a concern here because the process exits after the handler returns, flushing everything. If the flow changes to do more work after printing, consider `stdout().flush()`.
+
+- **Test data:** Use placeholders `PROJ-1`, `HELP-42`, `MISSING-1`, `abc-123`. Never use real Jira keys, org IDs, or instance URLs.

--- a/docs/superpowers/plans/2026-04-08-api-passthrough.md
+++ b/docs/superpowers/plans/2026-04-08-api-passthrough.md
@@ -1309,7 +1309,10 @@ async fn test_handler_api_error_response_body_to_stdout() {
         .assert()
         .failure()
         .stdout(predicate::str::contains("Issue does not exist"))
-        .stderr(predicate::str::contains("HTTP 404"));
+        // main.rs prints "Error: {e}" where e is JrError::ApiError with Display
+        // "API error ({status}): {message}" — stderr contains "(404)" and the extracted message
+        .stderr(predicate::str::contains("(404)"))
+        .stderr(predicate::str::contains("Issue does not exist"));
 }
 ```
 

--- a/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
+++ b/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
@@ -1,0 +1,318 @@
+# Raw API Passthrough Command (`jr api`) — Design Spec
+
+**Issue:** #111
+**Status:** Draft
+**Date:** 2026-04-08
+
+## Problem
+
+When a high-level `jr` command doesn't cover a use case, there's no way to fall back to the raw Jira REST API using `jr`'s stored credentials. Credentials live in the macOS keychain with no programmatic extraction path, so users can't pipe them to `curl`. The result: an agent or script hits a rough edge and has no escape hatch.
+
+## Solution
+
+Add a top-level `jr api` command that sends an arbitrary HTTP request to the configured Jira instance using the stored auth, modeled on `gh api`. Method, path, request body, and custom headers are all controlled by flags. The response body is printed to stdout as-is; human error messages go to stderr; the exit code conveys success or failure.
+
+## Command Surface
+
+```
+jr api <path> [flags]
+
+Arguments:
+  <path>    API path (leading slash optional; absolute URLs rejected)
+
+Flags:
+  -X, --method <METHOD>       HTTP method [default: GET]
+                              Possible values: GET, POST, PUT, PATCH, DELETE
+  -d, --data <BODY>           Request body: inline JSON, @file, or @- for stdin
+  -H, --header <KEY:VALUE>    Custom header (repeatable)
+```
+
+### Examples
+
+```bash
+# GET (default method)
+jr api /rest/api/3/myself
+
+# Leading slash is optional
+jr api rest/api/3/myself
+
+# PUT with inline JSON body
+jr api /rest/api/2/issue/PROJ-1/assignee \
+  --method PUT \
+  --data '{"accountId":"abc123"}'
+
+# POST with body from file
+jr api /rest/agile/1.0/sprint/123/issue \
+  --method POST \
+  --data @payload.json
+
+# POST with body from stdin
+echo '{"issues":["PROJ-456"]}' | jr api /rest/agile/1.0/sprint/123/issue -X POST -d @-
+
+# Custom header for experimental JSM API
+jr api /rest/servicedeskapi/servicedesk/1/organization \
+  -H "X-ExperimentalApi: opt-in"
+
+# Pipe response to jq (raw JSON enables composition)
+jr api /rest/api/3/myself | jq .accountId
+```
+
+### Design Choices
+
+- **No placeholder magic** (unlike `gh api`'s `{owner}/{repo}`) — `jr` has no equivalent "current repo" notion; users pass literal paths.
+- **No `--output` flag** — `jr api` always returns raw JSON from the server. The global `--output` flag is ignored by this command.
+- **No built-in `--jq`, `--paginate`, `--field`** — users pipe to `jq` or handle pagination via URL query params. More composable, follows Unix philosophy, smaller surface area.
+- **Path normalization:** if the path does not start with `/`, prepend one. Absolute URLs (starting with `http://` or `https://`) are rejected with `BadInput` — the instance URL comes from config.
+- **`@file` / `@-` curl conventions** for body input. A filename literally starting with `@` requires `./` prefix (documented footgun, identical to curl).
+
+## Architecture
+
+### Files Changed
+
+| File | Change | Description |
+|------|--------|-------------|
+| `src/cli/mod.rs` | Modify | Add `Api { path, method, data, header }` variant to `Command` enum |
+| `src/cli/api.rs` | **Create** | New module: `handle_api()`, `HttpMethod` enum, body/header helpers, unit tests |
+| `src/api/client.rs` | Modify | Add `send_raw()` method (preserves non-2xx responses); extract `extract_error_message(body: &[u8]) -> String` helper from `parse_error` so both `send()`-error-path and `jr api` can reuse it |
+| `src/main.rs` | Modify | Dispatch `Command::Api { ... }` to `cli::api::handle_api()` |
+| `tests/cli_handler.rs` | Modify | Add handler tests for the full flow |
+| `tests/api_client.rs` | Modify | Add `send_raw()` client-level tests |
+
+### Why a New Top-Level Command
+
+`jr api` is an escape hatch that spans all Jira APIs — issues, boards, sprints, JSM, assets, agile. Placing it under any specific resource module would be misleading. It sits alongside `issue`, `board`, `sprint`, etc. as a peer subcommand.
+
+### Why a New `send_raw()` Method
+
+The existing `send()` at `src/api/client.rs:157` parses non-2xx responses into `JrError::ApiError`, which consumes the response body and destroys the raw JSON. For a raw passthrough, we need to:
+
+1. Keep 429 retry (consistent with every other `jr` command)
+2. Skip error parsing — return `reqwest::Response` for any status code
+3. Let the caller read the raw body and decide on exit code
+
+The new method reuses the 429 retry loop from `send()` and differs only in the final step: it returns the `Response` directly for 2xx AND 4xx/5xx, with no error parsing. `send_raw()` is ~30 lines.
+
+### Module Layout
+
+`src/cli/api.rs` is estimated at ~200 lines:
+- `HttpMethod` enum (`ValueEnum` derive) — 15 lines
+- `parse_header(s: &str) -> Result<(HeaderName, HeaderValue)>` — 20 lines
+- `normalize_path(s: &str) -> Result<String>` — 15 lines
+- `resolve_body<R: Read>(arg: Option<&str>, stdin: R) -> Result<Option<String>>` — 40 lines
+- `handle_api(...) -> Result<()>` — 60 lines
+- Unit tests — 50 lines
+
+Small enough to stay in one file.
+
+## Request and Response Flow
+
+### Step-by-Step
+
+1. **Parse args** — clap derives method, path, data, header list.
+2. **Normalize path** (`normalize_path`):
+   - If starts with `http://` or `https://` → `JrError::BadInput` ("Use a path like /rest/api/3/... — do not include the instance URL")
+   - If starts with `/` → use as-is
+   - Otherwise → prepend `/`
+3. **Resolve body** (`resolve_body`):
+   - `None` → no body
+   - `Some("@-")` → read entire stdin into a `String`
+   - `Some("@filename")` → read entire file into a `String`
+   - `Some(inline)` → use as-is
+4. **Validate body is JSON** if present — `serde_json::from_str::<Value>(&body)`. On parse error, `JrError::BadInput("Request body is not valid JSON: {err}")`.
+5. **Parse headers** (`parse_header`): split each `-H` value on the **first** `:`, trim whitespace on both sides. Empty key or missing `:` → `JrError::BadInput("Header must be in 'Key: Value' format")`. Reject any user-supplied `Authorization` header (case-insensitive match) → `JrError::BadInput("Cannot override the Authorization header — auth is managed by jr")`. This prevents accidental credential leakage via `--verbose` output and ensures the escape hatch always uses the stored credentials.
+6. **Build request:**
+   - Start with `client.request(method, &path)` — returns a `RequestBuilder` with URL and auth header set
+   - `.build()?` to get a concrete `reqwest::Request`
+   - If body present: `req.body_mut().replace(body.into())` and insert `Content-Type: application/json` via `req.headers_mut().insert()`
+   - For each parsed custom header (already validated to exclude `Authorization` in step 5), call `req.headers_mut().insert(name, value)` — this **replaces** any existing header of the same name (including auto-set `Content-Type`), giving the user final say
+7. **Send** — call `client.send_raw(req)`. Retries 429 automatically. Returns `reqwest::Response` regardless of status code.
+8. **Read body** — `response.bytes().await?`.
+9. **Print body to stdout** — write bytes as-is (no parsing, no reformatting). Preserves whitespace and key order from the server.
+10. **Handle status:**
+    - 2xx → exit 0
+    - 4xx/5xx → extract a human-readable summary from the body using the same logic as `JiraClient::parse_error` at `src/api/client.rs:219` (tries `errorMessages` array, then `message` string, then falls back to the raw body). Print `Error: {message} (HTTP {status})` to stderr via `output::print_error`. Return `JrError::ApiError { status, message }` (401 → `JrError::NotAuthenticated`). The existing `parse_error` takes a `Response` which consumes the body — since we've already consumed the body bytes, extract the JSON-parsing logic into a shared helper `extract_error_message(body: &[u8]) -> String` and call it from both `parse_error` and `handle_api`.
+
+### Exit Codes
+
+| Scenario | Exit Code | Source |
+|----------|-----------|--------|
+| 2xx response | 0 | success |
+| 4xx/5xx response | 1 | `JrError::ApiError` |
+| 401 response | 1 | `JrError::NotAuthenticated` |
+| Invalid path, bad JSON body, bad header format | 64 | `JrError::BadInput` |
+| File read error (`@file`) | 66 | `JrError::InputError` |
+| Network error | 1 | `JrError::NetworkError` |
+
+### Stdout/Stderr Split
+
+| Stream | Content |
+|--------|---------|
+| **stdout** | Response body (success or error, raw bytes, no reformatting) |
+| **stderr** | Human-readable error summary on HTTP failure (e.g., `Error: Not Found (HTTP 404)`) |
+
+This matches `gh api`'s behavior and enables clean composition:
+
+```bash
+jr api /rest/api/3/myself | jq .accountId
+```
+
+### Header Precedence
+
+- Auth header is set automatically via `client.request()` — should not be overridable for safety
+- `Content-Type: application/json` is auto-set when a body is present
+- Custom headers via `-H` apply with **replace** semantics (`HeaderMap::insert`) — the user's value wins over auto-set Content-Type
+- Invariant: the outgoing HTTP request has exactly one header for each distinct header name
+- **Implementation note:** `RequestBuilder::header()` uses `append()` semantics which produces duplicates. The implementation must build the `Request` via `.build()?`, then manipulate `req.headers_mut()` directly with `insert()`.
+
+### 429 Retry
+
+`send_raw()` retries 429 responses up to `MAX_RETRIES` (3) using the same `Retry-After` logic as `send()`. This is intentional and consistent with every other `jr` command — agents running `jr api` in scripts benefit from automatic backoff, and Jira's documented rate limit behavior expects clients to honor `Retry-After`.
+
+## Type Changes
+
+Add to `src/cli/api.rs`:
+
+```rust
+#[derive(Copy, Clone, PartialEq, Eq, ValueEnum)]
+pub enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+}
+```
+
+Add to `src/cli/mod.rs` (`Command` enum):
+
+```rust
+/// Make a raw authenticated HTTP request to the Jira REST API.
+Api {
+    /// API path (leading slash optional). Example: /rest/api/3/myself
+    path: String,
+
+    /// HTTP method
+    #[arg(short = 'X', long, value_enum, default_value_t = HttpMethod::Get)]
+    method: HttpMethod,
+
+    /// Request body: inline JSON, @file to read from a file, or @- to read from stdin
+    #[arg(short = 'd', long)]
+    data: Option<String>,
+
+    /// Custom header in "Key: Value" format (repeatable)
+    #[arg(short = 'H', long = "header")]
+    header: Vec<String>,
+},
+```
+
+Add to `src/api/client.rs`:
+
+```rust
+/// Send a pre-built request without parsing non-2xx responses into errors.
+/// Retries 429 up to MAX_RETRIES times. Returns the raw Response for any status code.
+pub async fn send_raw(&self, request: reqwest::Request) -> anyhow::Result<reqwest::Response>
+```
+
+## Error Messages
+
+| Scenario | Message | Exit Code |
+|----------|---------|-----------|
+| Path starts with `http://` or `https://` | `Use a path like /rest/api/3/... — do not include the instance URL` | 64 |
+| Body is not valid JSON | `Request body is not valid JSON: <serde error>` | 64 |
+| Header missing `:` | `Header must be in 'Key: Value' format (got: <value>)` | 64 |
+| Header key is empty | `Header key cannot be empty` | 64 |
+| User-supplied `Authorization` header | `Cannot override the Authorization header — auth is managed by jr` | 64 |
+| `@file` does not exist | `Cannot read body file <path>: <os error>` | 66 |
+| 401 response | `Not authenticated. Run 'jr auth login' to refresh your credentials.` | 1 |
+| Other HTTP error | `Error: <errorMessages or message> (HTTP <status>)` on stderr, body on stdout | 1 |
+
+## Testing
+
+### Unit Tests (`src/cli/api.rs`)
+
+| Test | What it verifies |
+|------|------------------|
+| `test_normalize_path_with_slash` | `/rest/api/3/myself` → unchanged |
+| `test_normalize_path_without_slash` | `rest/api/3/myself` → `/rest/api/3/myself` |
+| `test_normalize_path_rejects_http_url` | `http://site.atlassian.net/foo` → `BadInput` |
+| `test_normalize_path_rejects_https_url` | `https://site.atlassian.net/foo` → `BadInput` |
+| `test_parse_header_valid` | `"X-Foo: bar"` → `("X-Foo", "bar")` |
+| `test_parse_header_no_colon` | `"X-Foo bar"` → `BadInput` |
+| `test_parse_header_empty_key` | `": bar"` → `BadInput` |
+| `test_parse_header_trims_whitespace` | `"X-Foo:   bar  "` → `("X-Foo", "bar")` |
+| `test_parse_header_value_with_colon` | `"X-Request-Id: abc:def"` → `("X-Request-Id", "abc:def")` (first-colon split) |
+| `test_parse_header_rejects_authorization` | `"Authorization: Bearer foo"` → `BadInput` |
+| `test_parse_header_rejects_authorization_case_insensitive` | `"authorization: Bearer foo"` → `BadInput` |
+| `test_resolve_body_none` | `None` → `Ok(None)` |
+| `test_resolve_body_inline_json` | `Some("{\"a\":1}")` → `Ok(Some("{\"a\":1}"))` |
+| `test_resolve_body_invalid_json` | `Some("not json")` → `BadInput` |
+| `test_resolve_body_at_file` | `Some("@/tmp/test.json")` reads the file contents |
+| `test_resolve_body_at_file_not_found` | `Some("@/no/such/file")` → `InputError` |
+| `test_resolve_body_at_dash_reads_stdin` | `Some("@-")` with injected `Cursor` → body matches Cursor content |
+
+### Handler Tests (`tests/cli_handler.rs`)
+
+Wiremock-backed, call `handle_api()` directly. Each test uses `JiraClient::new_for_test(server.uri(), ...)`.
+
+| Test | What it verifies |
+|------|------------------|
+| `test_handler_api_get_success` | Mocks GET `/rest/api/3/myself` → 200 JSON. Verifies Authorization header present, response printed to stdout, exit 0 |
+| `test_handler_api_post_with_inline_data` | `-d '{"a":1}'` → request body matches, exactly one `Content-Type: application/json` header |
+| `test_handler_api_put_with_method_flag` | `--method PUT` → request uses PUT |
+| `test_handler_api_custom_header_overrides_content_type` | Body + `-H "Content-Type: text/plain"` → exactly ONE Content-Type header with value `text/plain` |
+| `test_handler_api_custom_header_passes_through` | `-H "X-ExperimentalApi: opt-in"` → header present on the request |
+| `test_handler_api_error_response_body_to_stdout` | 404 with JSON body → body on stdout, `ApiError` returned |
+| `test_handler_api_path_normalization` | `rest/api/3/myself` (no leading slash) → request sent to `/rest/api/3/myself` |
+
+**Exactly-one-header pattern:** Use `server.received_requests().await` to inspect the raw request. Count headers matching a name case-insensitively. This approach works regardless of how reqwest normalizes or merges headers on the wire.
+
+```rust
+let requests = server.received_requests().await.unwrap();
+let content_type_count = requests[0]
+    .headers
+    .iter()
+    .filter(|(name, _)| name.as_str().eq_ignore_ascii_case("content-type"))
+    .count();
+assert_eq!(content_type_count, 1);
+```
+
+### Client Tests (`tests/api_client.rs`)
+
+| Test | What it verifies |
+|------|------------------|
+| `test_send_raw_returns_response_for_2xx` | `send_raw` returns `Response` for 200 |
+| `test_send_raw_returns_response_for_404` | `send_raw` returns `Response` (NOT an error) for 404 — critical for raw passthrough |
+| `test_send_raw_retries_429` | `send_raw` retries 429 with `Retry-After`, then returns 200 response |
+| `test_send_raw_returns_response_after_exhausted_429` | After `MAX_RETRIES` 429s, returns the 429 `Response` (caller decides what to do) |
+| `test_extract_error_message_from_error_messages` | `{"errorMessages":["foo","bar"]}` → `"foo; bar"` |
+| `test_extract_error_message_from_message_field` | `{"message":"foo"}` → `"foo"` |
+| `test_extract_error_message_from_plain_text` | `"not json"` → `"not json"` (fallback) |
+| `test_extract_error_message_from_empty_body` | `""` → `""` (fallback) |
+
+### Stdin Testing Approach
+
+The `resolve_body` function takes `stdin: impl Read` so unit tests pass a `Cursor` with synthetic content. `handle_api()` calls `std::io::stdin().lock()` internally and passes the result to `resolve_body()` — this matches the existing codebase pattern (`src/cli/issue/workflow.rs:402`, `src/cli/issue/create.rs:84`) where handlers call `stdin()` directly without dependency injection.
+
+Handler tests do NOT cover the `@-` stdin path (since the handler reads real stdin); that path is fully covered by the `test_resolve_body_at_dash_reads_stdin` unit test. No subprocess tests needed.
+
+### Test Data
+
+All JSON is synthetic. No real project keys, org IDs, account IDs, or instance URLs. Use placeholders like `PROJ-1`, `HELP-42`, `abc123`.
+
+## Caveats
+
+- **Header append footgun:** `reqwest::RequestBuilder::header()` appends rather than replaces. The implementation must build the `Request` via `.build()` and manipulate `req.headers_mut()` directly with `insert()`. The exactly-one-header test enforces this invariant.
+- **Auth header cannot be overridden:** User-supplied `-H Authorization: ...` is rejected with a `BadInput` error. Auth is managed by `jr` via `client.request()`, and explicit rejection prevents accidental credential leakage via `--verbose` output.
+- **Body size:** The entire body is read into memory before sending. Not suitable for very large payloads (multi-MB uploads) — but Jira's standard API is not typically used for large payloads.
+- **Streaming responses:** `jr api` reads the entire response into memory before printing. Fine for JSON payloads; not suitable for streaming endpoints (Jira has none in practice).
+- **`@` prefix in filenames:** A filename literally starting with `@` must be passed as `./@file.json` to avoid being interpreted as a nested reference. Matches curl's behavior.
+
+## Out of Scope
+
+- `--jq` / `--template` / `--slurp` response filtering — users pipe to `jq` directly for composition
+- `--paginate` — users handle pagination via URL query params (`startAt`, `maxResults`, `nextPageToken`)
+- `--field` / `--raw-field` / `-F`/`-f` — users construct JSON bodies themselves or via `jq`
+- `--include` / `-i` — response headers not exposed in v1
+- Multipart/form-data (file uploads) — deferred; the existing `add_comment` ADF path handles most text-based use cases
+- GraphQL endpoint support — Jira's REST API covers the issue's use cases; GraphQL can be added as a future enhancement
+- Request/response logging beyond the existing `--verbose` flag

--- a/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
+++ b/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
@@ -224,9 +224,9 @@ pub async fn send_raw(&self, request: reqwest::Request) -> anyhow::Result<reqwes
 | Header missing `:` | `Header must be in 'Key: Value' format (got: <value>)` | 64 |
 | Header key is empty | `Header key cannot be empty` | 64 |
 | User-supplied `Authorization` header | `Cannot override the Authorization header — auth is managed by jr` | 64 |
-| `@file` does not exist | Propagated from `std::fs::read_to_string` (`No such file or directory`) | 1 |
+| `@file` does not exist | Propagated I/O error from `std::fs::read_to_string` via `JrError::Io` (for example, `No such file or directory`) | 1 |
 | 401 response | `Not authenticated. Run "jr auth login" to connect.` | 2 |
-| Other HTTP error | `Error: <errorMessages or message> (HTTP <status>)` on stderr, body on stdout | 1 |
+| Other HTTP error | `Error: API error (<status>): <errorMessages or message>` on stderr, body on stdout | 1 |
 
 ## Testing
 
@@ -293,9 +293,9 @@ assert_eq!(content_type_count, 1);
 
 ### Stdin Testing Approach
 
-The `resolve_body` function takes `stdin: impl Read` so unit tests pass a `Cursor` with synthetic content. `handle_api()` calls `std::io::stdin().lock()` internally and passes the result to `resolve_body()` — this matches the existing codebase pattern (`src/cli/issue/workflow.rs:402`, `src/cli/issue/create.rs:84`) where handlers call `stdin()` directly without dependency injection.
+The `resolve_body` function takes `stdin: impl Read` so unit tests can pass a `Cursor` with synthetic content. `handle_api()` calls `std::io::stdin().lock()` internally and passes the result to `resolve_body()` — this matches the existing codebase pattern (`src/cli/issue/workflow.rs:402`, `src/cli/issue/create.rs:84`) where handlers call `stdin()` directly without dependency injection.
 
-Handler tests do NOT cover the `@-` stdin path (since the handler reads real stdin); that path is fully covered by the `test_resolve_body_at_dash_reads_stdin` unit test. No subprocess tests needed.
+This PR uses layered coverage for stdin behavior: unit tests exercise `resolve_body()` directly (including `@-`) with synthetic readers, and `tests/cli_handler.rs` also adds subprocess coverage via `Command::cargo_bin("jr")` to validate the real CLI entrypoint. That subprocess coverage includes an `@-` stdin case, so the end-to-end stdin path is tested as implemented, not just the helper in isolation.
 
 ### Test Data
 

--- a/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
+++ b/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
@@ -306,6 +306,7 @@ All JSON is synthetic. No real project keys, org IDs, account IDs, or instance U
 - **Body size:** The entire body is read into memory before sending. Not suitable for very large payloads (multi-MB uploads) — but Jira's standard API is not typically used for large payloads.
 - **Streaming responses:** `jr api` reads the entire response into memory before printing. Fine for JSON payloads; not suitable for streaming endpoints (Jira has none in practice).
 - **`@` prefix in filenames:** A filename literally starting with `@` must be passed as `./@file.json` to avoid being interpreted as a nested reference. Matches curl's behavior.
+- **Error message extraction is incomplete (pre-existing):** `extract_error_message` preserves the existing `parse_error` behavior — it handles `errorMessages` array and `message` string but not `errorMessage` (singular JSM field), `errors` object (field-level validation), or `status-code` + `message` format. Expanding format coverage is tracked as a follow-up enhancement, not in scope for this PR.
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
+++ b/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
@@ -62,7 +62,7 @@ jr api /rest/api/3/myself | jq .accountId
 - **No placeholder magic** (unlike `gh api`'s `{owner}/{repo}`) — `jr` has no equivalent "current repo" notion; users pass literal paths.
 - **No `--output` flag** — `jr api` always returns raw JSON from the server. The global `--output` flag is ignored by this command.
 - **No built-in `--jq`, `--paginate`, `--field`** — users pipe to `jq` or handle pagination via URL query params. More composable, follows Unix philosophy, smaller surface area.
-- **Path normalization:** if the path does not start with `/`, prepend one. Absolute URLs (starting with `http://` or `https://`) are rejected with `BadInput` — the instance URL comes from config.
+- **Path normalization:** if the path does not start with `/`, prepend one. Absolute URLs (starting with `http://` or `https://`) are rejected with `UserError` — the instance URL comes from config.
 - **`@file` / `@-` curl conventions** for body input. A filename literally starting with `@` requires `./` prefix (documented footgun, identical to curl).
 
 ## Architecture
@@ -110,7 +110,7 @@ Small enough to stay in one file.
 
 1. **Parse args** — clap derives method, path, data, header list.
 2. **Normalize path** (`normalize_path`):
-   - If starts with `http://` or `https://` → `JrError::BadInput` ("Use a path like /rest/api/3/... — do not include the instance URL")
+   - If starts with `http://` or `https://` → `JrError::UserError` ("Use a path like /rest/api/3/... — do not include the instance URL")
    - If starts with `/` → use as-is
    - Otherwise → prepend `/`
 3. **Resolve body** (`resolve_body`):
@@ -118,8 +118,8 @@ Small enough to stay in one file.
    - `Some("@-")` → read entire stdin into a `String`
    - `Some("@filename")` → read entire file into a `String`
    - `Some(inline)` → use as-is
-4. **Validate body is JSON** if present — `serde_json::from_str::<Value>(&body)`. On parse error, `JrError::BadInput("Request body is not valid JSON: {err}")`.
-5. **Parse headers** (`parse_header`): split each `-H` value on the **first** `:`, trim whitespace on both sides. Empty key or missing `:` → `JrError::BadInput("Header must be in 'Key: Value' format")`. Reject any user-supplied `Authorization` header (case-insensitive match) → `JrError::BadInput("Cannot override the Authorization header — auth is managed by jr")`. This prevents accidental credential leakage via `--verbose` output and ensures the escape hatch always uses the stored credentials.
+4. **Validate body is JSON** if present — `serde_json::from_str::<Value>(&body)`. On parse error, `JrError::UserError("Request body is not valid JSON: {err}")`.
+5. **Parse headers** (`parse_header`): split each `-H` value on the **first** `:`, trim whitespace on both sides. Empty key or missing `:` → `JrError::UserError("Header must be in 'Key: Value' format")`. Reject any user-supplied `Authorization` header (case-insensitive match) → `JrError::UserError("Cannot override the Authorization header — auth is managed by jr")`. This prevents accidental credential leakage via `--verbose` output and ensures the escape hatch always uses the stored credentials.
 6. **Build request:**
    - Start with `client.request(method, &path)` — returns a `RequestBuilder` with URL and auth header set
    - `.build()?` to get a concrete `reqwest::Request`
@@ -138,10 +138,12 @@ Small enough to stay in one file.
 |----------|-----------|--------|
 | 2xx response | 0 | success |
 | 4xx/5xx response | 1 | `JrError::ApiError` |
-| 401 response | 1 | `JrError::NotAuthenticated` |
-| Invalid path, bad JSON body, bad header format | 64 | `JrError::BadInput` |
-| File read error (`@file`) | 66 | `JrError::InputError` |
+| 401 response | 2 | `JrError::NotAuthenticated` |
+| Invalid path, bad JSON body, bad header format | 64 | `JrError::UserError` |
+| File read error (`@file`) | 1 | `JrError::Io` (propagated via `?`) |
 | Network error | 1 | `JrError::NetworkError` |
+
+Note: exit codes are derived from the `impl JrError::exit_code()` at `src/error.rs:34`. `UserError` → 64; `NotAuthenticated` → 2; all other variants → 1.
 
 ### Stdout/Stderr Split
 
@@ -222,8 +224,8 @@ pub async fn send_raw(&self, request: reqwest::Request) -> anyhow::Result<reqwes
 | Header missing `:` | `Header must be in 'Key: Value' format (got: <value>)` | 64 |
 | Header key is empty | `Header key cannot be empty` | 64 |
 | User-supplied `Authorization` header | `Cannot override the Authorization header — auth is managed by jr` | 64 |
-| `@file` does not exist | `Cannot read body file <path>: <os error>` | 66 |
-| 401 response | `Not authenticated. Run 'jr auth login' to refresh your credentials.` | 1 |
+| `@file` does not exist | Propagated from `std::fs::read_to_string` (`No such file or directory`) | 1 |
+| 401 response | `Not authenticated. Run "jr auth login" to connect.` | 2 |
 | Other HTTP error | `Error: <errorMessages or message> (HTTP <status>)` on stderr, body on stdout | 1 |
 
 ## Testing
@@ -234,18 +236,18 @@ pub async fn send_raw(&self, request: reqwest::Request) -> anyhow::Result<reqwes
 |------|------------------|
 | `test_normalize_path_with_slash` | `/rest/api/3/myself` → unchanged |
 | `test_normalize_path_without_slash` | `rest/api/3/myself` → `/rest/api/3/myself` |
-| `test_normalize_path_rejects_http_url` | `http://site.atlassian.net/foo` → `BadInput` |
-| `test_normalize_path_rejects_https_url` | `https://site.atlassian.net/foo` → `BadInput` |
+| `test_normalize_path_rejects_http_url` | `http://site.atlassian.net/foo` → `UserError` |
+| `test_normalize_path_rejects_https_url` | `https://site.atlassian.net/foo` → `UserError` |
 | `test_parse_header_valid` | `"X-Foo: bar"` → `("X-Foo", "bar")` |
-| `test_parse_header_no_colon` | `"X-Foo bar"` → `BadInput` |
-| `test_parse_header_empty_key` | `": bar"` → `BadInput` |
+| `test_parse_header_no_colon` | `"X-Foo bar"` → `UserError` |
+| `test_parse_header_empty_key` | `": bar"` → `UserError` |
 | `test_parse_header_trims_whitespace` | `"X-Foo:   bar  "` → `("X-Foo", "bar")` |
 | `test_parse_header_value_with_colon` | `"X-Request-Id: abc:def"` → `("X-Request-Id", "abc:def")` (first-colon split) |
-| `test_parse_header_rejects_authorization` | `"Authorization: Bearer foo"` → `BadInput` |
-| `test_parse_header_rejects_authorization_case_insensitive` | `"authorization: Bearer foo"` → `BadInput` |
+| `test_parse_header_rejects_authorization` | `"Authorization: Bearer foo"` → `UserError` |
+| `test_parse_header_rejects_authorization_case_insensitive` | `"authorization: Bearer foo"` → `UserError` |
 | `test_resolve_body_none` | `None` → `Ok(None)` |
 | `test_resolve_body_inline_json` | `Some("{\"a\":1}")` → `Ok(Some("{\"a\":1}"))` |
-| `test_resolve_body_invalid_json` | `Some("not json")` → `BadInput` |
+| `test_resolve_body_invalid_json` | `Some("not json")` → `UserError` |
 | `test_resolve_body_at_file` | `Some("@/tmp/test.json")` reads the file contents |
 | `test_resolve_body_at_file_not_found` | `Some("@/no/such/file")` → `InputError` |
 | `test_resolve_body_at_dash_reads_stdin` | `Some("@-")` with injected `Cursor` → body matches Cursor content |
@@ -302,7 +304,7 @@ All JSON is synthetic. No real project keys, org IDs, account IDs, or instance U
 ## Caveats
 
 - **Header append footgun:** `reqwest::RequestBuilder::header()` appends rather than replaces. The implementation must build the `Request` via `.build()` and manipulate `req.headers_mut()` directly with `insert()`. The exactly-one-header test enforces this invariant.
-- **Auth header cannot be overridden:** User-supplied `-H Authorization: ...` is rejected with a `BadInput` error. Auth is managed by `jr` via `client.request()`, and explicit rejection prevents accidental credential leakage via `--verbose` output.
+- **Auth header cannot be overridden:** User-supplied `-H Authorization: ...` is rejected with a `UserError` error. Auth is managed by `jr` via `client.request()`, and explicit rejection prevents accidental credential leakage via `--verbose` output.
 - **Body size:** The entire body is read into memory before sending. Not suitable for very large payloads (multi-MB uploads) — but Jira's standard API is not typically used for large payloads.
 - **Streaming responses:** `jr api` reads the entire response into memory before printing. Fine for JSON payloads; not suitable for streaming endpoints (Jira has none in practice).
 - **`@` prefix in filenames:** A filename literally starting with `@` must be passed as `./@file.json` to avoid being interpreted as a nested reference. Matches curl's behavior.

--- a/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
+++ b/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
@@ -60,7 +60,7 @@ jr api /rest/api/3/myself | jq .accountId
 ### Design Choices
 
 - **No placeholder magic** (unlike `gh api`'s `{owner}/{repo}`) — `jr` has no equivalent "current repo" notion; users pass literal paths.
-- **No `--output` flag** — `jr api` always returns raw JSON from the server. The global `--output` flag is ignored by this command.
+- **Stdout is always raw** — `jr api` prints the server's response body to stdout verbatim, regardless of the global `--output` flag. However, stderr error formatting (on non-2xx responses) still follows `--output` — when `--output json` is set, errors appear as `{"error":"...","code":N}` on stderr, consistent with all other `jr` commands.
 - **No built-in `--jq`, `--paginate`, `--field`** — users pipe to `jq` or handle pagination via URL query params. More composable, follows Unix philosophy, smaller surface area.
 - **Path normalization:** if the path does not start with `/`, prepend one. Absolute URLs (starting with `http://` or `https://`) are rejected with `UserError` — the instance URL comes from config.
 - **`@file` / `@-` curl conventions** for body input. A filename literally starting with `@` requires `./` prefix (documented footgun, identical to curl).

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -226,12 +226,13 @@ impl JiraClient {
     /// full response body regardless of HTTP status. Auth header is already set
     /// on the request by `client.request()`.
     pub async fn send_raw(&self, request: reqwest::Request) -> anyhow::Result<Response> {
-        let mut last_response: Option<Response> = None;
-
         for attempt in 0..=MAX_RETRIES {
-            let req = request
-                .try_clone()
-                .expect("request should be cloneable (no streaming body)");
+            let req = request.try_clone().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "request cannot be retried because it is not cloneable \
+                     (for example, it may use a streaming body)"
+                )
+            })?;
 
             if self.verbose {
                 eprintln!("[verbose] {} {}", req.method(), req.url());
@@ -258,8 +259,9 @@ impl JiraClient {
                         MAX_RETRIES
                     );
                 }
+                // Drop the 429 response before sleeping so its body isn't held open
+                drop(response);
                 tokio::time::sleep(Duration::from_secs(delay)).await;
-                last_response = Some(response);
                 continue;
             }
 
@@ -267,8 +269,7 @@ impl JiraClient {
             return Ok(response);
         }
 
-        // Exhausted retries — return the last 429 response to the caller
-        Ok(last_response.expect("retry loop always sets last_response on 429"))
+        unreachable!("loop iterates 0..=MAX_RETRIES; final iteration returns")
     }
 
     /// Parse an error response into a `JrError`.

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -216,11 +216,15 @@ impl JiraClient {
     }
 
     /// Send a pre-built request without parsing non-2xx responses into errors.
-    /// Retries 429 up to MAX_RETRIES times. Returns the raw Response for ANY status.
     ///
-    /// Used by `jr api` (the raw passthrough command) where the caller needs
-    /// the full response body regardless of HTTP status. Auth header is already
-    /// set on the request by `client.request()`.
+    /// Retries 429 up to MAX_RETRIES times using `Retry-After`. Returns the raw
+    /// `Response` for ANY HTTP status (2xx, 4xx, 5xx), including after exhausting
+    /// 429 retries — callers MUST check `response.status()` to detect errors.
+    /// Network-level failures are still returned as `Err(JrError::NetworkError)`.
+    ///
+    /// Used by `jr api` (the raw passthrough command) where the caller needs the
+    /// full response body regardless of HTTP status. Auth header is already set
+    /// on the request by `client.request()`.
     pub async fn send_raw(&self, request: reqwest::Request) -> anyhow::Result<Response> {
         let mut last_response: Option<Response> = None;
 
@@ -373,10 +377,16 @@ impl JiraClient {
 }
 
 /// Extract a human-readable error message from a Jira error response body.
-/// Matches the behavior of the old `parse_error` body handling:
-/// 1. Try `errorMessages` array → join with "; "
-/// 2. Try `message` string
-/// 3. Fall back to the raw body string
+///
+/// Precedence:
+/// 1. Non-empty `errorMessages` array → joined with "; "
+/// 2. `message` string field
+/// 3. Raw body as a string (fallback)
+///
+/// Note: Jira's common validation error format
+/// `{"errorMessages":[],"errors":{"field":"msg"}}` is not parsed — it falls
+/// through to the raw body. Expanding `errors` object support is tracked
+/// as a follow-up enhancement.
 pub fn extract_error_message(body: &[u8]) -> String {
     let body_str = match std::str::from_utf8(body) {
         Ok(s) => s,

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -223,27 +223,8 @@ impl JiraClient {
             return JrError::NotAuthenticated.into();
         }
 
-        // Try to extract errorMessages from the JSON body
-        let message = match response.text().await {
-            Ok(body) => {
-                if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
-                    // Jira returns { "errorMessages": ["..."] } or { "message": "..." }
-                    if let Some(msgs) = json.get("errorMessages").and_then(|v| v.as_array()) {
-                        let messages: Vec<&str> = msgs.iter().filter_map(|m| m.as_str()).collect();
-                        if !messages.is_empty() {
-                            messages.join("; ")
-                        } else {
-                            body
-                        }
-                    } else if let Some(msg) = json.get("message").and_then(|v| v.as_str()) {
-                        msg.to_string()
-                    } else {
-                        body
-                    }
-                } else {
-                    body
-                }
-            }
+        let message = match response.bytes().await {
+            Ok(body) => extract_error_message(&body),
             Err(e) => format!("Could not read error response: {e}"),
         };
 
@@ -337,4 +318,30 @@ impl JiraClient {
             .request(method, &url)
             .header("Authorization", &self.auth_header)
     }
+}
+
+/// Extract a human-readable error message from a Jira error response body.
+/// Matches the behavior of the old `parse_error` body handling:
+/// 1. Try `errorMessages` array → join with "; "
+/// 2. Try `message` string
+/// 3. Fall back to the raw body string
+pub fn extract_error_message(body: &[u8]) -> String {
+    let body_str = match std::str::from_utf8(body) {
+        Ok(s) => s,
+        Err(_) => return String::from_utf8_lossy(body).into_owned(),
+    };
+
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(body_str) {
+        if let Some(msgs) = json.get("errorMessages").and_then(|v| v.as_array()) {
+            let messages: Vec<&str> = msgs.iter().filter_map(|m| m.as_str()).collect();
+            if !messages.is_empty() {
+                return messages.join("; ");
+            }
+        }
+        if let Some(msg) = json.get("message").and_then(|v| v.as_str()) {
+            return msg.to_string();
+        }
+    }
+
+    body_str.to_string()
 }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -215,6 +215,58 @@ impl JiraClient {
         unreachable!("retry loop should always return or set last_response");
     }
 
+    /// Send a pre-built request without parsing non-2xx responses into errors.
+    /// Retries 429 up to MAX_RETRIES times. Returns the raw Response for ANY status.
+    ///
+    /// Used by `jr api` (the raw passthrough command) where the caller needs
+    /// the full response body regardless of HTTP status. Auth header is already
+    /// set on the request by `client.request()`.
+    pub async fn send_raw(&self, request: reqwest::Request) -> anyhow::Result<Response> {
+        let mut last_response: Option<Response> = None;
+
+        for attempt in 0..=MAX_RETRIES {
+            let req = request
+                .try_clone()
+                .expect("request should be cloneable (no streaming body)");
+
+            if self.verbose {
+                eprintln!("[verbose] {} {}", req.method(), req.url());
+            }
+
+            let response = match self.client.execute(req).await {
+                Ok(r) => r,
+                Err(e) => {
+                    let url = e
+                        .url()
+                        .map(|u| u.host_str().unwrap_or("unknown").to_string())
+                        .unwrap_or_else(|| "unknown".to_string());
+                    return Err(JrError::NetworkError(url).into());
+                }
+            };
+
+            if response.status() == StatusCode::TOO_MANY_REQUESTS && attempt < MAX_RETRIES {
+                let rate_info = RateLimitInfo::from_headers(response.headers());
+                let delay = rate_info.retry_after_secs.unwrap_or(DEFAULT_RETRY_SECS);
+                if self.verbose {
+                    eprintln!(
+                        "[verbose] Rate limited (429). Retrying in {delay}s (attempt {}/{})",
+                        attempt + 1,
+                        MAX_RETRIES
+                    );
+                }
+                tokio::time::sleep(Duration::from_secs(delay)).await;
+                last_response = Some(response);
+                continue;
+            }
+
+            // Return the response for ANY status (including 4xx/5xx) — no error parsing
+            return Ok(response);
+        }
+
+        // Exhausted retries — return the last 429 response to the caller
+        Ok(last_response.expect("retry loop always sets last_response on 429"))
+    }
+
     /// Parse an error response into a `JrError`.
     async fn parse_error(response: Response) -> anyhow::Error {
         let status = response.status().as_u16();

--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -1,0 +1,85 @@
+//! `jr api` — raw API passthrough command.
+//!
+//! Provides an escape hatch for calling the Jira REST API directly with
+//! stored credentials, modeled on `gh api`. Supports method override,
+//! request body (inline / file / stdin), and custom headers.
+
+use crate::error::JrError;
+use anyhow::Result;
+use clap::ValueEnum;
+use reqwest::Method;
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug, ValueEnum)]
+pub enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+}
+
+impl From<HttpMethod> for Method {
+    fn from(method: HttpMethod) -> Self {
+        match method {
+            HttpMethod::Get => Method::GET,
+            HttpMethod::Post => Method::POST,
+            HttpMethod::Put => Method::PUT,
+            HttpMethod::Patch => Method::PATCH,
+            HttpMethod::Delete => Method::DELETE,
+        }
+    }
+}
+
+/// Normalize a user-provided API path:
+/// - Accept absolute paths like `/rest/api/3/myself`
+/// - Prepend `/` if missing (e.g. `rest/api/3/myself` → `/rest/api/3/myself`)
+/// - Reject absolute URLs (starting with `http://` or `https://`)
+pub fn normalize_path(raw: &str) -> Result<String> {
+    let trimmed = raw.trim();
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        return Err(JrError::UserError(
+            "Use a path like /rest/api/3/... — do not include the instance URL".into(),
+        )
+        .into());
+    }
+    if trimmed.starts_with('/') {
+        Ok(trimmed.to_string())
+    } else {
+        Ok(format!("/{trimmed}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_path_with_slash() {
+        let result = normalize_path("/rest/api/3/myself").unwrap();
+        assert_eq!(result, "/rest/api/3/myself");
+    }
+
+    #[test]
+    fn test_normalize_path_without_slash() {
+        let result = normalize_path("rest/api/3/myself").unwrap();
+        assert_eq!(result, "/rest/api/3/myself");
+    }
+
+    #[test]
+    fn test_normalize_path_trims_whitespace() {
+        let result = normalize_path("  /rest/api/3/myself  ").unwrap();
+        assert_eq!(result, "/rest/api/3/myself");
+    }
+
+    #[test]
+    fn test_normalize_path_rejects_http_url() {
+        let err = normalize_path("http://site.atlassian.net/rest/api/3/myself").unwrap_err();
+        assert!(err.to_string().contains("do not include the instance URL"));
+    }
+
+    #[test]
+    fn test_normalize_path_rejects_https_url() {
+        let err = normalize_path("https://site.atlassian.net/rest/api/3/myself").unwrap_err();
+        assert!(err.to_string().contains("do not include the instance URL"));
+    }
+}

--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -39,7 +39,8 @@ impl From<HttpMethod> for Method {
 /// - Reject absolute URLs (starting with `http://` or `https://`)
 pub fn normalize_path(raw: &str) -> Result<String> {
     let trimmed = raw.trim();
-    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+    let lower = trimmed.to_ascii_lowercase();
+    if lower.starts_with("http://") || lower.starts_with("https://") {
         return Err(JrError::UserError(
             "Use a path like /rest/api/3/... — do not include the instance URL".into(),
         )
@@ -202,6 +203,19 @@ mod tests {
     #[test]
     fn test_normalize_path_rejects_https_url() {
         let err = normalize_path("https://site.atlassian.net/rest/api/3/myself").unwrap_err();
+        assert!(err.to_string().contains("do not include the instance URL"));
+    }
+
+    #[test]
+    fn test_normalize_path_rejects_uppercase_https() {
+        // RFC 3986: URL schemes are case-insensitive.
+        let err = normalize_path("HTTPS://site.atlassian.net/rest/api/3/myself").unwrap_err();
+        assert!(err.to_string().contains("do not include the instance URL"));
+    }
+
+    #[test]
+    fn test_normalize_path_rejects_mixed_case_http() {
+        let err = normalize_path("Http://site.atlassian.net/foo").unwrap_err();
         assert!(err.to_string().contains("do not include the instance URL"));
     }
 

--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -8,6 +8,7 @@ use crate::error::JrError;
 use anyhow::Result;
 use clap::ValueEnum;
 use reqwest::Method;
+use reqwest::header::{HeaderName, HeaderValue};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, ValueEnum)]
 pub enum HttpMethod {
@@ -49,6 +50,37 @@ pub fn normalize_path(raw: &str) -> Result<String> {
     }
 }
 
+/// Parse a user-supplied header string in `Key: Value` format.
+/// Rejects `Authorization` (case-insensitive) to prevent credential override.
+pub fn parse_header(raw: &str) -> Result<(HeaderName, HeaderValue)> {
+    let (key, value) = raw.split_once(':').ok_or_else(|| {
+        JrError::UserError(format!(
+            "Header must be in 'Key: Value' format (got: {raw})"
+        ))
+    })?;
+
+    let key = key.trim();
+    let value = value.trim();
+
+    if key.is_empty() {
+        return Err(JrError::UserError("Header key cannot be empty".into()).into());
+    }
+
+    if key.eq_ignore_ascii_case("authorization") {
+        return Err(JrError::UserError(
+            "Cannot override the Authorization header — auth is managed by jr".into(),
+        )
+        .into());
+    }
+
+    let name = HeaderName::from_bytes(key.as_bytes())
+        .map_err(|e| JrError::UserError(format!("Invalid header name '{key}': {e}")))?;
+    let value = HeaderValue::from_str(value)
+        .map_err(|e| JrError::UserError(format!("Invalid header value '{value}': {e}")))?;
+
+    Ok((name, value))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -81,5 +113,53 @@ mod tests {
     fn test_normalize_path_rejects_https_url() {
         let err = normalize_path("https://site.atlassian.net/rest/api/3/myself").unwrap_err();
         assert!(err.to_string().contains("do not include the instance URL"));
+    }
+
+    #[test]
+    fn test_parse_header_valid() {
+        let (name, value) = parse_header("X-Foo: bar").unwrap();
+        assert_eq!(name.as_str(), "x-foo");
+        assert_eq!(value.to_str().unwrap(), "bar");
+    }
+
+    #[test]
+    fn test_parse_header_no_colon() {
+        let err = parse_header("X-Foo bar").unwrap_err();
+        assert!(err.to_string().contains("Key: Value"));
+    }
+
+    #[test]
+    fn test_parse_header_empty_key() {
+        let err = parse_header(": bar").unwrap_err();
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn test_parse_header_trims_whitespace() {
+        let (name, value) = parse_header("  X-Foo  :   bar  ").unwrap();
+        assert_eq!(name.as_str(), "x-foo");
+        assert_eq!(value.to_str().unwrap(), "bar");
+    }
+
+    #[test]
+    fn test_parse_header_value_with_colon() {
+        // Value contains a colon — should split on FIRST colon only
+        let (name, value) = parse_header("X-Request-Id: abc:def:ghi").unwrap();
+        assert_eq!(name.as_str(), "x-request-id");
+        assert_eq!(value.to_str().unwrap(), "abc:def:ghi");
+    }
+
+    #[test]
+    fn test_parse_header_rejects_authorization() {
+        let err = parse_header("Authorization: Bearer foo").unwrap_err();
+        assert!(err.to_string().contains("Authorization"));
+    }
+
+    #[test]
+    fn test_parse_header_rejects_authorization_case_insensitive() {
+        let err = parse_header("authorization: Bearer foo").unwrap_err();
+        assert!(err.to_string().contains("Authorization"));
+        let err = parse_header("AUTHORIZATION: Bearer foo").unwrap_err();
+        assert!(err.to_string().contains("Authorization"));
     }
 }

--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -123,22 +123,19 @@ pub async fn handle_api(
     header: Vec<String>,
     client: &JiraClient,
 ) -> Result<()> {
-    // 1. Normalize the path
     let normalized_path = normalize_path(&path)?;
 
-    // 2. Resolve the body (reads real stdin in production)
+    // Reads real stdin in production; resolve_body takes impl Read for testing.
     let body = resolve_body(data.as_deref(), std::io::stdin().lock())?;
 
-    // 3. Parse custom headers (rejects Authorization)
     let custom_headers: Vec<(HeaderName, HeaderValue)> = header
         .iter()
         .map(|h| parse_header(h))
         .collect::<Result<Vec<_>>>()?;
 
-    // 4. Build the request using the shared client helper, then .build() to get
-    //    a concrete Request we can modify via headers_mut().insert().
-    //    This avoids RequestBuilder::header()'s append semantics which would
-    //    duplicate Content-Type when the user supplies their own.
+    // Use .build() + headers_mut().insert() for replace semantics, so user
+    // headers (applied last) override any defaults like Content-Type.
+    // RequestBuilder::header() would append and produce duplicates.
     let mut req = client.request(method.into(), &normalized_path).build()?;
 
     if let Some(body_str) = body {
@@ -151,17 +148,15 @@ pub async fn handle_api(
         req.headers_mut().insert(name, value);
     }
 
-    // 5. Send via send_raw — preserves non-2xx responses
     let response = client.send_raw(req).await?;
     let status = response.status();
     let body_bytes = response.bytes().await?;
 
-    // 6. Print response body to stdout (raw bytes, no reformatting).
-    //    Matches gh api behavior: no trailing newline added — preserves
-    //    exact server bytes for file redirection.
+    // Print response body to stdout (raw bytes, no reformatting).
+    // Matches gh api behavior: no trailing newline added — preserves
+    // exact server bytes for file redirection.
     std::io::stdout().write_all(&body_bytes)?;
 
-    // 7. Handle status code
     if status.is_success() {
         Ok(())
     } else if status.as_u16() == 401 {
@@ -256,6 +251,14 @@ mod tests {
         assert!(err.to_string().contains("Authorization"));
         let err = parse_header("AUTHORIZATION: Bearer foo").unwrap_err();
         assert!(err.to_string().contains("Authorization"));
+    }
+
+    #[test]
+    fn test_parse_header_rejects_crlf_injection() {
+        // HTTP header injection via CRLF is a well-known attack vector.
+        // HeaderValue::from_str rejects control characters (visible ASCII only).
+        let err = parse_header("X-Foo: bar\r\nInjected: evil").unwrap_err();
+        assert!(err.to_string().contains("Invalid header value"));
     }
 
     use std::io::Cursor;

--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -4,6 +4,7 @@
 //! stored credentials, modeled on `gh api`. Supports method override,
 //! request body (inline / file / stdin), and custom headers.
 
+use crate::api::client::JiraClient;
 use crate::error::JrError;
 use anyhow::Result;
 use clap::ValueEnum;
@@ -109,6 +110,21 @@ pub fn resolve_body<R: Read>(arg: Option<&str>, mut stdin: R) -> Result<Option<S
         .map_err(|e| JrError::UserError(format!("Request body is not valid JSON: {e}")))?;
 
     Ok(Some(body))
+}
+
+/// Main entry point for `jr api`.
+///
+/// Takes the parsed CLI arguments, performs validation, builds an HTTP request,
+/// sends it via `JiraClient::send_raw`, and prints the response body to stdout.
+pub async fn handle_api(
+    _path: String,
+    _method: HttpMethod,
+    _data: Option<String>,
+    _header: Vec<String>,
+    _client: &JiraClient,
+) -> Result<()> {
+    // Implemented in Task 7
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -141,8 +141,8 @@ pub async fn handle_api(
     //    duplicate Content-Type when the user supplies their own.
     let mut req = client.request(method.into(), &normalized_path).build()?;
 
-    if let Some(ref body_str) = body {
-        *req.body_mut() = Some(body_str.clone().into());
+    if let Some(body_str) = body {
+        *req.body_mut() = Some(body_str.into());
         req.headers_mut()
             .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
     }
@@ -168,8 +168,6 @@ pub async fn handle_api(
         Err(JrError::NotAuthenticated.into())
     } else {
         let message = extract_error_message(&body_bytes);
-        // Print a human error summary to stderr
-        crate::output::print_error(&format!("{message} (HTTP {})", status.as_u16()));
         Err(JrError::ApiError {
             status: status.as_u16(),
             message,

--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -39,6 +39,9 @@ impl From<HttpMethod> for Method {
 /// - Reject absolute URLs (starting with `http://` or `https://`)
 pub fn normalize_path(raw: &str) -> Result<String> {
     let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(JrError::UserError("API path cannot be empty".into()).into());
+    }
     let lower = trimmed.to_ascii_lowercase();
     if lower.starts_with("http://") || lower.starts_with("https://") {
         return Err(JrError::UserError(
@@ -217,6 +220,18 @@ mod tests {
     fn test_normalize_path_rejects_mixed_case_http() {
         let err = normalize_path("Http://site.atlassian.net/foo").unwrap_err();
         assert!(err.to_string().contains("do not include the instance URL"));
+    }
+
+    #[test]
+    fn test_normalize_path_rejects_empty() {
+        let err = normalize_path("").unwrap_err();
+        assert!(err.to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_normalize_path_rejects_whitespace_only() {
+        let err = normalize_path("   ").unwrap_err();
+        assert!(err.to_string().contains("cannot be empty"));
     }
 
     #[test]

--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -4,13 +4,13 @@
 //! stored credentials, modeled on `gh api`. Supports method override,
 //! request body (inline / file / stdin), and custom headers.
 
-use crate::api::client::JiraClient;
+use crate::api::client::{JiraClient, extract_error_message};
 use crate::error::JrError;
 use anyhow::Result;
 use clap::ValueEnum;
 use reqwest::Method;
-use reqwest::header::{HeaderName, HeaderValue};
-use std::io::Read;
+use reqwest::header::{CONTENT_TYPE, HeaderName, HeaderValue};
+use std::io::{Read, Write};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, ValueEnum)]
 pub enum HttpMethod {
@@ -117,14 +117,65 @@ pub fn resolve_body<R: Read>(arg: Option<&str>, mut stdin: R) -> Result<Option<S
 /// Takes the parsed CLI arguments, performs validation, builds an HTTP request,
 /// sends it via `JiraClient::send_raw`, and prints the response body to stdout.
 pub async fn handle_api(
-    _path: String,
-    _method: HttpMethod,
-    _data: Option<String>,
-    _header: Vec<String>,
-    _client: &JiraClient,
+    path: String,
+    method: HttpMethod,
+    data: Option<String>,
+    header: Vec<String>,
+    client: &JiraClient,
 ) -> Result<()> {
-    // Implemented in Task 7
-    Ok(())
+    // 1. Normalize the path
+    let normalized_path = normalize_path(&path)?;
+
+    // 2. Resolve the body (reads real stdin in production)
+    let body = resolve_body(data.as_deref(), std::io::stdin().lock())?;
+
+    // 3. Parse custom headers (rejects Authorization)
+    let custom_headers: Vec<(HeaderName, HeaderValue)> = header
+        .iter()
+        .map(|h| parse_header(h))
+        .collect::<Result<Vec<_>>>()?;
+
+    // 4. Build the request using the shared client helper, then .build() to get
+    //    a concrete Request we can modify via headers_mut().insert().
+    //    This avoids RequestBuilder::header()'s append semantics which would
+    //    duplicate Content-Type when the user supplies their own.
+    let mut req = client.request(method.into(), &normalized_path).build()?;
+
+    if let Some(ref body_str) = body {
+        *req.body_mut() = Some(body_str.clone().into());
+        req.headers_mut()
+            .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    }
+
+    for (name, value) in custom_headers {
+        req.headers_mut().insert(name, value);
+    }
+
+    // 5. Send via send_raw — preserves non-2xx responses
+    let response = client.send_raw(req).await?;
+    let status = response.status();
+    let body_bytes = response.bytes().await?;
+
+    // 6. Print response body to stdout (raw bytes, no reformatting).
+    //    Matches gh api behavior: no trailing newline added — preserves
+    //    exact server bytes for file redirection.
+    std::io::stdout().write_all(&body_bytes)?;
+
+    // 7. Handle status code
+    if status.is_success() {
+        Ok(())
+    } else if status.as_u16() == 401 {
+        Err(JrError::NotAuthenticated.into())
+    } else {
+        let message = extract_error_message(&body_bytes);
+        // Print a human error summary to stderr
+        crate::output::print_error(&format!("{message} (HTTP {})", status.as_u16()));
+        Err(JrError::ApiError {
+            status: status.as_u16(),
+            message,
+        }
+        .into())
+    }
 }
 
 #[cfg(test)]

--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use clap::ValueEnum;
 use reqwest::Method;
 use reqwest::header::{HeaderName, HeaderValue};
+use std::io::Read;
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, ValueEnum)]
 pub enum HttpMethod {
@@ -79,6 +80,35 @@ pub fn parse_header(raw: &str) -> Result<(HeaderName, HeaderValue)> {
         .map_err(|e| JrError::UserError(format!("Invalid header value '{value}': {e}")))?;
 
     Ok((name, value))
+}
+
+/// Resolve the `--data` argument into an actual request body.
+/// - `None` → `None`
+/// - `Some("@-")` → read from `stdin` parameter
+/// - `Some("@filename")` → read from file
+/// - `Some(inline)` → use as-is
+///
+/// Validates that the resulting body is valid JSON.
+pub fn resolve_body<R: Read>(arg: Option<&str>, mut stdin: R) -> Result<Option<String>> {
+    let body = match arg {
+        None => return Ok(None),
+        Some("@-") => {
+            let mut buf = String::new();
+            stdin.read_to_string(&mut buf)?;
+            buf
+        }
+        Some(s) if s.starts_with('@') => {
+            let path = &s[1..];
+            std::fs::read_to_string(path)?
+        }
+        Some(s) => s.to_string(),
+    };
+
+    // Validate JSON — Jira REST API always uses JSON, catch typos before network
+    serde_json::from_str::<serde_json::Value>(&body)
+        .map_err(|e| JrError::UserError(format!("Request body is not valid JSON: {e}")))?;
+
+    Ok(Some(body))
 }
 
 #[cfg(test)]
@@ -161,5 +191,55 @@ mod tests {
         assert!(err.to_string().contains("Authorization"));
         let err = parse_header("AUTHORIZATION: Bearer foo").unwrap_err();
         assert!(err.to_string().contains("Authorization"));
+    }
+
+    use std::io::Cursor;
+
+    #[test]
+    fn test_resolve_body_none() {
+        let stdin: Cursor<&[u8]> = Cursor::new(b"");
+        let result = resolve_body(None, stdin).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_resolve_body_inline_json() {
+        let stdin: Cursor<&[u8]> = Cursor::new(b"");
+        let result = resolve_body(Some(r#"{"a":1}"#), stdin).unwrap();
+        assert_eq!(result, Some(r#"{"a":1}"#.to_string()));
+    }
+
+    #[test]
+    fn test_resolve_body_invalid_json_errors() {
+        let stdin: Cursor<&[u8]> = Cursor::new(b"");
+        let err = resolve_body(Some("not json"), stdin).unwrap_err();
+        assert!(err.to_string().contains("Request body is not valid JSON"));
+    }
+
+    #[test]
+    fn test_resolve_body_at_file_reads_contents() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), r#"{"from":"file"}"#).unwrap();
+        let arg = format!("@{}", tmp.path().display());
+
+        let stdin: Cursor<&[u8]> = Cursor::new(b"");
+        let result = resolve_body(Some(&arg), stdin).unwrap();
+        assert_eq!(result, Some(r#"{"from":"file"}"#.to_string()));
+    }
+
+    #[test]
+    fn test_resolve_body_at_file_not_found() {
+        let stdin: Cursor<&[u8]> = Cursor::new(b"");
+        let err = resolve_body(Some("@/nonexistent/path/to/file.json"), stdin).unwrap_err();
+        // Propagated std::io::Error
+        assert!(err.to_string().to_lowercase().contains("no such file"));
+    }
+
+    #[test]
+    fn test_resolve_body_at_dash_reads_stdin() {
+        let stdin_content = br#"{"from":"stdin"}"#;
+        let stdin = Cursor::new(&stdin_content[..]);
+        let result = resolve_body(Some("@-"), stdin).unwrap();
+        assert_eq!(result, Some(r#"{"from":"stdin"}"#.to_string()));
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
+pub mod api;
 pub mod assets;
 pub mod auth;
 pub mod board;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -97,6 +97,23 @@ pub enum Command {
         #[command(subcommand)]
         command: QueueCommand,
     },
+    /// Make a raw authenticated HTTP request to the Jira REST API.
+    Api {
+        /// API path (leading slash optional). Example: /rest/api/3/myself
+        path: String,
+
+        /// HTTP method
+        #[arg(short = 'X', long, value_enum, default_value_t = api::HttpMethod::Get)]
+        method: api::HttpMethod,
+
+        /// Request body: inline JSON, @file to read from a file, or @- to read from stdin
+        #[arg(short = 'd', long)]
+        data: Option<String>,
+
+        /// Custom header in "Key: Value" format (repeatable)
+        #[arg(short = 'H', long = "header")]
+        header: Vec<String>,
+    },
     /// Generate shell completions
     Completion {
         /// Shell to generate completions for

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,6 +170,16 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 )
                 .await
             }
+            cli::Command::Api {
+                path,
+                method,
+                data,
+                header,
+            } => {
+                let config = config::Config::load()?;
+                let client = api::client::JiraClient::from_config(&config, cli.verbose)?;
+                cli::api::handle_api(path, method, data, header, &client).await
+            }
         }
     };
 

--- a/tests/api_client.rs
+++ b/tests/api_client.rs
@@ -1,4 +1,5 @@
 use jr::api::client::JiraClient;
+use jr::api::client::extract_error_message;
 use serde::Deserialize;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -92,4 +93,47 @@ async fn test_401_returns_not_authenticated() {
         err_string.contains("Not authenticated"),
         "Expected 'Not authenticated' in error, got: {err_string}"
     );
+}
+
+#[test]
+fn test_extract_error_message_from_error_messages_array() {
+    let body =
+        br#"{"errorMessages":["Issue does not exist","Or you lack permission"],"errors":{}}"#;
+    let result = extract_error_message(body);
+    assert_eq!(result, "Issue does not exist; Or you lack permission");
+}
+
+#[test]
+fn test_extract_error_message_from_message_field() {
+    let body = br#"{"message":"Property with key not found"}"#;
+    let result = extract_error_message(body);
+    assert_eq!(result, "Property with key not found");
+}
+
+#[test]
+fn test_extract_error_message_prefers_error_messages_over_message() {
+    let body = br#"{"errorMessages":["first"],"message":"second"}"#;
+    let result = extract_error_message(body);
+    assert_eq!(result, "first");
+}
+
+#[test]
+fn test_extract_error_message_empty_error_messages_falls_back_to_body() {
+    let body = br#"{"errorMessages":[]}"#;
+    let result = extract_error_message(body);
+    assert_eq!(result, r#"{"errorMessages":[]}"#);
+}
+
+#[test]
+fn test_extract_error_message_plain_text_body() {
+    let body = b"Internal Server Error";
+    let result = extract_error_message(body);
+    assert_eq!(result, "Internal Server Error");
+}
+
+#[test]
+fn test_extract_error_message_empty_body() {
+    let body = b"";
+    let result = extract_error_message(body);
+    assert_eq!(result, "");
 }

--- a/tests/api_client.rs
+++ b/tests/api_client.rs
@@ -1,5 +1,6 @@
 use jr::api::client::JiraClient;
 use jr::api::client::extract_error_message;
+use reqwest::Method;
 use serde::Deserialize;
 use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -136,4 +137,106 @@ fn test_extract_error_message_empty_body() {
     let body = b"";
     let result = extract_error_message(body);
     assert_eq!(result, "");
+}
+
+#[tokio::test]
+async fn test_send_raw_returns_response_for_2xx() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"accountId":"abc"}"#))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(server.uri(), "Basic dGVzdDp0ZXN0".to_string());
+
+    let req = client
+        .request(Method::GET, "/rest/api/3/myself")
+        .build()
+        .unwrap();
+    let response = client.send_raw(req).await.unwrap();
+
+    assert_eq!(response.status().as_u16(), 200);
+    let body = response.text().await.unwrap();
+    assert_eq!(body, r#"{"accountId":"abc"}"#);
+}
+
+#[tokio::test]
+async fn test_send_raw_returns_response_for_404() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/MISSING-1"))
+        .respond_with(
+            ResponseTemplate::new(404)
+                .set_body_string(r#"{"errorMessages":["Issue does not exist"],"errors":{}}"#),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(server.uri(), "Basic dGVzdDp0ZXN0".to_string());
+
+    let req = client
+        .request(Method::GET, "/rest/api/3/issue/MISSING-1")
+        .build()
+        .unwrap();
+    let response = client.send_raw(req).await.unwrap();
+
+    // Critical: 404 is NOT converted to an error
+    assert_eq!(response.status().as_u16(), 404);
+    let body = response.text().await.unwrap();
+    assert!(body.contains("Issue does not exist"));
+}
+
+#[tokio::test]
+async fn test_send_raw_retries_429_then_succeeds() {
+    let server = MockServer::start().await;
+    // First call returns 429
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "0"))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    // Second call returns 200
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"ok":true}"#))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(server.uri(), "Basic dGVzdDp0ZXN0".to_string());
+
+    let req = client
+        .request(Method::GET, "/rest/api/3/myself")
+        .build()
+        .unwrap();
+    let response = client.send_raw(req).await.unwrap();
+
+    assert_eq!(response.status().as_u16(), 200);
+}
+
+#[tokio::test]
+async fn test_send_raw_returns_429_after_exhausting_retries() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "0"))
+        .expect(4) // initial + 3 retries (MAX_RETRIES)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(server.uri(), "Basic dGVzdDp0ZXN0".to_string());
+
+    let req = client
+        .request(Method::GET, "/rest/api/3/myself")
+        .build()
+        .unwrap();
+    let response = client.send_raw(req).await.unwrap();
+
+    // Caller receives the 429 response — not an error
+    assert_eq!(response.status().as_u16(), 429);
 }

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1164,6 +1164,11 @@ async fn test_handler_api_custom_content_type_overrides_default() {
         content_type_values[0], "application/vnd.atlassian.custom+json",
         "user-supplied Content-Type must override the default"
     );
+    // Defensive: verify application/json is NOT present alongside the custom value
+    assert!(
+        !content_type_values.iter().any(|v| v == "application/json"),
+        "default application/json should have been replaced, got {content_type_values:?}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1257,4 +1262,50 @@ async fn test_handler_api_stdin_body() {
         .write_stdin(r#"{"from":"stdin"}"#)
         .assert()
         .success();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_401_returns_not_authenticated() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(
+            ResponseTemplate::new(401)
+                .set_body_string(r#"{"errorMessages":["Client must be authenticated"]}"#),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .args(["api", "/rest/api/3/myself"])
+        .assert()
+        .failure()
+        // 401 → JrError::NotAuthenticated, which has display "Not authenticated..."
+        .stderr(predicate::str::contains("Not authenticated"))
+        // Body is still printed to stdout before the status check
+        .stdout(predicate::str::contains("Client must be authenticated"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_stdout_byte_exact() {
+    let server = MockServer::start().await;
+
+    // Deliberately non-pretty-printed JSON to verify raw byte passthrough
+    let exact_body = r#"{"key":"PROJ-1","custom":"no reformatting"}"#;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(exact_body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .args(["api", "/rest/api/3/myself"])
+        .assert()
+        .success()
+        // Byte-exact: no trailing newline, no pretty-printing
+        .stdout(predicate::eq(exact_body));
 }

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -20,6 +20,16 @@ fn jr_cmd(server_uri: &str) -> Command {
     cmd
 }
 
+/// Build a `jr` command pre-configured for handler-level testing of `jr api`.
+/// Unlike `jr_cmd`, does not set `--output json` since `jr api` ignores it.
+fn jr_api_cmd(server_uri: &str) -> Command {
+    let mut cmd = Command::cargo_bin("jr").unwrap();
+    cmd.env("JR_BASE_URL", server_uri)
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .arg("--no-input");
+    cmd
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_handler_assign_with_account_id() {
     let server = MockServer::start().await;
@@ -992,4 +1002,259 @@ async fn test_handler_comments_hides_visibility_column_for_non_jsm() {
         !stdout.contains("Internal"),
         "Non-JSM comments should not show Internal, got: {stdout}"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_get_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(r#"{"accountId":"abc-123","displayName":"Test User"}"#),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .args(["api", "/rest/api/3/myself"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"accountId\":\"abc-123\""))
+        .stdout(predicate::str::contains("\"displayName\":\"Test User\""));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_post_with_inline_data() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue"))
+        .and(body_partial_json(
+            serde_json::json!({"fields": {"summary": "Test"}}),
+        ))
+        .respond_with(ResponseTemplate::new(201).set_body_string(r#"{"key":"PROJ-1"}"#))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .args([
+            "api",
+            "/rest/api/3/issue",
+            "--method",
+            "post",
+            "--data",
+            r#"{"fields":{"summary":"Test"}}"#,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"key\":\"PROJ-1\""));
+
+    // Verify exactly one Content-Type header on the received request
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let content_type_count = requests[0]
+        .headers
+        .iter()
+        .filter(|(name, _)| name.as_str().eq_ignore_ascii_case("content-type"))
+        .count();
+    assert_eq!(
+        content_type_count, 1,
+        "expected exactly one Content-Type header, got {content_type_count}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_put_with_method_flag() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/api/3/issue/PROJ-1/assignee"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .args([
+            "api",
+            "/rest/api/3/issue/PROJ-1/assignee",
+            "-X",
+            "put",
+            "-d",
+            r#"{"accountId":"abc-123"}"#,
+        ])
+        .assert()
+        .success();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_custom_header_passes_through() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/servicedeskapi/servicedesk/1/organization"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"values":[]}"#))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .args([
+            "api",
+            "/rest/servicedeskapi/servicedesk/1/organization",
+            "-H",
+            "X-ExperimentalApi: opt-in",
+        ])
+        .assert()
+        .success();
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let has_experimental_header = requests[0].headers.iter().any(|(name, value)| {
+        name.as_str().eq_ignore_ascii_case("x-experimentalapi") && value.as_bytes() == b"opt-in"
+    });
+    assert!(has_experimental_header, "X-ExperimentalApi header missing");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_custom_content_type_overrides_default() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/thing"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Note: body must still be valid JSON (we validate at resolve_body stage).
+    // The Content-Type override is tested separately from the JSON validation.
+    jr_api_cmd(&server.uri())
+        .args([
+            "api",
+            "/rest/api/3/thing",
+            "-X",
+            "post",
+            "-d",
+            r#"{"ok":true}"#,
+            "-H",
+            "Content-Type: application/vnd.atlassian.custom+json",
+        ])
+        .assert()
+        .success();
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1);
+    let content_type_values: Vec<String> = requests[0]
+        .headers
+        .iter()
+        .filter(|(name, _)| name.as_str().eq_ignore_ascii_case("content-type"))
+        .map(|(_, value)| String::from_utf8_lossy(value.as_bytes()).to_string())
+        .collect();
+    assert_eq!(
+        content_type_values.len(),
+        1,
+        "expected exactly one Content-Type, got {content_type_values:?}"
+    );
+    assert_eq!(
+        content_type_values[0], "application/vnd.atlassian.custom+json",
+        "user-supplied Content-Type must override the default"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_error_response_body_to_stdout() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/MISSING-1"))
+        .respond_with(
+            ResponseTemplate::new(404)
+                .set_body_string(r#"{"errorMessages":["Issue does not exist"],"errors":{}}"#),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .args(["api", "/rest/api/3/issue/MISSING-1"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("Issue does not exist"))
+        // main.rs prints "Error: {e}" where e is JrError::ApiError with Display
+        // "API error ({status}): {message}" — stderr contains "(404)" and the extracted message
+        .stderr(predicate::str::contains("(404)"))
+        .stderr(predicate::str::contains("Issue does not exist"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_path_normalization_missing_slash() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"ok":true}"#))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // No leading slash — should still work
+    jr_api_cmd(&server.uri())
+        .args(["api", "rest/api/3/myself"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"ok\":true"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_rejects_absolute_url() {
+    let server = MockServer::start().await;
+    // No mock defined — if the handler tries to hit the network, it will fail
+
+    jr_api_cmd(&server.uri())
+        .args(["api", "https://example.atlassian.net/rest/api/3/myself"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("do not include the instance URL"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_rejects_authorization_header() {
+    let server = MockServer::start().await;
+
+    jr_api_cmd(&server.uri())
+        .args([
+            "api",
+            "/rest/api/3/myself",
+            "-H",
+            "Authorization: Bearer pwned",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Cannot override the Authorization header",
+        ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_stdin_body() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/thing"))
+        .and(body_partial_json(serde_json::json!({"from":"stdin"})))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .args(["api", "/rest/api/3/thing", "-X", "post", "-d", "@-"])
+        .write_stdin(r#"{"from":"stdin"}"#)
+        .assert()
+        .success();
 }

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1309,3 +1309,29 @@ async fn test_handler_api_stdout_byte_exact() {
         // Byte-exact: no trailing newline, no pretty-printing
         .stdout(predicate::eq(exact_body));
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_api_output_json_flag_ignored() {
+    let server = MockServer::start().await;
+
+    let raw_body = r#"{"accountId":"abc-123"}"#;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(raw_body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Pass --output json globally — jr api should still return raw body, not wrapped
+    let mut cmd = Command::cargo_bin("jr").unwrap();
+    cmd.env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .arg("--no-input")
+        .arg("--output")
+        .arg("json")
+        .args(["api", "/rest/api/3/myself"])
+        .assert()
+        .success()
+        .stdout(predicate::eq(raw_body));
+}


### PR DESCRIPTION
## Summary

Closes #111. Closes #173 (try_clone panic was addressed inline after Copilot flagged it in review). Adds `jr api <path>` — a raw HTTP passthrough command modeled on `gh api` that lets users call arbitrary Jira REST endpoints with stored credentials when a high-level command doesn't cover a use case.

- **Minimal escape hatch:** `-X/--method`, `-d/--data` (inline/`@file`/`@-`), `-H/--header` (repeatable)
- **Raw JSON to stdout, errors to stderr, exit codes** match the rest of `jr`
- **Authorization header rejected** (case-insensitive) to prevent credential override
- **Exactly one Content-Type** header guarantee — uses `headers_mut().insert()` to sidestep `RequestBuilder::header()`'s append semantics
- **429 retry** preserved via new `JiraClient::send_raw()` method; non-2xx responses are returned raw instead of parsed into errors

```bash
jr api /rest/api/3/myself
jr api /rest/api/3/issue -X POST -d @payload.json
jr api /rest/servicedeskapi/servicedesk/1/organization -H "X-ExperimentalApi: opt-in"
jr api /rest/api/3/myself | jq .accountId
```

## Test Plan

- [x] Unit tests in `src/cli/api.rs` (19 tests: `normalize_path`, `parse_header` incl. CRLF injection, `resolve_body`)
- [x] Client tests in `tests/api_client.rs` (10 new: `extract_error_message` × 6, `send_raw` × 4)
- [x] Handler integration tests in `tests/cli_handler.rs` (12 new subprocess tests: GET/POST/PUT, stdin body, custom headers, Content-Type override, error passthrough, path normalization, 401 routing, absolute URL/Authorization rejection, byte-exact stdout)
- [x] `cargo test` — full suite passes (all binaries)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Addressed pr-review-toolkit findings (critical + important items); filed #171, #172, #173 for deferred items

## Design & Plan

- Spec: `docs/superpowers/specs/2026-04-08-api-passthrough-design.md`
- Plan: `docs/superpowers/plans/2026-04-08-api-passthrough.md`

## Follow-ups

- #171 — expand `extract_error_message` to handle `errors` object, `errorMessage` singular, empty body
- #172 — make 429 retry exhaustion observable to users
