### PR TITLE
fix: expand extract_error_message Jira error format coverage

### DIFF
--- a/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
+++ b/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
@@ -284,8 +284,8 @@ assert_eq!(content_type_count, 1);
 |------|------------------|
 | `test_send_raw_returns_response_for_2xx` | `send_raw` returns `Response` for 200 |
 | `test_send_raw_returns_response_for_404` | `send_raw` returns `Response` (NOT an error) for 404 — critical for raw passthrough |
-| `test_send_raw_retries_429` | `send_raw` retries 429 with `Retry-After`, then returns 200 response |
-| `test_send_raw_returns_response_after_exhausted_429` | After `MAX_RETRIES` 429s, returns the 429 `Response` (caller decides what to do) |
+| `test_send_raw_retries_429_then_succeeds` | `send_raw` retries 429 with `Retry-After`, then returns 200 response |
+| `test_send_raw_returns_429_after_exhausting_retries` | After `MAX_RETRIES` 429s, returns the 429 `Response` (caller decides what to do) |
 | `test_extract_error_message_from_error_messages_array` | `{"errorMessages":["foo","bar"]}` → `"foo; bar"` |
 | `test_extract_error_message_from_message_field` | `{"message":"foo"}` → `"foo"` |
 | `test_extract_error_message_plain_text_body` | `"not json"` → `"not json"` (fallback) |

--- a/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
+++ b/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
@@ -308,7 +308,7 @@ All JSON is synthetic. No real project keys, org IDs, account IDs, or instance U
 - **Body size:** The entire body is read into memory before sending. Not suitable for very large payloads (multi-MB uploads) — but Jira's standard API is not typically used for large payloads.
 - **Streaming responses:** `jr api` reads the entire response into memory before printing. Fine for JSON payloads; not suitable for streaming endpoints (Jira has none in practice).
 - **`@` prefix in filenames:** A filename literally starting with `@` must be passed as `./@file.json` to avoid being interpreted as a nested reference. Matches curl's behavior.
-- **Error message extraction is incomplete (pre-existing):** `extract_error_message` preserves the existing `parse_error` behavior — it handles `errorMessages` array and `message` string but not `errorMessage` (singular JSM field), `errors` object (field-level validation), or `status-code` + `message` format. Expanding format coverage is tracked as a follow-up enhancement, not in scope for this PR.
+- **Error message extraction:** `extract_error_message` now handles `errorMessages` array, `errors` object (field-level validation), `message` string, `errorMessage` singular, and empty bodies. See #171.
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
+++ b/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
@@ -289,7 +289,7 @@ assert_eq!(content_type_count, 1);
 | `test_extract_error_message_from_error_messages` | `{"errorMessages":["foo","bar"]}` → `"foo; bar"` |
 | `test_extract_error_message_from_message_field` | `{"message":"foo"}` → `"foo"` |
 | `test_extract_error_message_from_plain_text` | `"not json"` → `"not json"` (fallback) |
-| `test_extract_error_message_from_empty_body` | `""` → `""` (fallback) |
+| `test_extract_error_message_from_empty_body` | `""` → `"<empty response body>"` |
 
 ### Stdin Testing Approach
 

--- a/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
+++ b/docs/superpowers/specs/2026-04-08-api-passthrough-design.md
@@ -286,10 +286,10 @@ assert_eq!(content_type_count, 1);
 | `test_send_raw_returns_response_for_404` | `send_raw` returns `Response` (NOT an error) for 404 — critical for raw passthrough |
 | `test_send_raw_retries_429` | `send_raw` retries 429 with `Retry-After`, then returns 200 response |
 | `test_send_raw_returns_response_after_exhausted_429` | After `MAX_RETRIES` 429s, returns the 429 `Response` (caller decides what to do) |
-| `test_extract_error_message_from_error_messages` | `{"errorMessages":["foo","bar"]}` → `"foo; bar"` |
+| `test_extract_error_message_from_error_messages_array` | `{"errorMessages":["foo","bar"]}` → `"foo; bar"` |
 | `test_extract_error_message_from_message_field` | `{"message":"foo"}` → `"foo"` |
-| `test_extract_error_message_from_plain_text` | `"not json"` → `"not json"` (fallback) |
-| `test_extract_error_message_from_empty_body` | `""` → `"<empty response body>"` |
+| `test_extract_error_message_plain_text_body` | `"not json"` → `"not json"` (fallback) |
+| `test_extract_error_message_empty_body` | `""` → `"<empty response body>"` |
 
 ### Stdin Testing Approach
 

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -381,14 +381,16 @@ impl JiraClient {
 ///
 /// Precedence:
 /// 1. Non-empty `errorMessages` array → joined with "; "
-/// 2. `message` string field
-/// 3. Raw body as a string (fallback)
-///
-/// Note: Jira's common validation error format
-/// `{"errorMessages":[],"errors":{"field":"msg"}}` is not parsed — it falls
-/// through to the raw body. Expanding `errors` object support is tracked
-/// as a follow-up enhancement.
+/// 2. Non-empty `errors` object (field-level validation) → "field: msg; field2: msg2"
+/// 3. `message` string field
+/// 4. `errorMessage` string field (singular, seen in some JSM endpoints)
+/// 5. Empty body → "<empty response body>"
+/// 6. Raw body as a string (fallback)
 pub fn extract_error_message(body: &[u8]) -> String {
+    if body.is_empty() {
+        return "<empty response body>".to_string();
+    }
+
     let body_str = match std::str::from_utf8(body) {
         Ok(s) => s,
         Err(_) => return String::from_utf8_lossy(body).into_owned(),
@@ -401,7 +403,20 @@ pub fn extract_error_message(body: &[u8]) -> String {
                 return messages.join("; ");
             }
         }
+        if let Some(errors) = json.get("errors").and_then(|v| v.as_object()) {
+            if !errors.is_empty() {
+                let mut pairs: Vec<String> = errors
+                    .iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| format!("{k}: {s}")))
+                    .collect();
+                pairs.sort();
+                return pairs.join("; ");
+            }
+        }
         if let Some(msg) = json.get("message").and_then(|v| v.as_str()) {
+            return msg.to_string();
+        }
+        if let Some(msg) = json.get("errorMessage").and_then(|v| v.as_str()) {
             return msg.to_string();
         }
     }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -407,7 +407,13 @@ pub fn extract_error_message(body: &[u8]) -> String {
             if !errors.is_empty() {
                 let mut pairs: Vec<String> = errors
                     .iter()
-                    .filter_map(|(k, v)| v.as_str().map(|s| format!("{k}: {s}")))
+                    .map(|(k, v)| {
+                        if let Some(s) = v.as_str() {
+                            format!("{k}: {s}")
+                        } else {
+                            format!("{k}: {v}")
+                        }
+                    })
                     .collect();
                 pairs.sort();
                 return pairs.join("; ");

--- a/tests/api_client.rs
+++ b/tests/api_client.rs
@@ -130,15 +130,7 @@ fn test_extract_error_message_errors_object_multiple_fields() {
     let body =
         br#"{"errorMessages":[],"errors":{"summary":"is required","priority":"is required"}}"#;
     let result = extract_error_message(body);
-    // Both fields present, joined with "; " (order may vary due to JSON object)
-    assert!(
-        result.contains("summary: is required"),
-        "expected 'summary: is required' in '{result}'"
-    );
-    assert!(
-        result.contains("priority: is required"),
-        "expected 'priority: is required' in '{result}'"
-    );
+    assert_eq!(result, "priority: is required; summary: is required");
 }
 
 #[test]

--- a/tests/api_client.rs
+++ b/tests/api_client.rs
@@ -119,10 +119,41 @@ fn test_extract_error_message_prefers_error_messages_over_message() {
 }
 
 #[test]
-fn test_extract_error_message_empty_error_messages_falls_back_to_body() {
-    let body = br#"{"errorMessages":[]}"#;
+fn test_extract_error_message_empty_error_messages_falls_back_to_errors_object() {
+    let body = br#"{"errorMessages":[],"errors":{"summary":"You must specify a summary"}}"#;
     let result = extract_error_message(body);
-    assert_eq!(result, r#"{"errorMessages":[]}"#);
+    assert_eq!(result, "summary: You must specify a summary");
+}
+
+#[test]
+fn test_extract_error_message_errors_object_multiple_fields() {
+    let body =
+        br#"{"errorMessages":[],"errors":{"summary":"is required","priority":"is required"}}"#;
+    let result = extract_error_message(body);
+    // Both fields present, joined with "; " (order may vary due to JSON object)
+    assert!(
+        result.contains("summary: is required"),
+        "expected 'summary: is required' in '{result}'"
+    );
+    assert!(
+        result.contains("priority: is required"),
+        "expected 'priority: is required' in '{result}'"
+    );
+}
+
+#[test]
+fn test_extract_error_message_errors_object_empty_falls_through() {
+    let body = br#"{"errorMessages":[],"errors":{}}"#;
+    let result = extract_error_message(body);
+    // Empty errors object, no message field → raw body fallback
+    assert_eq!(result, r#"{"errorMessages":[],"errors":{}}"#);
+}
+
+#[test]
+fn test_extract_error_message_error_message_singular() {
+    let body = br#"{"errorMessage":"Cannot find issue"}"#;
+    let result = extract_error_message(body);
+    assert_eq!(result, "Cannot find issue");
 }
 
 #[test]
@@ -136,7 +167,7 @@ fn test_extract_error_message_plain_text_body() {
 fn test_extract_error_message_empty_body() {
     let body = b"";
     let result = extract_error_message(body);
-    assert_eq!(result, "");
+    assert_eq!(result, "<empty response body>");
 }
 
 #[tokio::test]

--- a/tests/api_client.rs
+++ b/tests/api_client.rs
@@ -150,6 +150,27 @@ fn test_extract_error_message_errors_object_empty_falls_through() {
 }
 
 #[test]
+fn test_extract_error_message_errors_object_nested_value() {
+    let body = br#"{"errorMessages":[],"errors":{"customfield_10001":{"messages":["invalid"]}}}"#;
+    let result = extract_error_message(body);
+    assert_eq!(result, r#"customfield_10001: {"messages":["invalid"]}"#);
+}
+
+#[test]
+fn test_extract_error_message_errors_object_mixed_values() {
+    let body = br#"{"errorMessages":[],"errors":{"summary":"is required","components":["a","b"]}}"#;
+    let result = extract_error_message(body);
+    assert!(
+        result.contains("summary: is required"),
+        "expected 'summary: is required' in '{result}'"
+    );
+    assert!(
+        result.contains(r#"components: ["a","b"]"#),
+        "expected serialized array in '{result}'"
+    );
+}
+
+#[test]
 fn test_extract_error_message_error_message_singular() {
     let body = br#"{"errorMessage":"Cannot find issue"}"#;
     let result = extract_error_message(body);


### PR DESCRIPTION
## Summary

Closes #171. Expands `extract_error_message` in `src/api/client.rs` to handle additional Jira Cloud error response formats that previously fell through to raw body dump.

- **`errors` object** (field-level validation): `{"errorMessages":[],"errors":{"summary":"is required"}}` → `"summary: is required"`. Non-string values (nested objects, arrays) are stringified rather than dropped.
- **`errorMessage` singular** (defensive for JSM endpoints): `{"errorMessage":"Cannot find issue"}` → `"Cannot find issue"`
- **Empty body** → `"<empty response body>"` sentinel instead of bare empty string
- Precedence chain: `errorMessages` array → `errors` object → `message` → `errorMessage` → empty sentinel → raw body fallback
- Updated api-passthrough spec caveat to reflect expanded coverage

## Test Plan

- [x] `cargo test` — 578 tests pass (13 `extract_error_message` tests: 6 existing + 5 new formats + 2 non-string value edge cases)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] PR review (code-reviewer + silent-failure-hunter) — addressed Important finding (non-string errors values)