### PR TITLE
fix: warn on stderr when 429 retry exhaustion occurs

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -199,6 +199,11 @@ impl JiraClient {
                 continue;
             }
 
+            // Warn the user if we exhausted retries on a 429
+            if response.status() == StatusCode::TOO_MANY_REQUESTS {
+                eprintln!("warning: rate limited by Jira — gave up after {MAX_RETRIES} retries");
+            }
+
             // For non-429 errors, parse and return the error
             if response.status().is_client_error() || response.status().is_server_error() {
                 return Err(Self::parse_error(response).await);

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -206,7 +206,7 @@ impl JiraClient {
                 );
             }
 
-            // For non-429 errors, parse and return the error
+            // Parse and return any error response (including 429 after exhausting retries)
             if response.status().is_client_error() || response.status().is_server_error() {
                 return Err(Self::parse_error(response).await);
             }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -201,7 +201,9 @@ impl JiraClient {
 
             // Warn the user if we exhausted retries on a 429
             if response.status() == StatusCode::TOO_MANY_REQUESTS {
-                eprintln!("warning: rate limited by Jira — gave up after {MAX_RETRIES} retries");
+                eprintln!(
+                    "warning: rate limited by Jira — gave up after {MAX_RETRIES} retries. Wait a moment and try again."
+                );
             }
 
             // For non-429 errors, parse and return the error
@@ -272,7 +274,9 @@ impl JiraClient {
 
             // Warn the user if we exhausted retries on a 429
             if response.status() == StatusCode::TOO_MANY_REQUESTS {
-                eprintln!("warning: rate limited by Jira — gave up after {MAX_RETRIES} retries");
+                eprintln!(
+                    "warning: rate limited by Jira — gave up after {MAX_RETRIES} retries. Wait a moment and try again."
+                );
             }
 
             // Return the response for ANY status (including 4xx/5xx) — no error parsing

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -265,6 +265,11 @@ impl JiraClient {
                 continue;
             }
 
+            // Warn the user if we exhausted retries on a 429
+            if response.status() == StatusCode::TOO_MANY_REQUESTS {
+                eprintln!("warning: rate limited by Jira — gave up after {MAX_RETRIES} retries");
+            }
+
             // Return the response for ANY status (including 4xx/5xx) — no error parsing
             return Ok(response);
         }

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1358,3 +1358,25 @@ async fn test_api_warns_on_429_retry_exhaustion() {
         .stderr(predicate::str::contains("3 retries"))
         .stderr(predicate::str::contains("Wait a moment and try again"));
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_send_warns_on_429_retry_exhaustion() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FAKE-1"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("Retry-After", "0")
+                .set_body_string(r#"{"errorMessages":["Rate limit exceeded"]}"#),
+        )
+        .expect(4) // initial + 3 retries (MAX_RETRIES)
+        .mount(&server)
+        .await;
+
+    jr_cmd(&server.uri())
+        .args(["issue", "view", "FAKE-1"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("warning: rate limited by Jira"))
+        .stderr(predicate::str::contains("3 retries"));
+}

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1335,3 +1335,25 @@ async fn test_handler_api_output_json_flag_ignored() {
         .success()
         .stdout(predicate::eq(raw_body));
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_api_warns_on_429_retry_exhaustion() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("Retry-After", "0")
+                .set_body_string(r#"{"errorMessages":["Rate limit exceeded"]}"#),
+        )
+        .expect(4) // initial + 3 retries (MAX_RETRIES)
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .args(["api", "/rest/api/3/myself"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("warning: rate limited by Jira"))
+        .stderr(predicate::str::contains("3 retries"));
+}

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1355,5 +1355,6 @@ async fn test_api_warns_on_429_retry_exhaustion() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("warning: rate limited by Jira"))
-        .stderr(predicate::str::contains("3 retries"));
+        .stderr(predicate::str::contains("3 retries"))
+        .stderr(predicate::str::contains("Wait a moment and try again"));
 }


### PR DESCRIPTION
## Summary

Closes #172. Adds a non-verbose stderr warning when `send` or `send_raw` exhaust `MAX_RETRIES` (3) for HTTP 429 rate limiting. Previously, users saw a delayed error with no indication that jr absorbed backoff time on their behalf.

- **Warning message:** `warning: rate limited by Jira — gave up after 3 retries. Wait a moment and try again.`
- **Always printed** (not gated on `--verbose`) — retry exhaustion is operationally significant
- **Applies to both `send` and `send_raw`** — consistent across `jr api` and all high-level commands
- **No change** to return types, error messages, exit codes, or stdout

## Test Plan

- [x] `cargo test` — 580 tests pass (2 new handler tests: `send_raw` path via `jr api`, `send` path via `jr issue view`)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] PR review round 1 (code-reviewer + silent-failure-hunter) — addressed actionable guidance finding
- [x] PR review round 2 (code-reviewer + pr-test-analyzer + comment-analyzer) — addressed misleading comment + send path test gap
- [x] PR review round 3 (code-reviewer) — clean, no issues

## Design & Plan

- Spec: `docs/superpowers/specs/2026-04-10-429-retry-exhaustion-warning-design.md`
- Plan: `docs/superpowers/plans/2026-04-10-429-retry-exhaustion-warning.md`