### PR TITLE
refactor: separate human status messages (stderr) from machine output (stdout)

### DIFF
--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -129,8 +129,8 @@ pub async fn oauth_login(client_id: &str, client_secret: &str) -> Result<OAuthRe
         urlencoding::encode(SCOPES),
     );
 
-    println!("Opening browser for authorization...");
-    println!("If browser doesn't open, visit: {auth_url}");
+    eprintln!("Opening browser for authorization...");
+    eprintln!("If browser doesn't open, visit: {auth_url}");
     let _ = open::that(&auth_url);
 
     // 2. Listen for the OAuth callback.

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -18,15 +18,15 @@ pub async fn login_token() -> Result<()> {
         .context("failed to read API token")?;
 
     auth::store_api_token(&email, &token)?;
-    println!("Credentials stored in keychain.");
+    eprintln!("Credentials stored in keychain.");
     Ok(())
 }
 
 /// Run the OAuth 2.0 (3LO) login flow and persist site configuration.
 /// Prompts the user for their own OAuth app credentials.
 pub async fn login_oauth() -> Result<()> {
-    println!("OAuth 2.0 requires your own Atlassian OAuth app.");
-    println!("Create one at: https://developer.atlassian.com/console/myapps/\n");
+    eprintln!("OAuth 2.0 requires your own Atlassian OAuth app.");
+    eprintln!("Create one at: https://developer.atlassian.com/console/myapps/\n");
 
     let client_id: String = Input::new()
         .with_prompt("OAuth Client ID")

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -7,7 +7,7 @@ use crate::config::{
 use crate::{api, output};
 
 pub async fn handle() -> Result<()> {
-    println!("Setting up jr — Jira CLI\n");
+    eprintln!("Setting up jr — Jira CLI\n");
 
     // Step 1: Instance URL
     let url: String = Input::new()
@@ -66,7 +66,7 @@ pub async fn handle() -> Result<()> {
     if setup_project {
         let boards = client.list_boards(None, None).await?;
         if boards.is_empty() {
-            println!("No boards found. You can configure .jr.toml manually.");
+            eprintln!("No boards found. You can configure .jr.toml manually.");
         } else {
             let board_names: Vec<String> = boards
                 .iter()

--- a/src/cli/issue/create.rs
+++ b/src/cli/issue/create.rs
@@ -151,7 +151,7 @@ pub(super) async fn handle_create(
         }
         OutputFormat::Table => {
             output::print_success(&format!("Created issue {}", response.key));
-            println!("{}", browse_url);
+            eprintln!("{}", browse_url);
         }
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -43,7 +43,7 @@ pub fn print_output<T: Serialize>(
 }
 
 pub fn print_success(msg: &str) {
-    println!("{}", msg.green());
+    eprintln!("{}", msg.green());
 }
 
 pub fn print_error(msg: &str) {

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1380,3 +1380,35 @@ async fn test_send_warns_on_429_retry_exhaustion() {
         .stderr(predicate::str::contains("warning: rate limited by Jira"))
         .stderr(predicate::str::contains("3 retries"));
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_create_table_mode_outputs_to_stderr() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue"))
+        .respond_with(
+            ResponseTemplate::new(201)
+                .set_body_json(common::fixtures::create_issue_response("HDL-300")),
+        )
+        .mount(&server)
+        .await;
+
+    // Use jr_api_cmd (no --output json) to test Table mode
+    jr_api_cmd(&server.uri())
+        .args([
+            "issue",
+            "create",
+            "-p",
+            "HDL",
+            "-t",
+            "Task",
+            "-s",
+            "Table mode test",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("Created issue HDL-300"))
+        .stderr(predicate::str::contains("/browse/HDL-300"));
+}

--- a/tests/issue_commands.rs
+++ b/tests/issue_commands.rs
@@ -1214,14 +1214,13 @@ async fn test_move_by_transition_name() {
         .unwrap();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         output.status.success(),
         "Expected success, stderr: {stderr}"
     );
     assert!(
-        stdout.contains("Moved FOO-1"),
-        "Expected move confirmation in stdout: {stdout}"
+        stderr.contains("Moved FOO-1"),
+        "Expected move confirmation in stderr: {stderr}"
     );
 }
 
@@ -1274,14 +1273,13 @@ async fn test_move_by_status_name() {
         .unwrap();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         output.status.success(),
         "Expected success, stderr: {stderr}"
     );
     assert!(
-        stdout.contains("Moved FOO-1"),
-        "Expected move confirmation in stdout: {stdout}"
+        stderr.contains("Moved FOO-1"),
+        "Expected move confirmation in stderr: {stderr}"
     );
 }
 
@@ -1334,14 +1332,13 @@ async fn test_move_dedup_same_transition_and_status_name() {
         .unwrap();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         output.status.success(),
         "Expected success, stderr: {stderr}"
     );
     assert!(
-        stdout.contains("Moved FOO-1"),
-        "Expected move confirmation in stdout: {stdout}"
+        stderr.contains("Moved FOO-1"),
+        "Expected move confirmation in stderr: {stderr}"
     );
 }
 
@@ -1490,14 +1487,13 @@ async fn test_move_idempotent_with_status_name() {
         .unwrap();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         output.status.success(),
         "Expected success (idempotent), stderr: {stderr}"
     );
     assert!(
-        stdout.contains("already in status"),
-        "Expected idempotent message in stdout: {stdout}"
+        stderr.contains("already in status"),
+        "Expected idempotent message in stderr: {stderr}"
     );
 }
 
@@ -1546,14 +1542,13 @@ async fn test_move_idempotent_with_transition_name() {
         .unwrap();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         output.status.success(),
         "Expected success (idempotent via transition name), stderr: {stderr}"
     );
     assert!(
-        stdout.contains("already in status"),
-        "Expected idempotent message in stdout: {stdout}"
+        stderr.contains("already in status"),
+        "Expected idempotent message in stderr: {stderr}"
     );
 }
 

--- a/tests/sprint_commands.rs
+++ b/tests/sprint_commands.rs
@@ -254,10 +254,10 @@ async fn sprint_add_with_sprint_id() {
         "Expected success, got: {:?}",
         output
     );
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stdout.contains("Added 2 issue(s) to sprint 100"),
-        "Expected success message, got: {stdout}"
+        stderr.contains("Added 2 issue(s) to sprint 100"),
+        "Expected success message, got: {stderr}"
     );
 }
 
@@ -320,10 +320,10 @@ async fn sprint_remove_moves_to_backlog() {
         "Expected success, got: {:?}",
         output
     );
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stdout.contains("Moved 2 issue(s) to backlog"),
-        "Expected success message, got: {stdout}"
+        stderr.contains("Moved 2 issue(s) to backlog"),
+        "Expected success message, got: {stderr}"
     );
 }
 
@@ -386,9 +386,9 @@ async fn sprint_add_with_current_flag() {
         "Expected success, got: {:?}",
         output
     );
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stdout.contains("Added 2 issue(s) to sprint 100"),
-        "Expected success message, got: {stdout}"
+        stderr.contains("Added 2 issue(s) to sprint 100"),
+        "Expected success message, got: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary

- Changed `output::print_success` from `println!` to `eprintln!`, moving all ~20 write-command confirmation messages to stderr
- Moved browse URL in `issue create` Table mode to stderr (matching `gh` CLI convention)
- Moved standalone status messages in `auth.rs`, `init.rs`, and `api/auth.rs` (OAuth browser prompts) to stderr
- Added `test_create_table_mode_outputs_to_stderr` handler test verifying stdout is empty and stderr contains confirmations in Table mode
- Updated 8 existing tests in `issue_commands.rs` and `sprint_commands.rs` from stdout→stderr assertions

Closes #134

## Test plan
- [x] New handler test: Table-mode create emits confirmation + URL on stderr, stdout is empty
- [x] All existing handler tests pass (JSON-mode stdout assertions unaffected)
- [x] 5 issue_commands.rs tests updated and passing (move confirmations on stderr)
- [x] 3 sprint_commands.rs tests updated and passing (add/remove confirmations on stderr)
- [x] Full test suite: 581 tests, 0 failures
- [x] `cargo clippy -- -D warnings`: clean
- [x] `cargo fmt --all -- --check`: clean