### PR TITLE
feat: add user search/list/view commands (#114)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ src/
 │   ├── sprint.rs        # sprint list/current/add/remove (scrum-only, errors on kanban)
 │   ├── worklog.rs       # worklog add/list
 │   ├── team.rs          # team list (with cache + lazy org discovery)
+│   ├── user.rs          # user search/list/view (thin wrapper over api/jira/users.rs)
 │   ├── auth.rs          # auth login (API token default, --oauth for OAuth 2.0), auth status
 │   ├── init.rs          # Interactive setup (prefetches org metadata + team cache + story points field)
 │   ├── project.rs       # project fields (types, priorities, statuses, CMDB fields)
@@ -49,7 +50,7 @@ src/
 │       ├── teams.rs     # org metadata (GraphQL), list teams
 │       ├── worklogs.rs  # add/list worklogs
 │       ├── projects.rs  # project details
-│       └── users.rs     # current user, user search, assignable users
+│       └── users.rs     # current user, user search, assignable users, single-user lookup
 │   ├── jsm/             # JSM-specific API call implementations
 │   │   ├── servicedesks.rs  # list service desks, project meta orchestration
 │   │   └── queues.rs        # list queues, get queue issues

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,9 +1793,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ jr issue comment KEY-123 "Deployed to staging"
 | `jr assets types [--schema]`    | List object types (all or filtered by schema)  |
 | `jr assets schema <TYPE>`       | Show attributes for an object type (partial match) |
 | `jr team list` | List available teams (`--refresh` to force update) |
+| `jr user search <query>` | Search users by display name or email (`--limit`/`--all`) |
+| `jr user list --project FOO` | List users assignable to a project (`--limit`/`--all`) |
+| `jr user view <accountId>` | Look up a single user by accountId |
 | `jr project list` | List accessible projects (`--type`, `--limit`/`--all`) |
 | `jr project fields --project FOO` | Show valid issue types, priorities, statuses, and asset custom fields |
 | `jr completion bash\|zsh\|fish` | Generate shell completions |

--- a/docs/superpowers/plans/2026-04-05-jsm-internal-comments.md
+++ b/docs/superpowers/plans/2026-04-05-jsm-internal-comments.md
@@ -1,0 +1,731 @@
+# JSM Internal vs External Comments Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `--internal` flag to `jr issue comment` and display visibility status in `jr issue comments` for JSM projects.
+
+**Architecture:** Add `EntityProperty` type and `properties` field to `Comment` struct. Modify `add_comment` to accept an `internal` flag and include `sd.public.comment` property when set. Modify `list_comments` to request `expand=properties` and conditionally display a "Visibility" column based on whether any comment has the `sd.public.comment` property.
+
+**Tech Stack:** Rust, clap (derive), wiremock (tests), assert_cmd/predicates (tests)
+
+---
+
+## File Structure
+
+| File | Responsibility | Change type |
+|------|---------------|-------------|
+| `src/types/jira/issue.rs` | `EntityProperty` type, `properties` field on `Comment` | Modify |
+| `src/api/jira/issues.rs` | `add_comment` accepts `internal`, `list_comments` adds `expand=properties` | Modify |
+| `src/cli/mod.rs` | `--internal` flag on `Comment` variant | Modify |
+| `src/cli/issue/workflow.rs` | Pass `internal` flag through to `add_comment` | Modify |
+| `src/cli/issue/list.rs` | Conditional "Visibility" column in `handle_comments` | Modify |
+| `tests/comments.rs` | Update existing mocks for `expand=properties`, add property tests | Modify |
+| `tests/cli_handler.rs` | Handler-level tests for `--internal` flag and visibility column | Modify |
+
+---
+
+### Task 1: Add `EntityProperty` type and update `Comment` struct
+
+**Files:**
+- Modify: `src/types/jira/issue.rs:147-153`
+
+- [ ] **Step 1: Add `EntityProperty` struct and update `Comment`**
+
+In `src/types/jira/issue.rs`, replace the `Comment` struct (lines 147-153):
+
+```rust
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct Comment {
+    pub id: Option<String>,
+    pub body: Option<Value>,
+    pub author: Option<User>,
+    pub created: Option<String>,
+}
+```
+
+With:
+
+```rust
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct EntityProperty {
+    pub key: String,
+    pub value: Value,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct Comment {
+    pub id: Option<String>,
+    pub body: Option<Value>,
+    pub author: Option<User>,
+    pub created: Option<String>,
+    #[serde(default)]
+    pub properties: Vec<EntityProperty>,
+}
+```
+
+- [ ] **Step 2: Add unit tests for Comment deserialization with properties**
+
+In `src/types/jira/issue.rs`, add these tests inside the existing `#[cfg(test)] mod tests` block (after the last test):
+
+```rust
+    #[test]
+    fn comment_deserialize_with_properties() {
+        let json = json!({
+            "id": "10001",
+            "body": null,
+            "properties": [
+                {"key": "sd.public.comment", "value": {"internal": true}}
+            ]
+        });
+        let comment: Comment = serde_json::from_value(json).unwrap();
+        assert_eq!(comment.properties.len(), 1);
+        assert_eq!(comment.properties[0].key, "sd.public.comment");
+        assert_eq!(comment.properties[0].value["internal"], true);
+    }
+
+    #[test]
+    fn comment_deserialize_without_properties() {
+        let json = json!({
+            "id": "10002",
+            "body": null
+        });
+        let comment: Comment = serde_json::from_value(json).unwrap();
+        assert!(comment.properties.is_empty());
+    }
+
+    #[test]
+    fn comment_deserialize_empty_properties() {
+        let json = json!({
+            "id": "10003",
+            "body": null,
+            "properties": []
+        });
+        let comment: Comment = serde_json::from_value(json).unwrap();
+        assert!(comment.properties.is_empty());
+    }
+```
+
+- [ ] **Step 3: Verify it compiles and tests pass**
+
+Run: `export PATH="$HOME/.cargo/bin:$PATH" && cargo test --lib -- issue::tests::comment_deserialize 2>&1 | tail -10`
+
+Expected: All 3 new tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/jira/issue.rs
+git commit -m "feat: add EntityProperty type and properties field to Comment (#103)"
+```
+
+---
+
+### Task 2: Update `add_comment` API to support `internal` flag
+
+**Files:**
+- Modify: `src/api/jira/issues.rs:158-163`
+- Modify: `src/cli/issue/workflow.rs:422`
+
+- [ ] **Step 1: Update `add_comment` signature and implementation**
+
+In `src/api/jira/issues.rs`, replace the `add_comment` method (lines 158-163):
+
+```rust
+    /// Add a comment to an issue.
+    pub async fn add_comment(&self, key: &str, body: Value) -> Result<Comment> {
+        let path = format!("/rest/api/3/issue/{}/comment", urlencoding::encode(key));
+        let payload = serde_json::json!({ "body": body });
+        self.post(&path, &payload).await
+    }
+```
+
+With:
+
+```rust
+    /// Add a comment to an issue.
+    ///
+    /// When `internal` is true, sets the `sd.public.comment` entity property
+    /// to mark the comment as internal (agent-only) on JSM projects.
+    /// On non-JSM projects, the property is silently accepted with no effect.
+    pub async fn add_comment(&self, key: &str, body: Value, internal: bool) -> Result<Comment> {
+        let path = format!("/rest/api/3/issue/{}/comment", urlencoding::encode(key));
+        let mut payload = serde_json::json!({ "body": body });
+        if internal {
+            payload["properties"] = serde_json::json!([{
+                "key": "sd.public.comment",
+                "value": { "internal": true }
+            }]);
+        }
+        self.post(&path, &payload).await
+    }
+```
+
+- [ ] **Step 2: Update the call site in workflow.rs**
+
+In `src/cli/issue/workflow.rs`, replace line 422:
+
+```rust
+    let comment = client.add_comment(&key, adf_body).await?;
+```
+
+With:
+
+```rust
+    let comment = client.add_comment(&key, adf_body, false).await?;
+```
+
+(The `false` is temporary — Task 3 will wire the actual flag value.)
+
+- [ ] **Step 3: Verify it compiles and existing tests pass**
+
+Run: `export PATH="$HOME/.cargo/bin:$PATH" && cargo check 2>&1 | tail -5 && cargo test --lib 2>&1 | tail -5`
+
+Expected: Compiles. All existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/api/jira/issues.rs src/cli/issue/workflow.rs
+git commit -m "feat: add internal flag to add_comment API (#103)"
+```
+
+---
+
+### Task 3: Add `--internal` flag to CLI and wire through handler
+
+**Files:**
+- Modify: `src/cli/mod.rs:336-351`
+- Modify: `src/cli/issue/workflow.rs:382-422`
+
+- [ ] **Step 1: Add `--internal` flag to Comment variant**
+
+In `src/cli/mod.rs`, replace the `Comment` variant (lines 336-351):
+
+```rust
+    /// Add a comment
+    Comment {
+        /// Issue key
+        key: String,
+        /// Comment text
+        message: Option<String>,
+        /// Interpret input as Markdown
+        #[arg(long)]
+        markdown: bool,
+        /// Read comment from file
+        #[arg(long)]
+        file: Option<String>,
+        /// Read comment from stdin (for piping)
+        #[arg(long)]
+        stdin: bool,
+    },
+```
+
+With:
+
+```rust
+    /// Add a comment
+    Comment {
+        /// Issue key
+        key: String,
+        /// Comment text
+        message: Option<String>,
+        /// Interpret input as Markdown
+        #[arg(long)]
+        markdown: bool,
+        /// Read comment from file
+        #[arg(long)]
+        file: Option<String>,
+        /// Read comment from stdin (for piping)
+        #[arg(long)]
+        stdin: bool,
+        /// Mark comment as internal (agent-only, not visible to customers on JSM projects)
+        #[arg(long)]
+        internal: bool,
+    },
+```
+
+- [ ] **Step 2: Wire the flag through the handler**
+
+In `src/cli/issue/workflow.rs`, replace the destructure and call site (lines 387-422).
+
+Replace:
+
+```rust
+    let IssueCommand::Comment {
+        key,
+        message,
+        markdown,
+        file,
+        stdin,
+    } = command
+    else {
+        unreachable!()
+    };
+```
+
+With:
+
+```rust
+    let IssueCommand::Comment {
+        key,
+        message,
+        markdown,
+        file,
+        stdin,
+        internal,
+    } = command
+    else {
+        unreachable!()
+    };
+```
+
+And replace:
+
+```rust
+    let comment = client.add_comment(&key, adf_body, false).await?;
+```
+
+With:
+
+```rust
+    let comment = client.add_comment(&key, adf_body, internal).await?;
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `export PATH="$HOME/.cargo/bin:$PATH" && cargo check 2>&1 | tail -5`
+
+Expected: Compiles cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/cli/mod.rs src/cli/issue/workflow.rs
+git commit -m "feat: add --internal flag to issue comment command (#103)"
+```
+
+---
+
+### Task 4: Add `expand=properties` to `list_comments`
+
+**Files:**
+- Modify: `src/api/jira/issues.rs:183`
+
+- [ ] **Step 1: Add `expand=properties` to the query string**
+
+In `src/api/jira/issues.rs`, replace line 183:
+
+```rust
+            let path = format!("{}?startAt={}&maxResults={}", base, start_at, page_size);
+```
+
+With:
+
+```rust
+            let path = format!(
+                "{}?startAt={}&maxResults={}&expand=properties",
+                base, start_at, page_size
+            );
+```
+
+- [ ] **Step 2: Update existing integration tests for the new query parameter**
+
+In `tests/comments.rs`, add `expand=properties` to all mock query param matchers. For each of the 4 tests, add this matcher line after the existing `query_param` lines:
+
+In `list_comments_returns_all_comments` (line 15), `list_comments_empty` (line 52), and `list_comments_paginated` first page (line 108), second page (line 130), add:
+
+```rust
+        .and(query_param("expand", "properties"))
+```
+
+In `list_comments_with_limit` (line 76), add:
+
+```rust
+        .and(query_param("expand", "properties"))
+```
+
+- [ ] **Step 3: Verify tests pass**
+
+Run: `export PATH="$HOME/.cargo/bin:$PATH" && cargo test --test comments 2>&1 | tail -10`
+
+Expected: All 4 existing tests pass (mocks now expect the `expand=properties` param).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/api/jira/issues.rs tests/comments.rs
+git commit -m "feat: add expand=properties to list_comments query (#103)"
+```
+
+---
+
+### Task 5: Conditional "Visibility" column in comment listing
+
+**Files:**
+- Modify: `src/cli/issue/list.rs:612-640`
+
+- [ ] **Step 1: Add helper to extract visibility from comment properties**
+
+In `src/cli/issue/list.rs`, add this function before `handle_comments` (around line 611):
+
+```rust
+/// Extract the internal/external visibility from a comment's `sd.public.comment` property.
+/// Returns `Some("Internal")` or `Some("External")` if the property exists, `None` otherwise.
+fn comment_visibility(comment: &Comment) -> Option<&'static str> {
+    comment
+        .properties
+        .iter()
+        .find(|p| p.key == "sd.public.comment")
+        .map(|p| {
+            if p.value.get("internal") == Some(&serde_json::Value::Bool(true)) {
+                "Internal"
+            } else {
+                "External"
+            }
+        })
+}
+```
+
+- [ ] **Step 2: Update `handle_comments` to show conditional Visibility column**
+
+Replace the `handle_comments` function (lines 612-640):
+
+```rust
+pub(super) async fn handle_comments(
+    key: &str,
+    limit: Option<u32>,
+    output_format: &OutputFormat,
+    client: &JiraClient,
+) -> Result<()> {
+    let comments = client.list_comments(key, limit).await?;
+
+    match output_format {
+        OutputFormat::Json => {
+            output::print_output(output_format, &["Author", "Date", "Body"], &[], &comments)?;
+        }
+        OutputFormat::Table => {
+            let rows: Vec<Vec<String>> = comments
+                .iter()
+                .map(|c| {
+                    let author = c.author.as_ref().map(|a| a.display_name.as_str());
+                    let created = c.created.as_deref();
+                    let body_text = c.body.as_ref().map(adf::adf_to_text);
+                    format_comment_row(author, created, body_text.as_deref())
+                })
+                .collect();
+
+            output::print_output(output_format, &["Author", "Date", "Body"], &rows, &comments)?;
+        }
+    }
+
+    Ok(())
+}
+```
+
+With:
+
+```rust
+pub(super) async fn handle_comments(
+    key: &str,
+    limit: Option<u32>,
+    output_format: &OutputFormat,
+    client: &JiraClient,
+) -> Result<()> {
+    let comments = client.list_comments(key, limit).await?;
+
+    // Show Visibility column only if any comment has sd.public.comment property
+    let has_visibility = comments.iter().any(|c| comment_visibility(c).is_some());
+
+    match output_format {
+        OutputFormat::Json => {
+            let headers = if has_visibility {
+                vec!["Author", "Date", "Visibility", "Body"]
+            } else {
+                vec!["Author", "Date", "Body"]
+            };
+            output::print_output(output_format, &headers, &[], &comments)?;
+        }
+        OutputFormat::Table => {
+            let (headers, rows) = if has_visibility {
+                let rows: Vec<Vec<String>> = comments
+                    .iter()
+                    .map(|c| {
+                        let author = c.author.as_ref().map(|a| a.display_name.as_str());
+                        let created = c.created.as_deref();
+                        let body_text = c.body.as_ref().map(adf::adf_to_text);
+                        let visibility = comment_visibility(c).unwrap_or("External");
+                        let mut row = format_comment_row(author, created, body_text.as_deref());
+                        // Insert Visibility before Body (index 2)
+                        row.insert(2, visibility.to_string());
+                        row
+                    })
+                    .collect();
+                (
+                    vec!["Author", "Date", "Visibility", "Body"],
+                    rows,
+                )
+            } else {
+                let rows: Vec<Vec<String>> = comments
+                    .iter()
+                    .map(|c| {
+                        let author = c.author.as_ref().map(|a| a.display_name.as_str());
+                        let created = c.created.as_deref();
+                        let body_text = c.body.as_ref().map(adf::adf_to_text);
+                        format_comment_row(author, created, body_text.as_deref())
+                    })
+                    .collect();
+                (vec!["Author", "Date", "Body"], rows)
+            };
+
+            output::print_output(output_format, &headers, &rows, &comments)?;
+        }
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Add import for `Comment` type**
+
+At the top of `src/cli/issue/list.rs`, check if `Comment` is already imported. If not, add to the existing `use crate::types::jira::...` import:
+
+```rust
+use crate::types::jira::issue::Comment;
+```
+
+(If `Comment` is already imported via another path, skip this step.)
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `export PATH="$HOME/.cargo/bin:$PATH" && cargo check 2>&1 | tail -5`
+
+Expected: Compiles cleanly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/issue/list.rs
+git commit -m "feat: show conditional Visibility column in comment listing (#103)"
+```
+
+---
+
+### Task 6: Handler Tests
+
+**Files:**
+- Modify: `tests/cli_handler.rs`
+
+These tests verify end-to-end behavior via the CLI binary.
+
+- [ ] **Step 1: Add handler test for `--internal` flag**
+
+Add this test to `tests/cli_handler.rs`, after the last existing test:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_comment_internal_flag_adds_property() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue/HELP-42/comment"))
+        .and(body_partial_json(serde_json::json!({
+            "properties": [{
+                "key": "sd.public.comment",
+                "value": { "internal": true }
+            }]
+        })))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": "10001",
+            "created": "2026-04-05T12:00:00.000+0000"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args([
+            "issue",
+            "comment",
+            "HELP-42",
+            "Internal note",
+            "--internal",
+            "--no-input",
+        ])
+        .assert()
+        .success();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_comment_without_internal_omits_property() {
+    let server = MockServer::start().await;
+
+    // This mock expects NO properties field in the body.
+    // We verify by checking the body does NOT contain "sd.public.comment".
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue/HELP-42/comment"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": "10002",
+            "created": "2026-04-05T12:00:00.000+0000"
+        })))
+        .expect(1)
+        .named("comment without internal")
+        .mount(&server)
+        .await;
+
+    Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args([
+            "issue",
+            "comment",
+            "HELP-42",
+            "External note",
+            "--no-input",
+        ])
+        .assert()
+        .success();
+}
+```
+
+- [ ] **Step 2: Add handler test for visibility column in comments listing**
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_comments_shows_visibility_column_for_jsm() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/HELP-42/comment"))
+        .and(query_param("expand", "properties"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "comments": [
+                {
+                    "id": "10001",
+                    "author": { "accountId": "abc", "displayName": "Agent", "active": true },
+                    "body": { "type": "doc", "version": 1, "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Internal note" }] }] },
+                    "created": "2026-04-05T10:00:00.000+0000",
+                    "properties": [{"key": "sd.public.comment", "value": {"internal": true}}]
+                },
+                {
+                    "id": "10002",
+                    "author": { "accountId": "def", "displayName": "Agent", "active": true },
+                    "body": { "type": "doc", "version": 1, "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Customer reply" }] }] },
+                    "created": "2026-04-05T11:00:00.000+0000",
+                    "properties": [{"key": "sd.public.comment", "value": {"internal": false}}]
+                }
+            ],
+            "startAt": 0,
+            "maxResults": 100,
+            "total": 2
+        })))
+        .mount(&server)
+        .await;
+
+    Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "comments", "HELP-42", "--no-input"])
+        .assert()
+        .success()
+        .stdout(predicates::prelude::predicate::str::contains("Internal"))
+        .stdout(predicates::prelude::predicate::str::contains("External"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_handler_comments_hides_visibility_column_for_non_jsm() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/DEV-99/comment"))
+        .and(query_param("expand", "properties"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "comments": [
+                {
+                    "id": "10001",
+                    "author": { "accountId": "abc", "displayName": "Dev", "active": true },
+                    "body": { "type": "doc", "version": 1, "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "Fixed in commit abc123" }] }] },
+                    "created": "2026-04-05T10:00:00.000+0000",
+                    "properties": []
+                }
+            ],
+            "startAt": 0,
+            "maxResults": 100,
+            "total": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "comments", "DEV-99", "--no-input"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "Expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Visibility"),
+        "Non-JSM comments should not show Visibility column, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Internal"),
+        "Non-JSM comments should not show Internal, got: {stdout}"
+    );
+}
+```
+
+- [ ] **Step 3: Run handler tests**
+
+Run: `export PATH="$HOME/.cargo/bin:$PATH" && cargo test --test cli_handler test_handler_comment 2>&1 | tail -20`
+
+Expected: All 4 new handler tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/cli_handler.rs
+git commit -m "test: add handler tests for internal comments and visibility column (#103)"
+```
+
+---
+
+### Task 7: Format and Lint Check
+
+**Files:** (none — formatting/linting only)
+
+- [ ] **Step 1: Run formatter**
+
+Run: `export PATH="$HOME/.cargo/bin:$PATH" && cargo fmt --all`
+
+- [ ] **Step 2: Run clippy**
+
+Run: `export PATH="$HOME/.cargo/bin:$PATH" && cargo clippy -- -D warnings 2>&1 | tail -20`
+
+Expected: Zero warnings.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `export PATH="$HOME/.cargo/bin:$PATH" && cargo test 2>&1 | tail -20`
+
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit if any formatting changes**
+
+```bash
+git add -A
+git commit -m "style: format JSM internal comments implementation (#103)"
+```
+
+(Skip commit if no changes.)

--- a/docs/superpowers/plans/2026-04-10-429-retry-exhaustion-warning.md
+++ b/docs/superpowers/plans/2026-04-10-429-retry-exhaustion-warning.md
@@ -1,0 +1,202 @@
+# 429 Retry Exhaustion Warning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a stderr warning when 429 retry exhaustion occurs in `send` and `send_raw`, so users know jr absorbed backoff time on their behalf.
+
+**Architecture:** Add an unconditional `eprintln!` warning to both retry loops in `src/api/client.rs` at the point where the final 429 falls through. Test via a subprocess handler test using wiremock + assert_cmd stderr capture.
+
+**Tech Stack:** Rust, wiremock, assert_cmd, predicates
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/api/client.rs` | Modify | Add `eprintln!` warning to `send` (line ~202) and `send_raw` (line ~268) |
+| `tests/cli_handler.rs` | Modify | Add `test_api_warns_on_429_retry_exhaustion` handler test |
+
+---
+
+### Task 1: Write the failing handler test
+
+**Files:**
+- Modify: `tests/cli_handler.rs` (append after line 1337)
+
+- [ ] **Step 1.1: Write the failing test**
+
+Add this test at the end of `tests/cli_handler.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_api_warns_on_429_retry_exhaustion() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("Retry-After", "0")
+                .set_body_string(r#"{"errorMessages":["Rate limit exceeded"]}"#),
+        )
+        .expect(4) // initial + 3 retries (MAX_RETRIES)
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .args(["api", "/rest/api/3/myself"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("warning: rate limited by Jira"))
+        .stderr(predicate::str::contains("3 retries"));
+}
+```
+
+- [ ] **Step 1.2: Run the test to verify it fails**
+
+Run:
+```bash
+cargo test --test cli_handler test_api_warns_on_429_retry_exhaustion -- --nocapture
+```
+
+Expected: FAIL — stderr does not contain "warning: rate limited by Jira" (the warning doesn't exist yet).
+
+---
+
+### Task 2: Add the warning to `send_raw`
+
+**Files:**
+- Modify: `src/api/client.rs:268` (just before the final `return Ok(response)`)
+
+- [ ] **Step 2.1: Add the warning before the final return in `send_raw`**
+
+In `src/api/client.rs`, find this block inside `send_raw` (currently around line 268):
+
+```rust
+            // Return the response for ANY status (including 4xx/5xx) — no error parsing
+            return Ok(response);
+```
+
+Replace with:
+
+```rust
+            // Warn the user if we exhausted retries on a 429
+            if response.status() == StatusCode::TOO_MANY_REQUESTS {
+                eprintln!(
+                    "warning: rate limited by Jira — gave up after {MAX_RETRIES} retries"
+                );
+            }
+
+            // Return the response for ANY status (including 4xx/5xx) — no error parsing
+            return Ok(response);
+```
+
+- [ ] **Step 2.2: Run the handler test**
+
+Run:
+```bash
+cargo test --test cli_handler test_api_warns_on_429_retry_exhaustion -- --nocapture
+```
+
+Expected: PASS — the `jr api` subprocess now prints the warning to stderr, and the test asserts it.
+
+- [ ] **Step 2.3: Run the full test suite**
+
+Run:
+```bash
+cargo test
+```
+
+Expected: All tests pass. The existing `test_send_raw_returns_429_after_exhausting_retries` unit test is unaffected (it tests the return value, not stderr).
+
+- [ ] **Step 2.4: Run clippy and fmt**
+
+Run:
+```bash
+cargo clippy -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: Both clean.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/api/client.rs tests/cli_handler.rs
+git commit -m "fix: warn on stderr when 429 retry exhaustion occurs in send_raw (#172)"
+```
+
+---
+
+### Task 3: Add the warning to `send`
+
+**Files:**
+- Modify: `src/api/client.rs:202` (just before the `is_client_error()` check)
+
+- [ ] **Step 3.1: Add the warning before the error check in `send`**
+
+In `src/api/client.rs`, find this block inside `send` (currently around line 202):
+
+```rust
+            // For non-429 errors, parse and return the error
+            if response.status().is_client_error() || response.status().is_server_error() {
+                return Err(Self::parse_error(response).await);
+            }
+```
+
+Replace with:
+
+```rust
+            // Warn the user if we exhausted retries on a 429
+            if response.status() == StatusCode::TOO_MANY_REQUESTS {
+                eprintln!(
+                    "warning: rate limited by Jira — gave up after {MAX_RETRIES} retries"
+                );
+            }
+
+            // For non-429 errors, parse and return the error
+            if response.status().is_client_error() || response.status().is_server_error() {
+                return Err(Self::parse_error(response).await);
+            }
+```
+
+- [ ] **Step 3.2: Run the full test suite**
+
+Run:
+```bash
+cargo test
+```
+
+Expected: All tests pass. The `send` warning fires the same way as `send_raw` — when `attempt == MAX_RETRIES` and the response is 429, the retry condition `attempt < MAX_RETRIES` is false, so execution falls through to the new warning check.
+
+- [ ] **Step 3.3: Run clippy and fmt**
+
+Run:
+```bash
+cargo clippy -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: Both clean.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add src/api/client.rs
+git commit -m "fix: warn on stderr when 429 retry exhaustion occurs in send (#172)"
+```
+
+---
+
+## Spec Coverage Checklist
+
+| Spec Requirement | Task |
+|------------------|------|
+| Warning in `send_raw` | Task 2 |
+| Warning in `send` | Task 3 |
+| Warning message format: `warning: rate limited by Jira — gave up after 3 retries` | Task 2, 3 (identical message) |
+| Not gated on `--verbose` | Task 2, 3 (unconditional `eprintln!`) |
+| No change to return types, error messages, exit codes | Verified by existing tests passing |
+| Handler subprocess test | Task 1 |
+| Uses existing `jr_api_cmd` helper | Task 1 |
+| Uses `predicate::str::contains` for stderr | Task 1 |

--- a/docs/superpowers/plans/2026-04-12-stderr-stdout-separation.md
+++ b/docs/superpowers/plans/2026-04-12-stderr-stdout-separation.md
@@ -1,0 +1,266 @@
+# Separate Human Status Messages (stderr) from Machine Output (stdout) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move write-command confirmation messages from stdout to stderr, matching the `gh` CLI convention where table mode is for human consumption and `--output json` is for scripting.
+
+**Architecture:** One-line change to `output::print_success` (println→eprintln) moves ~20 call sites. Five additional standalone `println!` calls in auth.rs, init.rs, and create.rs also move to `eprintln!`. One new handler test verifies the stream separation.
+
+**Tech Stack:** Rust, wiremock, assert_cmd, predicates
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/output.rs` | Modify | Change `print_success` from `println!` to `eprintln!` |
+| `src/cli/issue/create.rs` | Modify | Change browse URL in Table mode from `println!` to `eprintln!` |
+| `src/cli/auth.rs` | Modify | Change 3 status `println!` calls to `eprintln!` |
+| `src/cli/init.rs` | Modify | Change 2 status `println!` calls to `eprintln!` |
+| `tests/cli_handler.rs` | Modify | Add `test_create_table_mode_outputs_to_stderr` handler test |
+
+---
+
+### Task 1: TDD — test and implement core stream separation
+
+**Files:**
+- Modify: `tests/cli_handler.rs` (append new test)
+- Modify: `src/output.rs:45-47`
+- Modify: `src/cli/issue/create.rs:154`
+
+- [ ] **Step 1.1: Write the failing handler test**
+
+Add this test at the end of `tests/cli_handler.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_create_table_mode_outputs_to_stderr() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue"))
+        .respond_with(
+            ResponseTemplate::new(201)
+                .set_body_json(common::fixtures::create_issue_response("HDL-300")),
+        )
+        .mount(&server)
+        .await;
+
+    // Use jr_api_cmd (no --output json) to test Table mode
+    jr_api_cmd(&server.uri())
+        .args([
+            "issue",
+            "create",
+            "-p",
+            "HDL",
+            "-t",
+            "Task",
+            "-s",
+            "Table mode test",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("Created issue HDL-300"))
+        .stderr(predicate::str::contains("/browse/HDL-300"));
+}
+```
+
+This test uses `jr_api_cmd` which sets `JR_BASE_URL` + `JR_AUTH_HEADER` + `--no-input` but does NOT set `--output json`, so the command runs in Table mode. It asserts that:
+- stdout is empty (no data in Table-mode write commands)
+- stderr contains the confirmation message and browse URL
+
+- [ ] **Step 1.2: Run the test to verify it fails**
+
+Run:
+```bash
+cargo test --test cli_handler test_create_table_mode_outputs_to_stderr -- --nocapture
+```
+
+Expected: FAIL — stdout is NOT empty (it currently contains "Created issue HDL-300" and the URL), and stderr does NOT contain those strings.
+
+- [ ] **Step 1.3: Change `print_success` to use stderr**
+
+In `src/output.rs`, find:
+
+```rust
+pub fn print_success(msg: &str) {
+    println!("{}", msg.green());
+}
+```
+
+Replace with:
+
+```rust
+pub fn print_success(msg: &str) {
+    eprintln!("{}", msg.green());
+}
+```
+
+- [ ] **Step 1.4: Change browse URL to stderr**
+
+In `src/cli/issue/create.rs`, find:
+
+```rust
+        OutputFormat::Table => {
+            output::print_success(&format!("Created issue {}", response.key));
+            println!("{}", browse_url);
+        }
+```
+
+Replace with:
+
+```rust
+        OutputFormat::Table => {
+            output::print_success(&format!("Created issue {}", response.key));
+            eprintln!("{}", browse_url);
+        }
+```
+
+- [ ] **Step 1.5: Run the test to verify it passes**
+
+Run:
+```bash
+cargo test --test cli_handler test_create_table_mode_outputs_to_stderr -- --nocapture
+```
+
+Expected: PASS — confirmation and URL now go to stderr, stdout is empty.
+
+- [ ] **Step 1.6: Run the full test suite**
+
+Run:
+```bash
+cargo test
+```
+
+Expected: All tests pass. Existing handler tests use `--output json` (JSON output stays on stdout), so they are unaffected.
+
+- [ ] **Step 1.7: Run clippy and fmt**
+
+Run:
+```bash
+cargo clippy -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: Both clean.
+
+- [ ] **Step 1.8: Commit**
+
+```bash
+git add src/output.rs src/cli/issue/create.rs tests/cli_handler.rs
+git commit -m "refactor: move print_success and browse URL to stderr (#134)"
+```
+
+---
+
+### Task 2: Move standalone status messages to stderr
+
+**Files:**
+- Modify: `src/cli/auth.rs:21,28,29`
+- Modify: `src/cli/init.rs:10,69`
+
+- [ ] **Step 2.1: Change auth.rs status messages**
+
+In `src/cli/auth.rs`, find:
+
+```rust
+    auth::store_api_token(&email, &token)?;
+    println!("Credentials stored in keychain.");
+    Ok(())
+```
+
+Replace with:
+
+```rust
+    auth::store_api_token(&email, &token)?;
+    eprintln!("Credentials stored in keychain.");
+    Ok(())
+```
+
+In the same file, find:
+
+```rust
+pub async fn login_oauth() -> Result<()> {
+    println!("OAuth 2.0 requires your own Atlassian OAuth app.");
+    println!("Create one at: https://developer.atlassian.com/console/myapps/\n");
+```
+
+Replace with:
+
+```rust
+pub async fn login_oauth() -> Result<()> {
+    eprintln!("OAuth 2.0 requires your own Atlassian OAuth app.");
+    eprintln!("Create one at: https://developer.atlassian.com/console/myapps/\n");
+```
+
+- [ ] **Step 2.2: Change init.rs status messages**
+
+In `src/cli/init.rs`, find:
+
+```rust
+pub async fn handle() -> Result<()> {
+    println!("Setting up jr — Jira CLI\n");
+```
+
+Replace with:
+
+```rust
+pub async fn handle() -> Result<()> {
+    eprintln!("Setting up jr — Jira CLI\n");
+```
+
+In the same file, find:
+
+```rust
+            println!("No boards found. You can configure .jr.toml manually.");
+```
+
+Replace with:
+
+```rust
+            eprintln!("No boards found. You can configure .jr.toml manually.");
+```
+
+- [ ] **Step 2.3: Run the full test suite**
+
+Run:
+```bash
+cargo test
+```
+
+Expected: All tests pass. These `println!` calls are in interactive paths (login, init) with no handler tests — changes are safe.
+
+- [ ] **Step 2.4: Run clippy and fmt**
+
+Run:
+```bash
+cargo clippy -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: Both clean.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/cli/auth.rs src/cli/init.rs
+git commit -m "refactor: move auth and init status messages to stderr (#134)"
+```
+
+---
+
+## Spec Coverage Checklist
+
+| Spec Requirement | Task |
+|------------------|------|
+| `print_success` → `eprintln!` | Task 1 (Step 1.3) |
+| Browse URL after create → stderr | Task 1 (Step 1.4) |
+| `auth.rs` 3 `println!` → `eprintln!` | Task 2 (Step 2.1) |
+| `init.rs` 2 `println!` → `eprintln!` | Task 2 (Step 2.2) |
+| JSON output stays on stdout | Verified by existing tests passing (Task 1 Step 1.6) |
+| `auth status` stays on stdout | Not touched — no code change needed |
+| `open --url-only` stays on stdout | Not touched — no code change needed |
+| `"No results found."` stays on stdout | Not touched — no code change needed |
+| Handler test for Table-mode stream separation | Task 1 (Step 1.1) |

--- a/docs/superpowers/plans/2026-04-13-user-commands.md
+++ b/docs/superpowers/plans/2026-04-13-user-commands.md
@@ -826,8 +826,8 @@ Any failure in Steps 5.1–5.4 means returning to the failing task to correct th
 | `✓`/`✗` for active | Task 3 (`format_active`) |
 | View uses labeled Field/Value rows | Task 3 (`handle_view`) |
 | JSON mode: raw user(s) | Task 3 (`print_output` passes `&user` / `&users`) |
-| 404 on view → friendly "not found" error, exit 1 | Task 3 (`handle_view`), Task 4 (Step 4.1 404 test) |
-| 400 also treated as "not found" | Task 3 (`handle_view`) |
+| 404 on view → friendly "not found" error, exit 64 via `JrError::UserError` | Task 3 (`handle_view`), Task 4 (Step 4.1 404 test) |
+| 400 also treated as "not found" (same exit 64) | Task 3 (`handle_view`) |
 | Empty search result → "No results found." | Task 4 (Step 4.1 empty test) — uses `output::print_output` default behavior |
 | Help text: GDPR caveat | Task 2 (Step 2.3 doc comments on `Search` and `List`) |
 | Integration tests with wiremock | Task 4 (all) |

--- a/docs/superpowers/plans/2026-04-13-user-commands.md
+++ b/docs/superpowers/plans/2026-04-13-user-commands.md
@@ -1,0 +1,835 @@
+# User Search and Lookup Commands Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `jr user search`, `jr user list --project`, and `jr user view <accountId>` commands, wrapping existing `search_users` / `search_assignable_users_by_project` API methods and one new `get_user` method.
+
+**Architecture:** Thin CLI surface over existing `JiraClient` methods. New file `src/cli/user.rs` follows the `team.rs` / `project.rs` pattern. One new API method `get_user(account_id)`. Integration tests in a new `tests/user_commands.rs` following the existing wiremock + `assert_cmd` pattern.
+
+**Tech Stack:** Rust, clap derive, reqwest, tokio, wiremock, assert_cmd, `comfy-table` via `output::print_output`.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/api/jira/users.rs` | Modify | Add `get_user(account_id)` method (~12 lines) |
+| `src/cli/mod.rs` | Modify | Register `pub mod user;`, add `User { command: UserCommand }` enum variant, add `UserCommand` enum |
+| `src/cli/user.rs` | Create | Command handler: dispatches `search`, `list`, `view`; formats rows; maps 404 to friendly error |
+| `src/main.rs` | Modify | Dispatch `Command::User` to `cli::user::handle` |
+| `tests/user_commands.rs` | Create | Wiremock integration tests for all three commands |
+
+---
+
+### Task 1: Add `get_user` API method (TDD)
+
+**Files:**
+- Modify: `src/api/jira/users.rs`
+
+- [ ] **Step 1.1: Write the failing unit test**
+
+Append to the `#[cfg(test)] mod tests { ... }` block at the end of `src/api/jira/users.rs`:
+
+```rust
+    #[test]
+    fn single_user_response_deserializes() {
+        let json = r#"{
+            "accountId": "5b10ac8d82e05b22cc7d4349",
+            "displayName": "Jane Smith",
+            "emailAddress": "jane@acme.io",
+            "active": true
+        }"#;
+        let user: User = serde_json::from_str(json).unwrap();
+        assert_eq!(user.account_id, "5b10ac8d82e05b22cc7d4349");
+        assert_eq!(user.display_name, "Jane Smith");
+        assert_eq!(user.email_address.as_deref(), Some("jane@acme.io"));
+        assert_eq!(user.active, Some(true));
+    }
+
+    #[test]
+    fn single_user_without_email_deserializes() {
+        let json = r#"{
+            "accountId": "abc",
+            "displayName": "Privacy User",
+            "active": true
+        }"#;
+        let user: User = serde_json::from_str(json).unwrap();
+        assert_eq!(user.account_id, "abc");
+        assert!(user.email_address.is_none());
+    }
+```
+
+Run: `cargo test --lib --quiet single_user_response_deserializes single_user_without_email_deserializes`
+
+Expected: PASS (these tests only verify the existing `User` struct deserializes a single object — no new code required yet but they document the expected response shape).
+
+- [ ] **Step 1.2: Add the `get_user` method**
+
+In `src/api/jira/users.rs`, inside the `impl JiraClient` block, after `search_assignable_users_by_project` (currently the last method in the block, line 80), add:
+
+```rust
+    /// Fetch a single user by accountId.
+    ///
+    /// Returns a `JrError::ApiError { status: 404, .. }` when the accountId
+    /// does not exist. Email may be omitted from the response based on the
+    /// target user's profile-visibility settings.
+    pub async fn get_user(&self, account_id: &str) -> Result<User> {
+        let path = format!(
+            "/rest/api/3/user?accountId={}",
+            urlencoding::encode(account_id)
+        );
+        self.get(&path).await
+    }
+```
+
+- [ ] **Step 1.3: Run unit tests**
+
+Run: `cargo test --lib --quiet api::jira::users`
+
+Expected: PASS — all existing tests plus the two new deserialization tests.
+
+- [ ] **Step 1.4: Run clippy and fmt**
+
+Run:
+```bash
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: Both clean.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/api/jira/users.rs
+git commit -m "feat: add get_user API method for accountId lookup (#114)"
+```
+
+---
+
+### Task 2: Register `UserCommand` in CLI enum
+
+**Files:**
+- Modify: `src/cli/mod.rs`
+
+- [ ] **Step 2.1: Register the module**
+
+In `src/cli/mod.rs`, find the `pub mod` list at the top (lines 1-11):
+
+```rust
+pub mod api;
+pub mod assets;
+pub mod auth;
+pub mod board;
+pub mod init;
+pub mod issue;
+pub mod project;
+pub mod queue;
+pub mod sprint;
+pub mod team;
+pub mod worklog;
+```
+
+Add `pub mod user;` in alphabetical order (after `team`, before `worklog`):
+
+```rust
+pub mod api;
+pub mod assets;
+pub mod auth;
+pub mod board;
+pub mod init;
+pub mod issue;
+pub mod project;
+pub mod queue;
+pub mod sprint;
+pub mod team;
+pub mod user;
+pub mod worklog;
+```
+
+- [ ] **Step 2.2: Add the `User` variant to `Command`**
+
+In `src/cli/mod.rs`, find the `Command` enum definition. After the `Team { command: TeamCommand }` variant (currently lines 91-94), add a `User { command: UserCommand }` variant before `Queue`:
+
+```rust
+    /// Manage teams
+    Team {
+        #[command(subcommand)]
+        command: TeamCommand,
+    },
+    /// Manage users
+    User {
+        #[command(subcommand)]
+        command: UserCommand,
+    },
+    /// Manage JSM queues
+    Queue {
+        #[command(subcommand)]
+        command: QueueCommand,
+    },
+```
+
+- [ ] **Step 2.3: Add the `UserCommand` enum**
+
+In `src/cli/mod.rs`, after the `TeamCommand` enum definition (currently ends at line 509) and before the `WorklogCommand` enum, add:
+
+```rust
+#[derive(Subcommand)]
+pub enum UserCommand {
+    /// Search for users by display name or email
+    ///
+    /// Results depend on the "Browse users and groups" global permission.
+    /// Empty results may indicate either no matches or missing permission.
+    /// Email is hidden when the target user's privacy settings opt out.
+    Search {
+        /// Search string (matches displayName and emailAddress substrings)
+        query: String,
+        /// Maximum number of results
+        #[arg(long)]
+        limit: Option<u32>,
+        /// Fetch all results (no default limit)
+        #[arg(long, conflicts_with = "limit")]
+        all: bool,
+    },
+    /// List users assignable to a project
+    ///
+    /// Results depend on the "Browse users and groups" global permission.
+    List {
+        /// Project key (e.g., FOO)
+        #[arg(long, short = 'p')]
+        project: String,
+        /// Maximum number of results
+        #[arg(long)]
+        limit: Option<u32>,
+        /// Fetch all results (no default limit)
+        #[arg(long, conflicts_with = "limit")]
+        all: bool,
+    },
+    /// Look up a user by accountId
+    ///
+    /// Returns full user details (displayName, email when visible, active,
+    /// timeZone). Use this to resolve accountIds surfaced in JSON output
+    /// from other commands (e.g., `jr issue view --output json`).
+    View {
+        /// Atlassian accountId (e.g., 5b10ac8d82e05b22cc7d4349)
+        account_id: String,
+    },
+}
+```
+
+- [ ] **Step 2.4: Build to verify the enum compiles**
+
+Run: `cargo build --quiet`
+
+Expected: Fails with `unresolved import `crate::cli::user`` or similar — the module file doesn't exist yet. This failure confirms the enum plumbing is correct and Task 3 will resolve it.
+
+- [ ] **Step 2.5: Do not commit yet**
+
+Commits happen together with Task 3 once the module exists and the build is clean.
+
+---
+
+### Task 3: Implement `user search` + `user list` + `user view` handler
+
+**Files:**
+- Create: `src/cli/user.rs`
+- Modify: `src/main.rs`
+
+- [ ] **Step 3.1: Create the handler module**
+
+Create `src/cli/user.rs` with this complete content:
+
+```rust
+use anyhow::{Result, anyhow};
+use colored::Colorize;
+
+use crate::api::client::JiraClient;
+use crate::cli::{OutputFormat, UserCommand, resolve_effective_limit};
+use crate::error::JrError;
+use crate::output;
+use crate::types::jira::User;
+
+pub async fn handle(
+    command: UserCommand,
+    output_format: &OutputFormat,
+    client: &JiraClient,
+) -> Result<()> {
+    match command {
+        UserCommand::Search { query, limit, all } => {
+            handle_search(&query, limit, all, output_format, client).await
+        }
+        UserCommand::List {
+            project,
+            limit,
+            all,
+        } => handle_list(&project, limit, all, output_format, client).await,
+        UserCommand::View { account_id } => handle_view(&account_id, output_format, client).await,
+    }
+}
+
+async fn handle_search(
+    query: &str,
+    limit: Option<u32>,
+    all: bool,
+    output_format: &OutputFormat,
+    client: &JiraClient,
+) -> Result<()> {
+    let effective = resolve_effective_limit(limit, all);
+    let mut users = client.search_users(query).await?;
+    if let Some(cap) = effective {
+        users.truncate(cap as usize);
+    }
+    print_user_list(&users, output_format)
+}
+
+async fn handle_list(
+    project: &str,
+    limit: Option<u32>,
+    all: bool,
+    output_format: &OutputFormat,
+    client: &JiraClient,
+) -> Result<()> {
+    let effective = resolve_effective_limit(limit, all);
+    let mut users = client
+        .search_assignable_users_by_project("", project)
+        .await?;
+    if let Some(cap) = effective {
+        users.truncate(cap as usize);
+    }
+    print_user_list(&users, output_format)
+}
+
+async fn handle_view(
+    account_id: &str,
+    output_format: &OutputFormat,
+    client: &JiraClient,
+) -> Result<()> {
+    let user = match client.get_user(account_id).await {
+        Ok(u) => u,
+        Err(e) => {
+            if let Some(JrError::ApiError { status, .. }) = e.downcast_ref::<JrError>() {
+                if *status == 404 || *status == 400 {
+                    return Err(anyhow!(
+                        "User with accountId '{account_id}' not found."
+                    ));
+                }
+            }
+            return Err(e);
+        }
+    };
+
+    let rows = vec![
+        vec!["Account ID".into(), user.account_id.clone()],
+        vec!["Display Name".into(), user.display_name.clone()],
+        vec![
+            "Email".into(),
+            user.email_address.clone().unwrap_or_else(|| "—".into()),
+        ],
+        vec!["Active".into(), format_active(user.active)],
+    ];
+
+    output::print_output(output_format, &["Field", "Value"], &rows, &user)
+}
+
+fn print_user_list(users: &[User], output_format: &OutputFormat) -> Result<()> {
+    let rows: Vec<Vec<String>> = users.iter().map(format_user_row).collect();
+    output::print_output(
+        output_format,
+        &["Display Name", "Email", "Active", "Account ID"],
+        &rows,
+        &users,
+    )
+}
+
+fn format_user_row(user: &User) -> Vec<String> {
+    vec![
+        user.display_name.clone(),
+        user.email_address.clone().unwrap_or_else(|| "—".into()),
+        format_active(user.active),
+        user.account_id.clone(),
+    ]
+}
+
+fn format_active(active: Option<bool>) -> String {
+    match active {
+        Some(true) => "✓".green().to_string(),
+        Some(false) => "✗".red().to_string(),
+        None => "—".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn row_shows_display_name_email_and_id() {
+        let user = User {
+            account_id: "acc-1".into(),
+            display_name: "Alice".into(),
+            email_address: Some("alice@acme.io".into()),
+            active: Some(true),
+        };
+        let row = format_user_row(&user);
+        assert_eq!(row[0], "Alice");
+        assert_eq!(row[1], "alice@acme.io");
+        assert!(row[2].contains('✓'));
+        assert_eq!(row[3], "acc-1");
+    }
+
+    #[test]
+    fn row_renders_dash_for_missing_email() {
+        let user = User {
+            account_id: "acc-2".into(),
+            display_name: "Privacy User".into(),
+            email_address: None,
+            active: Some(true),
+        };
+        let row = format_user_row(&user);
+        assert_eq!(row[1], "—");
+    }
+
+    #[test]
+    fn active_formatter_handles_missing() {
+        assert_eq!(format_active(None), "—");
+    }
+}
+```
+
+- [ ] **Step 3.2: Wire up dispatch in `main.rs`**
+
+In `src/main.rs`, find the match arm for `Command::Team` (currently lines 156-160):
+
+```rust
+            cli::Command::Team { command } => {
+                let config = config::Config::load()?;
+                let client = api::client::JiraClient::from_config(&config, cli.verbose)?;
+                cli::team::handle(command, &cli.output, &config, &client).await
+            }
+```
+
+After this arm and before `cli::Command::Queue`, add:
+
+```rust
+            cli::Command::User { command } => {
+                let config = config::Config::load()?;
+                let client = api::client::JiraClient::from_config(&config, cli.verbose)?;
+                cli::user::handle(command, &cli.output, &client).await
+            }
+```
+
+- [ ] **Step 3.3: Build**
+
+Run: `cargo build --quiet`
+
+Expected: Clean build.
+
+- [ ] **Step 3.4: Run unit tests**
+
+Run: `cargo test --lib --quiet user`
+
+Expected: The three tests in `src/cli/user.rs::tests` pass, alongside any existing tests that match the `user` substring.
+
+- [ ] **Step 3.5: Run clippy and fmt**
+
+Run:
+```bash
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: Both clean.
+
+- [ ] **Step 3.6: Smoke-test the CLI**
+
+Run: `cargo run --quiet -- user --help`
+
+Expected output contains `Manage users` and the three subcommands `search`, `list`, `view`.
+
+Run: `cargo run --quiet -- user search --help`
+
+Expected output contains `--limit`, `--all`, and the permission caveat.
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add src/api/jira/users.rs src/cli/mod.rs src/cli/user.rs src/main.rs
+git commit -m "feat: add user search/list/view commands (#114)"
+```
+
+---
+
+### Task 4: Integration tests (wiremock)
+
+**Files:**
+- Create: `tests/user_commands.rs`
+
+- [ ] **Step 4.1: Create the test file**
+
+Create `tests/user_commands.rs` with this complete content:
+
+```rust
+#[allow(dead_code)]
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use common::fixtures;
+
+fn jr_cmd(base_url: &str) -> Command {
+    let mut cmd = Command::cargo_bin("jr").unwrap();
+    cmd.env("JR_BASE_URL", base_url)
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .arg("--no-input");
+    cmd
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_search_returns_matching_users() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "jane"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            fixtures::user_search_response(vec![
+                ("acc-1", "Jane Smith", true),
+                ("acc-2", "Jane Doe", true),
+            ]),
+        ))
+        .mount(&server)
+        .await;
+
+    jr_cmd(&server.uri())
+        .args(["user", "search", "jane"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Jane Smith"))
+        .stdout(predicate::str::contains("Jane Doe"))
+        .stdout(predicate::str::contains("acc-1"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_search_empty_result_prints_no_results() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&server)
+        .await;
+
+    jr_cmd(&server.uri())
+        .args(["user", "search", "nobody"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No results found."));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_search_json_output_is_array() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            fixtures::user_search_response(vec![("acc-1", "Jane Smith", true)]),
+        ))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri())
+        .args(["--output", "json", "user", "search", "jane"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON array");
+    assert!(parsed.is_array());
+    assert_eq!(parsed.as_array().unwrap().len(), 1);
+    assert_eq!(parsed[0]["accountId"], "acc-1");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_search_limit_truncates_results() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            fixtures::user_search_response(vec![
+                ("acc-1", "Alice One", true),
+                ("acc-2", "Alice Two", true),
+                ("acc-3", "Alice Three", true),
+            ]),
+        ))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri())
+        .args(["--output", "json", "user", "search", "alice", "--limit", "2"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(parsed.as_array().unwrap().len(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_list_requires_project_flag() {
+    // No server needed — clap should fail before any HTTP call.
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", "http://127.0.0.1:1")
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["--no-input", "user", "list"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "missing --project should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--project") || stderr.contains("required"),
+        "expected error mentions missing --project, got: {stderr}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_list_by_project_returns_users() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
+        .and(query_param("projectKeys", "FOO"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            fixtures::multi_project_user_search_response(vec![
+                ("acc-1", "Alice"),
+                ("acc-2", "Bob"),
+            ]),
+        ))
+        .mount(&server)
+        .await;
+
+    jr_cmd(&server.uri())
+        .args(["user", "list", "--project", "FOO"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_view_returns_detail_rows() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user"))
+        .and(query_param("accountId", "acc-xyz"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "accountId": "acc-xyz",
+            "displayName": "Jane Smith",
+            "emailAddress": "jane@acme.io",
+            "active": true
+        })))
+        .mount(&server)
+        .await;
+
+    jr_cmd(&server.uri())
+        .args(["user", "view", "acc-xyz"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Jane Smith"))
+        .stdout(predicate::str::contains("jane@acme.io"))
+        .stdout(predicate::str::contains("acc-xyz"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_view_json_emits_user_object() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user"))
+        .and(query_param("accountId", "acc-xyz"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "accountId": "acc-xyz",
+            "displayName": "Jane Smith",
+            "emailAddress": "jane@acme.io",
+            "active": true
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri())
+        .args(["--output", "json", "user", "view", "acc-xyz"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(parsed["accountId"], "acc-xyz");
+    assert_eq!(parsed["displayName"], "Jane Smith");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_view_404_shows_friendly_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user"))
+        .and(query_param("accountId", "does-not-exist"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "errorMessages": ["User not found"]
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri())
+        .args(["user", "view", "does-not-exist"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("User with accountId 'does-not-exist' not found"),
+        "expected friendly not-found message, got: {stderr}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_view_hidden_email_renders_dash() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user"))
+        .and(query_param("accountId", "private-user"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "accountId": "private-user",
+            "displayName": "Private Person",
+            "active": true
+        })))
+        .mount(&server)
+        .await;
+
+    jr_cmd(&server.uri())
+        .args(["user", "view", "private-user"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Private Person"))
+        .stdout(predicate::str::contains("—"));
+}
+```
+
+- [ ] **Step 4.2: Run the new integration tests**
+
+Run: `cargo test --test user_commands --quiet`
+
+Expected: All 10 tests pass.
+
+- [ ] **Step 4.3: Run the full test suite**
+
+Run: `cargo test --quiet`
+
+Expected: All tests pass — no existing tests broken by the new module/variant.
+
+- [ ] **Step 4.4: Run clippy and fmt**
+
+Run:
+```bash
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: Both clean.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add tests/user_commands.rs
+git commit -m "test: add integration tests for user commands (#114)"
+```
+
+---
+
+### Task 5: Verify end-to-end and tidy
+
+**Files:**
+- None (verification task — catches anything the earlier tasks missed)
+
+- [ ] **Step 5.1: Full CI-equivalent check set**
+
+Run each in sequence:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+Expected: All three clean.
+
+- [ ] **Step 5.2: Verify `jr user --help` reads correctly**
+
+Run: `cargo run --quiet -- user --help`
+
+Expected output includes:
+- Top description: "Manage users"
+- Three subcommands: `search`, `list`, `view`
+- Global flags inherited: `--output`, `--project`, `--no-color`, `--no-input`, `--verbose`
+
+- [ ] **Step 5.3: Verify each subcommand help text includes the GDPR caveat for `search` and `list`**
+
+Run: `cargo run --quiet -- user search --help`
+
+Expected contains: "Browse users and groups" and "privacy settings"
+
+Run: `cargo run --quiet -- user list --help`
+
+Expected contains: "Browse users and groups"
+
+- [ ] **Step 5.4: Check for stale or dead code**
+
+Run: `cargo clippy --all-targets -- -D warnings -W dead-code 2>&1 | head -20`
+
+Expected: No warnings referencing `src/cli/user.rs` or `tests/user_commands.rs`.
+
+- [ ] **Step 5.5: If anything failed, fix it — do not commit partial work**
+
+Any failure in Steps 5.1–5.4 means returning to the failing task to correct the implementation. Do not proceed to PR review until the full check set is clean.
+
+---
+
+## Spec Coverage Checklist
+
+| Spec Requirement | Task / Step |
+|---|---|
+| `jr user search <query>` command | Task 2 (enum), Task 3 (handler) |
+| `jr user list --project KEY` command | Task 2 (enum), Task 3 (handler) |
+| `jr user view <accountId>` command | Task 2 (enum), Task 3 (handler) |
+| New `get_user` API method | Task 1 |
+| Reuse existing `search_users` unchanged | Task 3 (Step 3.1 — `handle_search`) |
+| Reuse existing `search_assignable_users_by_project` unchanged | Task 3 (Step 3.1 — `handle_list`) |
+| `--limit N` / `--all` on search and list | Task 2 (Step 2.3), Task 3 (`resolve_effective_limit`) |
+| Positional `<query>` and `<accountId>` args | Task 2 (Step 2.3) |
+| No `--email` flag | Task 2 (Step 2.3 — deliberately absent) |
+| Table columns: Display Name \| Email \| Active \| Account ID | Task 3 (`print_user_list`) |
+| Full accountId (not truncated) | Task 3 (`format_user_row`) |
+| `—` for missing email | Task 3 (`format_user_row`), Task 4 (Step 4.1 privacy test) |
+| `✓`/`✗` for active | Task 3 (`format_active`) |
+| View uses labeled Field/Value rows | Task 3 (`handle_view`) |
+| JSON mode: raw user(s) | Task 3 (`print_output` passes `&user` / `&users`) |
+| 404 on view → friendly "not found" error, exit 1 | Task 3 (`handle_view`), Task 4 (Step 4.1 404 test) |
+| 400 also treated as "not found" | Task 3 (`handle_view`) |
+| Empty search result → "No results found." | Task 4 (Step 4.1 empty test) — uses `output::print_output` default behavior |
+| Help text: GDPR caveat | Task 2 (Step 2.3 doc comments on `Search` and `List`) |
+| Integration tests with wiremock | Task 4 (all) |
+| Unit tests for formatters | Task 3 (`#[cfg(test)]` block in `src/cli/user.rs`) |
+| Full CI-equivalent checks clean | Task 5 (Step 5.1) |

--- a/docs/superpowers/specs/2026-04-05-jsm-internal-comments-design.md
+++ b/docs/superpowers/specs/2026-04-05-jsm-internal-comments-design.md
@@ -1,0 +1,197 @@
+# Internal vs External Comments for JSM Tickets — Design Spec
+
+**Issue:** #103
+**Status:** Draft
+**Date:** 2026-04-05
+
+## Problem
+
+`jr issue comment` has no way to specify whether a comment should be internal (agent-only) or external (customer-visible). On JSM service desk projects, this distinction is critical — internal comments are used for analyst notes that should never be exposed to customers.
+
+Currently all comments created via jr use the standard comment API with no visibility control, which defaults to external (customer-visible) on JSM projects.
+
+## Solution
+
+Add an `--internal` flag to `jr issue comment` and display visibility status in `jr issue comments` output.
+
+```
+# External (default, customer-visible)
+jr issue comment HELP-42 "Customer update"
+
+# Internal (agent-only)
+jr issue comment HELP-42 "Investigation notes" --internal
+```
+
+## API Approach
+
+Use the standard Jira REST API v3 for both create and list — no JSM-specific API needed.
+
+**Validated against live Jira Cloud instance (2026-04-05):**
+
+- `POST /rest/api/3/issue/{key}/comment` accepts a `properties` array with `sd.public.comment` entity property
+- `GET /rest/api/3/issue/{key}/comment?expand=properties` returns `sd.public.comment` on each comment for JSM projects
+- Non-JSM projects return empty `properties: []` — clean, no special handling needed
+
+The JSM-specific API (`/rest/servicedeskapi/request/{key}/comment`) was evaluated and rejected:
+- Only works for "service request" types, not all JSM issue types (404 on Problem, Task, etc.)
+- Uses plain text body instead of ADF (loses markdown support)
+- No benefit over the standard API approach
+
+### Why Not the JSM API
+
+| Criteria | Standard API | JSM API |
+|----------|-------------|---------|
+| Works on all issue types | Yes | Only service requests |
+| Body format | ADF (existing support) | Plain text |
+| Visibility in response | Via `expand=properties` | `public` boolean |
+| Non-JSM projects | Property ignored, empty properties | 404 error |
+
+## Create: `--internal` Flag
+
+When `--internal` is passed, add the `sd.public.comment` entity property to the POST payload:
+
+```json
+{
+  "body": { "type": "doc", "version": 1, "content": [...] },
+  "properties": [
+    {
+      "key": "sd.public.comment",
+      "value": { "internal": true }
+    }
+  ]
+}
+```
+
+When `--internal` is NOT passed, omit the `properties` field entirely. Jira's default is external (customer-visible) — confirmed by live testing: comments without `sd.public.comment` have empty `properties: []` and are treated as external.
+
+### Non-JSM Projects
+
+The `sd.public.comment` property is silently accepted and stored on non-JSM projects but has no effect — there is no customer portal to restrict visibility on. The `--internal` flag works on any project without error.
+
+## List: Conditional Visibility Column
+
+Add `?expand=properties` to the GET comments request. For each comment, check for the `sd.public.comment` property.
+
+**Display logic:**
+- If ANY comment in the result has `sd.public.comment` → show "Visibility" column
+- If NO comments have `sd.public.comment` (non-JSM projects) → omit column entirely
+
+**Per-comment mapping:**
+- `sd.public.comment: {internal: true}` → "Internal"
+- `sd.public.comment: {internal: false}` → "External"
+- No `sd.public.comment` property (but column is shown because other comments have it) → "External" (Jira's default)
+
+### Table Output
+
+```
+# JSM project with mixed visibility
+┌────────┬──────────┬────────────┬──────────────────────────────┐
+│ Author ┆ Date     ┆ Visibility ┆ Body                         │
+╞════════╪══════════╪════════════╪══════════════════════════════╡
+│ Agent  ┆ 04-05    ┆ Internal   ┆ Investigation notes...       │
+│ Agent  ┆ 04-05    ┆ External   ┆ Customer update...           │
+
+# Non-JSM project (no visibility column)
+┌────────┬──────────┬──────────────────────────────┐
+│ Author ┆ Date     ┆ Body                         │
+╞════════╪══════════╪══════════════════════════════╡
+│ Dev    ┆ 04-05    ┆ Fixed in commit abc123...    │
+```
+
+### JSON Output
+
+Include the raw `properties` array on each comment. Consumers can inspect it directly:
+
+```json
+{
+  "id": "10042",
+  "author": { "displayName": "Agent" },
+  "body": { ... },
+  "properties": [
+    { "key": "sd.public.comment", "value": { "internal": true } }
+  ]
+}
+```
+
+Non-JSM comments have `"properties": []`.
+
+## Implementation
+
+### Files Changed
+
+| File | Change | Description |
+|------|--------|-------------|
+| `src/cli/mod.rs` | Modify | Add `--internal` flag to `Comment` variant |
+| `src/cli/issue/workflow.rs` | Modify | Pass `internal` flag to `add_comment` |
+| `src/api/jira/issues.rs` | Modify | Accept `internal` param in `add_comment`, add `expand=properties` to `list_comments` query |
+| `src/types/jira/issue.rs` | Modify | Add `properties` field to `Comment` struct, add `EntityProperty` type |
+| `src/cli/issue/list.rs` | Modify | Conditional "Visibility" column in `handle_comments` |
+
+### Type Changes
+
+```rust
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct EntityProperty {
+    pub key: String,
+    pub value: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct Comment {
+    pub id: Option<String>,
+    pub body: Option<Value>,
+    pub author: Option<User>,
+    pub created: Option<String>,
+    #[serde(default)]
+    pub properties: Vec<EntityProperty>,
+}
+```
+
+### API Changes
+
+`add_comment` signature change:
+
+```rust
+// Before:
+pub async fn add_comment(&self, key: &str, body: Value) -> Result<Comment>
+
+// After:
+pub async fn add_comment(&self, key: &str, body: Value, internal: bool) -> Result<Comment>
+```
+
+`list_comments` — add `expand=properties` to the query string (no signature change).
+
+## Error Messages
+
+| Scenario | Message |
+|----------|---------|
+| `--internal` on non-JSM project | No error — property silently accepted |
+| Comment creation failure | Existing error handling unchanged |
+
+## Testing
+
+### Handler Tests (wiremock)
+
+1. **`--internal` flag adds property to POST**: Mock `/rest/api/3/issue/{key}/comment`, verify request body contains `properties` array with `sd.public.comment: {internal: true}`
+2. **No `--internal` omits property**: Mock same endpoint, verify request body has no `properties` field
+3. **Comment listing with visibility**: Mock GET with `expand=properties`, return comments with `sd.public.comment` properties, verify "Visibility" column appears in output
+4. **Comment listing without visibility**: Mock GET returning empty properties, verify no "Visibility" column
+
+### Unit Tests
+
+1. **`Comment` deserialization with properties**: Parse JSON with `sd.public.comment` property
+2. **`Comment` deserialization without properties**: Parse JSON with empty/missing properties array
+3. **`EntityProperty` deserialization**: Parse the `{key, value}` format
+
+## Caveats
+
+- `?expand=properties` on the comment list endpoint works in practice but is not explicitly documented by Atlassian as a supported expansion value. The `expand` parameter itself is documented, and `properties` is a documented field on the Comment model. If this ever breaks, a per-comment fallback exists via `GET /rest/api/3/comment/{id}/properties`.
+- The `--internal` flag has no effect on non-JSM projects but is silently accepted. This is intentional — flagging an error would require JSM project detection, adding complexity with no user benefit.
+
+## Out of Scope
+
+- Interactive prompt for visibility selection — `--internal` flag is sufficient
+- `--external` flag — omitting `--internal` already defaults to external
+- JSM API integration — standard API handles both create and list
+- Editing comment visibility after creation — separate feature
+- Filtering comments by visibility — YAGNI

--- a/docs/superpowers/specs/2026-04-10-429-retry-exhaustion-warning-design.md
+++ b/docs/superpowers/specs/2026-04-10-429-retry-exhaustion-warning-design.md
@@ -1,0 +1,79 @@
+# 429 Retry Exhaustion Warning
+
+> **Issue:** #172 — jr api: 429 retry exhaustion is invisible to users
+
+## Problem
+
+When `JiraClient::send_raw` or `JiraClient::send` exhaust `MAX_RETRIES` (3) for HTTP 429 responses, the user gets no indication that retries were attempted. They see a delayed error (or delayed 429 response from `jr api`) with no explanation for the hang.
+
+## Design
+
+### Approach
+
+Add a non-verbose `eprintln!` warning to both `send` and `send_raw` when the final retry attempt returns 429. The warning fires unconditionally (not gated on `--verbose`) because retry exhaustion is operationally significant — users need to know jr absorbed backoff time on their behalf.
+
+### Warning Message
+
+```
+warning: rate limited by Jira — gave up after 3 retries
+```
+
+- Lowercase `warning:` prefix matches Rust ecosystem convention (`cargo`, `rustc`) and existing jr patterns (`src/cli/issue/list.rs:362`, `src/cli/board.rs:205`)
+- Includes retry count for debuggability (Perplexity-validated convention)
+- Does not include total delay — per-retry delays are already visible via `--verbose`
+
+### Placement
+
+**`send_raw`** (`src/api/client.rs`): The retry loop iterates `0..=MAX_RETRIES`. On the final attempt (`attempt == MAX_RETRIES`), if the response is 429, the retry condition `attempt < MAX_RETRIES` is false, so execution falls through to `return Ok(response)`. The warning is inserted just before this return, guarded by a 429 status check:
+
+```rust
+if response.status() == StatusCode::TOO_MANY_REQUESTS {
+    eprintln!("warning: rate limited by Jira — gave up after {MAX_RETRIES} retries");
+}
+return Ok(response);
+```
+
+**`send`** (`src/api/client.rs`): Same loop structure. On the final attempt, a 429 falls through the retry condition and hits the `is_client_error()` check, which converts it to `JrError::ApiError`. The warning is inserted before this check:
+
+```rust
+if response.status() == StatusCode::TOO_MANY_REQUESTS {
+    eprintln!("warning: rate limited by Jira — gave up after {MAX_RETRIES} retries");
+}
+if response.status().is_client_error() || response.status().is_server_error() {
+    return Err(Self::parse_error(response).await);
+}
+```
+
+### What Does NOT Change
+
+- Return types of `send` or `send_raw`
+- Error message format (`JrError::ApiError` Display)
+- Exit codes
+- `--output json` behavior
+- Stdout output (warning is stderr only)
+
+## Testing
+
+**1 new handler subprocess test** in `tests/cli_handler.rs`:
+
+| Test | Setup | Assertion |
+|------|-------|-----------|
+| `test_api_warns_on_429_retry_exhaustion` | wiremock returns 429 for all requests (persistent mock) | stderr contains `"warning: rate limited by Jira"` and `"3 retries"` |
+
+Uses the existing `jr_api_cmd` helper + `assert_cmd` stderr assertions (`predicate::str::contains`), matching the project's established pattern (22 existing stderr assertions across handler and smoke tests).
+
+No unit test needed — `eprintln!` is not capturable in-process without external crates, and the subprocess test reliably captures stderr.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/api/client.rs` | Add `eprintln!` warning to both `send` and `send_raw` retry loops |
+| `tests/cli_handler.rs` | Add `test_api_warns_on_429_retry_exhaustion` handler test |
+
+## Validation
+
+- **Perplexity:** Confirmed lowercase `warning:` is Rust CLI convention; recommended including retry count
+- **Context7 (reqwest):** No built-in retry mechanism — retry logic is entirely custom in jr
+- **Context7 (gh CLI):** gh does not retry 429s at all — no precedent to follow; jr's retry is already more user-friendly
+- **Codebase:** Existing `warning:` pattern in `list.rs` and `board.rs` confirms format choice

--- a/docs/superpowers/specs/2026-04-12-stderr-stdout-separation-design.md
+++ b/docs/superpowers/specs/2026-04-12-stderr-stdout-separation-design.md
@@ -39,6 +39,7 @@ Five additional `println!` calls are human status messages, not data:
 | `auth status` output (Instance, Auth method, Credentials) | Command's primary data output, not a status message |
 | `project fields` output | Data |
 | `"No results found."` in `print_output` | Empty data result; scripts expect `cmd \| wc -l` to return 0 |
+| `open --url-only` URL | Data output — the command's sole purpose is to emit the URL for piping |
 
 ### Stream Model
 
@@ -49,6 +50,12 @@ After this change, the stream model is:
 | **Table — read commands** (list, view) | Table data | Warnings, verbose logs |
 | **Table — write commands** (create, edit, move) | Nothing | Confirmations, URLs |
 | **JSON — all commands** | Structured JSON | Warnings, verbose logs |
+
+### Breaking Change
+
+This is a **behavioral change** for Table-mode write commands. Any script or pipeline that captures stdout from Table-mode write commands (e.g., `jr issue create | grep "Created"`) will stop receiving that output. The migration path is `--output json`, which already exists for all write commands and was always the intended scripting interface. This is a pre-1.0 tool, and this change aligns with the documented project vision (agentic CLI in the spirit of `gh`).
+
+The `open --url-only` command is unaffected — its `println!("{}", url)` is data output and stays on stdout.
 
 ## What Does NOT Change
 
@@ -88,3 +95,5 @@ Uses existing `jr_cmd` helper with no `--output json` flag, matching established
 - **Perplexity:** Confirmed `auth status`-style config display belongs on stdout (primary command output)
 - **Context7 (colored):** `eprintln!` with `.green()` works identically to `println!`; no special handling needed
 - **Context7 (comfy-table):** `Table::to_string()` returns `String` — no stream interaction; `print_output` controls the stream
+- **Perplexity:** Identified edge cases for stdout→stderr migration (breaking scripts, CI log capture); mitigated by pre-1.0 status and existing `--output json` scripting path
+- **Local verification:** All `println!` calls in write-command Table-mode paths are either `print_success` (covered by core change) or JSON-mode data (stays stdout); no gaps in change list

--- a/docs/superpowers/specs/2026-04-12-stderr-stdout-separation-design.md
+++ b/docs/superpowers/specs/2026-04-12-stderr-stdout-separation-design.md
@@ -1,0 +1,90 @@
+# Separate Human Status Messages (stderr) from Machine Output (stdout)
+
+> **Issue:** #134 — refactor: separate human status messages (stderr) from machine output (stdout)
+
+## Problem
+
+Write commands (create, edit, move, assign, comment, link, unlink, sprint add/remove, worklog add) send confirmation messages to stdout via `output::print_success`. This mixes human-facing status text with machine-parseable data, breaking scriptability. For example, `jr issue create | pbcopy` captures "Created issue FOO-123\nhttps://..." instead of structured data.
+
+The `gh` CLI separates these streams: table mode writes everything to stderr (confirmations, URLs, status), JSON mode writes structured data to stdout. This lets `gh issue create --json url --jq .url | pbcopy` cleanly capture just the URL.
+
+## Design
+
+### Core Change
+
+Change `output::print_success` from `println!` to `eprintln!`. This single-line change moves all ~20 write-command confirmation messages to stderr. The `colored` crate's `.green()` styling works identically with `eprintln!` (validated via Context7 — colored v3 handles stderr TTY detection).
+
+### Standalone Status Messages
+
+Five additional `println!` calls are human status messages, not data:
+
+| File | Current `println!` | Reason for stderr |
+|------|---------------------|-------------------|
+| `src/cli/auth.rs:21` | `"Credentials stored in keychain."` | Login confirmation |
+| `src/cli/auth.rs:28` | `"OAuth 2.0 requires your own Atlassian OAuth app."` | Setup instruction |
+| `src/cli/auth.rs:29` | `"Create one at: https://developer.atlassian.com/..."` | Setup instruction |
+| `src/cli/init.rs:10` | `"Setting up jr — Jira CLI\n"` | Setup banner |
+| `src/cli/init.rs:69` | `"No boards found. You can configure .jr.toml manually."` | Setup guidance |
+
+### Browse URL After Create
+
+`src/cli/issue/create.rs:154` prints the browse URL in Table mode via `println!("{}", browse_url)`. This moves to `eprintln!` to match the `gh` convention: table mode is purely for human consumption. Scripts should use `--output json` to capture URLs. This matches `gh issue create` behavior where the URL goes to stderr in table mode (Perplexity-validated).
+
+### What Stays on stdout
+
+| Output | Reason |
+|--------|--------|
+| All `--output json` paths | Machine-parseable data — the whole point of JSON mode |
+| `print_output` (table/JSON for read commands) | Data output for list, view, board, sprint, etc. |
+| `auth status` output (Instance, Auth method, Credentials) | Command's primary data output, not a status message |
+| `project fields` output | Data |
+| `"No results found."` in `print_output` | Empty data result; scripts expect `cmd \| wc -l` to return 0 |
+
+### Stream Model
+
+After this change, the stream model is:
+
+| Mode | stdout | stderr |
+|------|--------|--------|
+| **Table — read commands** (list, view) | Table data | Warnings, verbose logs |
+| **Table — write commands** (create, edit, move) | Nothing | Confirmations, URLs |
+| **JSON — all commands** | Structured JSON | Warnings, verbose logs |
+
+## What Does NOT Change
+
+- Return types, error messages, exit codes
+- JSON output (all stays on stdout)
+- `--no-color` / `NO_COLOR` behavior (colored crate handles stderr identically)
+- Read command output (list, view, board list, queue list, etc.)
+- `print_output` function behavior
+- `print_error` function (already uses `eprintln!`)
+
+## Testing
+
+**Existing tests:** All handler tests use `--output json` and assert on `.stdout()`. Since JSON paths are unaffected, no existing tests need modification.
+
+**1 new handler test** in `tests/cli_handler.rs`:
+
+| Test | Setup | Assertion |
+|------|-------|-----------|
+| `test_create_table_mode_outputs_to_stderr` | wiremock returns 201 for issue create | Table-mode confirmation + URL on `.stderr()`, stdout is empty |
+
+Uses existing `jr_cmd` helper with no `--output json` flag, matching established handler test patterns.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/output.rs` | `print_success`: `println!` → `eprintln!` |
+| `src/cli/auth.rs` | 3 `println!` → `eprintln!` (lines 21, 28, 29) |
+| `src/cli/init.rs` | 2 `println!` → `eprintln!` (lines 10, 69) |
+| `src/cli/issue/create.rs` | 1 `println!` → `eprintln!` (line 154, browse URL) |
+| `tests/cli_handler.rs` | Add `test_create_table_mode_outputs_to_stderr` |
+
+## Validation
+
+- **Perplexity:** Confirmed `gh issue create` writes everything to stderr in table mode; URL is only on stdout via `--json`
+- **Perplexity:** Confirmed clig.dev convention — stdout for data, stderr for messaging/logs/status
+- **Perplexity:** Confirmed `auth status`-style config display belongs on stdout (primary command output)
+- **Context7 (colored):** `eprintln!` with `.green()` works identically to `println!`; no special handling needed
+- **Context7 (comfy-table):** `Table::to_string()` returns `String` — no stream interaction; `print_output` controls the stream

--- a/docs/superpowers/specs/2026-04-13-user-search-lookup-design.md
+++ b/docs/superpowers/specs/2026-04-13-user-search-lookup-design.md
@@ -106,7 +106,7 @@ Help text for `search` and `list` includes a note:
 src/cli/user.rs       — handler + formatting (NEW)
 src/cli/mod.rs        — register `pub mod user;`, add `User { command: UserCommand }` variant and `UserCommand` enum
 src/api/jira/users.rs — add `get_user(account_id)` method (~10 lines)
-src/main.rs           — dispatch `Command::User { command } => cli::user::handle(cli, command).await`
+src/main.rs           — dispatch `Command::User { command } => cli::user::handle(command, &cli.output, &client).await`
 tests/user_commands.rs — integration tests (NEW)
 ```
 
@@ -117,20 +117,19 @@ The handler file follows the same shape as `src/cli/team.rs` or `src/cli/project
 Integration tests in `tests/user_commands.rs` using wiremock:
 
 1. `search` — query matches two users → table has both rows, JSON is an array of 2
-2. `search` — empty result → stdout empty in table mode, "No users found." on stderr, exit 0
-3. `search --limit 5` — passes `maxResults=5` to API
-4. `search --all` — paginates through multiple pages
-5. `list --project FOO` — calls `/user/assignable/multiProjectSearch` with correct projectKeys
+2. `search` — empty result → `"No results found."` on stdout (via `output::print_output`), exit 0
+3. `search --limit N` — truncates output locally to N rows; does not pass `maxResults` to the API
+4. `search --all` — disables the local default cap but does not paginate beyond Jira's single page
+5. `list --project FOO` — calls `/user/assignable/multiProjectSearch` with correct `projectKeys`
 6. `list` with no `--project` → clap error, exit 64
 7. `view <accountId>` — success, table view shows labeled rows
-8. `view <accountId>` — 404 → friendly error, exit 1
-9. `view <accountId> --output json` — emits the full user object
-10. Privacy case — user with no `emailAddress` field → table shows `—`, JSON shows field absent
-11. Verify snapshot tests of table output match (using `insta` consistent with other commands)
+8. `view <accountId>` — 404 → friendly `User with accountId 'X' not found.` error, exit 1
+9. `view <accountId> --output json` — emits the full `User` object
+10. Privacy case — user response without `emailAddress` → table shows `—`, JSON serializes `"emailAddress": null` (present but null, not absent)
 
 Unit tests inline in `src/cli/user.rs`:
-- Row-formatting helper handles missing email
-- Active indicator maps correctly
+- `format_user_row` renders `—` when `email_address` is `None`
+- `format_active` maps `Some(true)` → `✓`, `Some(false)` → `✗`, `None` → `—`
 
 ## What stays out of scope
 

--- a/docs/superpowers/specs/2026-04-13-user-search-lookup-design.md
+++ b/docs/superpowers/specs/2026-04-13-user-search-lookup-design.md
@@ -90,7 +90,7 @@ Active:       ✓
 
 | Scenario | HTTP | jr behavior |
 |---|---|---|
-| `view`: unknown accountId | 404 (or 400 — Jira is inconsistent across accountId formats) | `Error: User with accountId 'X' not found.` — exit 1. Match on either status in the handler; rely on wiremock tests to lock in behavior against a real response shape. |
+| `view`: unknown accountId | 404 (or 400 — Jira is inconsistent across accountId formats) | `Error: User with accountId 'X' not found.` — exit 64 via `JrError::UserError` (matches codebase convention for user-input errors; see `src/cli/assets.rs` and `src/api/jsm/servicedesks.rs`). Match on either status in the handler; wiremock test locks the exit code. |
 | `search`/`list`: no matches | 200 empty array | `"No results found."` on stdout via `output::print_output` — exit 0 (matches `issue list` convention) |
 | `search`/`list`: caller lacks "Browse users and groups" | 200 empty array | Same as "no matches" — API silently returns empty. Help text warns of this. |
 | `view`: caller lacks permission | 403 | Propagated through existing error handling with "permission" guidance |

--- a/docs/superpowers/specs/2026-04-13-user-search-lookup-design.md
+++ b/docs/superpowers/specs/2026-04-13-user-search-lookup-design.md
@@ -1,0 +1,155 @@
+# User Search and Lookup Commands
+
+> **Issue:** #114 — Feature: user search/lookup command
+
+## Problem
+
+There is no CLI path to search for Jira users or resolve an `accountId` to a human name. When `issue assign --to <name>` fails (duplicate names, GDPR-hidden email, user not in expected project), the workaround is to find a ticket assigned to that person, run `jr issue view --output json`, and pull `assignee.accountId` by hand.
+
+AI agents hit the same wall in reverse: JSON output from `issue view`/`issue list` surfaces raw `accountId` strings like `5b10ac8d82e05b22cc7d4349` with no in-CLI way to resolve them to a display name.
+
+The API client already has `search_users`, `search_assignable_users`, and `search_assignable_users_by_project` (used internally by `issue assign`, `issue create --to`, etc.). Only the CLI surface is missing.
+
+## Design
+
+### Commands
+
+| Command | Arg | API | Purpose |
+|---|---|---|---|
+| `jr user search <query>` | positional `<query>` | `GET /rest/api/3/user/search?query=X` | Fuzzy match displayName + emailAddress |
+| `jr user list --project <KEY>` | `--project <KEY>` (required) | `GET /rest/api/3/user/assignable/multiProjectSearch?query=&projectKeys=KEY` | List users assignable to a project |
+| `jr user view <accountId>` | positional `<accountId>` | `GET /rest/api/3/user?accountId=X` | Exact lookup — closes the reverse-resolution loop |
+
+`user search` and `user list` reuse existing client methods (`search_users`, `search_assignable_users_by_project`) unchanged. `user view` needs one new client method.
+
+### New API client method
+
+Add to `src/api/jira/users.rs`:
+
+```rust
+/// Fetch a single user by accountId.
+///
+/// Returns `ApiError { status: 404 }` if the user does not exist.
+/// Email may be omitted based on the target user's profile-visibility settings.
+pub async fn get_user(&self, account_id: &str) -> Result<User> {
+    let path = format!(
+        "/rest/api/3/user?accountId={}",
+        urlencoding::encode(account_id)
+    );
+    self.get(&path).await
+}
+```
+
+Pattern matches `get_myself` (same file, line 6).
+
+### Argument names
+
+- `<query>` — matches the Jira API parameter name and reads naturally (`jr user search "jane"` or `jr user search "jane@acme.io"`).
+- `<accountId>` — positional; the Atlassian-canonical name for the identifier. Not `--account-id` because this is the primary input, not a filter.
+- `--project <KEY>` on `list` — required. Mirrors the convention of `--project` being a global flag with an explicit override (clap will treat the subcommand-local `--project` as the effective value).
+
+### Flags
+
+| Flag | Commands | Behavior |
+|---|---|---|
+| `--limit <N>` | `search`, `list` | Default 30 via `DEFAULT_LIMIT`. Conflicts with `--all`. |
+| `--all` | `search`, `list` | Fetch all pages. No default limit. |
+| global `--output {table,json}` | all three | Inherited from root CLI. |
+| global `--no-color`, `--no-input`, `--verbose` | all three | Inherited. |
+
+No `--email` flag — the API `query` parameter already matches both displayName and email substrings (confirmed via Atlassian docs and community reports). Passing `"jane@acme.io"` to `user search` works.
+
+### Output
+
+**Table mode** for `search` and `list`:
+
+```
+Display Name        | Email               | Active | Account ID
+Jane Smith          | jane@acme.io        | ✓      | 5b10ac8d82e05b22cc7d4349
+Ada Lovelace        | —                   | ✓      | 712020:abc123...
+John Archive        | —                   | ✗      | 557058:def456...
+```
+
+- Column order: `Display Name`, `Email`, `Active`, `Account ID`. Display name first because it's the primary scannable column; accountId last because it's long and mainly for copy-paste.
+- Full accountId (not truncated). Matches existing codebase convention (`src/cli/issue/helpers.rs:179,197` shows full IDs in disambiguation output).
+- Missing email displays as `—`.
+- Active uses `✓` / `✗` with color.
+
+**Table mode** for `view`: labeled rows like `jr issue view` detail view:
+
+```
+Account ID:   5b10ac8d82e05b22cc7d4349
+Display Name: Jane Smith
+Email:        jane@acme.io
+Active:       ✓
+Time Zone:    America/Los_Angeles
+Account Type: atlassian
+```
+
+**JSON mode:** raw `User` objects (already serializable via `src/types/jira/user.rs`). Array for `search`/`list`, single object for `view`.
+
+### Error handling
+
+| Scenario | HTTP | jr behavior |
+|---|---|---|
+| `view`: unknown accountId | 404 (or 400 — Jira is inconsistent across accountId formats) | `Error: User with accountId 'X' not found.` — exit 1. Match on either status in the handler; rely on wiremock tests to lock in behavior against a real response shape. |
+| `search`/`list`: no matches | 200 empty array | `No users found.` on stderr — exit 0 (matches `issue list` convention) |
+| `search`/`list`: caller lacks "Browse users and groups" | 200 empty array | Same as "no matches" — API silently returns empty. Help text warns of this. |
+| `view`: caller lacks permission | 403 | Propagated through existing error handling with "permission" guidance |
+| Network/auth failures | existing | Existing client error handling (401 retry, rate limit, etc.) |
+
+Help text for `search` and `list` includes a note:
+
+> Results depend on the **Browse users and groups** global permission and each user's profile-visibility settings. Empty results may indicate either no matches or missing permission. Email is hidden when the target user's privacy settings opt out.
+
+### CLI module layout
+
+```
+src/cli/user.rs       — handler + formatting (NEW)
+src/cli/mod.rs        — register `pub mod user;`, add `User { command: UserCommand }` variant and `UserCommand` enum
+src/api/jira/users.rs — add `get_user(account_id)` method (~10 lines)
+src/main.rs           — dispatch `Command::User { command } => cli::user::handle(cli, command).await`
+tests/user_commands.rs — integration tests (NEW)
+```
+
+The handler file follows the same shape as `src/cli/team.rs` or `src/cli/project.rs` (small, three-operation module — appropriate since user commands are a thin surface over existing API methods).
+
+### Tests
+
+Integration tests in `tests/user_commands.rs` using wiremock:
+
+1. `search` — query matches two users → table has both rows, JSON is an array of 2
+2. `search` — empty result → stdout empty in table mode, "No users found." on stderr, exit 0
+3. `search --limit 5` — passes `maxResults=5` to API
+4. `search --all` — paginates through multiple pages
+5. `list --project FOO` — calls `/user/assignable/multiProjectSearch` with correct projectKeys
+6. `list` with no `--project` → clap error, exit 64
+7. `view <accountId>` — success, table view shows labeled rows
+8. `view <accountId>` — 404 → friendly error, exit 1
+9. `view <accountId> --output json` — emits the full user object
+10. Privacy case — user with no `emailAddress` field → table shows `—`, JSON shows field absent
+11. Verify snapshot tests of table output match (using `insta` consistent with other commands)
+
+Unit tests inline in `src/cli/user.rs`:
+- Row-formatting helper handles missing email
+- Active indicator maps correctly
+
+## What stays out of scope
+
+| Feature | Why |
+|---|---|
+| `--email` flag | Redundant with positional query (validated) |
+| Multiple projects on `list` | API supports comma-separated; YAGNI for v1. If added later, use repeated `-p X -p Y` per modern CLI convention |
+| `/user/bulk` for multi-accountId lookup | No current demand; can add as `user view A B C` later |
+| `/user/search/query` structured queries | Powerful (`is assignee of PROJ`, property filters) but a separate feature |
+| User list caching | Users join/leave frequently; cache would be stale |
+| accountId truncation | Codebase convention is full IDs |
+| Auto-disambiguation on `view` by name | Keeps `view` deterministic — `search` is for fuzzy lookup |
+
+## Alignment with project conventions
+
+- **Thin client, no abstraction layer** — reuses existing `search_users` / `search_assignable_users_by_project`, adds one sibling method.
+- **Machine-output-first** — all three commands return `--output json`; empty-result message is on stderr, not stdout.
+- **Non-interactive by default** — no prompts; every option has a flag equivalent.
+- **Idempotent read operations** — all three are pure GETs.
+- **Pipe-friendly** — `jr user search jane --output json | jq '.[0].accountId' | xargs jr user view` works cleanly.

--- a/docs/superpowers/specs/2026-04-13-user-search-lookup-design.md
+++ b/docs/superpowers/specs/2026-04-13-user-search-lookup-design.md
@@ -52,8 +52,8 @@ Pattern matches `get_myself` (same file, line 6).
 
 | Flag | Commands | Behavior |
 |---|---|---|
-| `--limit <N>` | `search`, `list` | Default 30 via `DEFAULT_LIMIT`. Conflicts with `--all`. |
-| `--all` | `search`, `list` | Fetch all pages. No default limit. |
+| `--limit <N>` | `search`, `list` | Cap the number of rows shown (default 30 via `DEFAULT_LIMIT`). Applied client-side after the Jira response — does not reduce the API fetch. Conflicts with `--all`. |
+| `--all` | `search`, `list` | Disable the default local cap. Jira still returns a single page (default 50, server-capped at 100). True multi-page pagination is a separate follow-up — see the "What stays out of scope" section. |
 | global `--output {table,json}` | all three | Inherited from root CLI. |
 | global `--no-color`, `--no-input`, `--verbose` | all three | Inherited. |
 
@@ -75,25 +75,23 @@ John Archive        | —                   | ✗      | 557058:def456...
 - Missing email displays as `—`.
 - Active uses `✓` / `✗` with color.
 
-**Table mode** for `view`: labeled rows like `jr issue view` detail view:
+**Table mode** for `view`: labeled rows like `jr issue view` detail view — the four fields surfaced by the `User` type:
 
 ```
-Account ID:   5b10ac8d82e05b22cc7d4349
+Account ID:   acc-xyz-1234
 Display Name: Jane Smith
 Email:        jane@acme.io
 Active:       ✓
-Time Zone:    America/Los_Angeles
-Account Type: atlassian
 ```
 
-**JSON mode:** raw `User` objects (already serializable via `src/types/jira/user.rs`). Array for `search`/`list`, single object for `view`.
+**JSON mode:** raw `User` objects serialized via `src/types/jira/user.rs`. Array for `search`/`list`, single object for `view`. When privacy hides the email, `emailAddress` is emitted as JSON `null` (the field is present, not absent) — `Option<String>` serializes without `skip_serializing_if`.
 
 ### Error handling
 
 | Scenario | HTTP | jr behavior |
 |---|---|---|
 | `view`: unknown accountId | 404 (or 400 — Jira is inconsistent across accountId formats) | `Error: User with accountId 'X' not found.` — exit 1. Match on either status in the handler; rely on wiremock tests to lock in behavior against a real response shape. |
-| `search`/`list`: no matches | 200 empty array | `No users found.` on stderr — exit 0 (matches `issue list` convention) |
+| `search`/`list`: no matches | 200 empty array | `"No results found."` on stdout via `output::print_output` — exit 0 (matches `issue list` convention) |
 | `search`/`list`: caller lacks "Browse users and groups" | 200 empty array | Same as "no matches" — API silently returns empty. Help text warns of this. |
 | `view`: caller lacks permission | 403 | Propagated through existing error handling with "permission" guidance |
 | Network/auth failures | existing | Existing client error handling (401 retry, rate limit, etc.) |
@@ -145,11 +143,12 @@ Unit tests inline in `src/cli/user.rs`:
 | User list caching | Users join/leave frequently; cache would be stale |
 | accountId truncation | Codebase convention is full IDs |
 | Auto-disambiguation on `view` by name | Keeps `view` deterministic — `search` is for fuzzy lookup |
+| True multi-page pagination for `search`/`list` | Both endpoints support `startAt`/`maxResults` but currently the client calls them once without either. `--all` disables the local cap but cannot exceed Jira's single-page default (50, capped at 100). Filed as a follow-up issue so the client method change can be planned alongside callers like `issue assign --to`. |
 
 ## Alignment with project conventions
 
 - **Thin client, no abstraction layer** — reuses existing `search_users` / `search_assignable_users_by_project`, adds one sibling method.
-- **Machine-output-first** — all three commands return `--output json`; empty-result message is on stderr, not stdout.
+- **Machine-output-first** — all three commands return `--output json`. The empty-result message (`"No results found."`) stays on stdout via `output::print_output`, consistent with the rest of the CLI.
 - **Non-interactive by default** — no prompts; every option has a flag equivalent.
 - **Idempotent read operations** — all three are pure GETs.
 - **Pipe-friendly** — `jr user search jane --output json | jq '.[0].accountId' | xargs jr user view` works cleanly.

--- a/src/api/jira/users.rs
+++ b/src/api/jira/users.rs
@@ -78,11 +78,51 @@ impl JiraClient {
         };
         Ok(users)
     }
+
+    /// Fetch a single user by accountId.
+    ///
+    /// Returns a `JrError::ApiError { status: 404, .. }` when the accountId
+    /// does not exist. Email may be omitted from the response based on the
+    /// target user's profile-visibility settings.
+    pub async fn get_user(&self, account_id: &str) -> Result<User> {
+        let path = format!(
+            "/rest/api/3/user?accountId={}",
+            urlencoding::encode(account_id)
+        );
+        self.get(&path).await
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::types::jira::User;
+
+    #[test]
+    fn single_user_response_deserializes() {
+        let json = r#"{
+            "accountId": "5b10ac8d82e05b22cc7d4349",
+            "displayName": "Jane Smith",
+            "emailAddress": "jane@acme.io",
+            "active": true
+        }"#;
+        let user: User = serde_json::from_str(json).unwrap();
+        assert_eq!(user.account_id, "5b10ac8d82e05b22cc7d4349");
+        assert_eq!(user.display_name, "Jane Smith");
+        assert_eq!(user.email_address.as_deref(), Some("jane@acme.io"));
+        assert_eq!(user.active, Some(true));
+    }
+
+    #[test]
+    fn single_user_without_email_deserializes() {
+        let json = r#"{
+            "accountId": "abc",
+            "displayName": "Privacy User",
+            "active": true
+        }"#;
+        let user: User = serde_json::from_str(json).unwrap();
+        assert_eq!(user.account_id, "abc");
+        assert!(user.email_address.is_none());
+    }
 
     #[test]
     fn multi_project_search_response_deserializes() {

--- a/src/api/jira/users.rs
+++ b/src/api/jira/users.rs
@@ -81,9 +81,10 @@ impl JiraClient {
 
     /// Fetch a single user by accountId.
     ///
-    /// Returns a `JrError::ApiError { status: 404, .. }` when the accountId
-    /// does not exist. Email may be omitted from the response based on the
-    /// target user's profile-visibility settings.
+    /// Returns a `JrError::ApiError { status: 404 | 400, .. }` when the
+    /// accountId is unknown or malformed — Jira is inconsistent which it
+    /// returns. Email may be omitted from the response based on the target
+    /// user's profile-visibility settings.
     pub async fn get_user(&self, account_id: &str) -> Result<User> {
         let path = format!(
             "/rest/api/3/user?accountId={}",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -524,8 +524,8 @@ pub enum UserCommand {
     Search {
         /// Search string (matches displayName and emailAddress substrings)
         query: String,
-        /// Cap the number of rows shown (default 30). Caps the single Jira
-        /// page locally; does not reduce the API fetch.
+        /// Cap the number of results shown (default 30). Applies to both
+        /// table rows and JSON array length; does not reduce the API fetch.
         #[arg(long)]
         limit: Option<u32>,
         /// Disable the default local cap. Jira still returns a single page
@@ -540,8 +540,8 @@ pub enum UserCommand {
         /// Project key (e.g., FOO)
         #[arg(long, short = 'p')]
         project: String,
-        /// Cap the number of rows shown (default 30). Caps the single Jira
-        /// page locally; does not reduce the API fetch.
+        /// Cap the number of results shown (default 30). Applies to both
+        /// table rows and JSON array length; does not reduce the API fetch.
         #[arg(long)]
         limit: Option<u32>,
         /// Disable the default local cap. Jira still returns a single page

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -524,10 +524,12 @@ pub enum UserCommand {
     Search {
         /// Search string (matches displayName and emailAddress substrings)
         query: String,
-        /// Maximum number of results
+        /// Cap the number of rows shown (default 30). Caps the single Jira
+        /// page locally; does not reduce the API fetch.
         #[arg(long)]
         limit: Option<u32>,
-        /// Fetch all results (no default limit)
+        /// Disable the default local cap. Jira still returns a single page
+        /// (up to 50 results by default, capped at 100 server-side).
         #[arg(long, conflicts_with = "limit")]
         all: bool,
     },
@@ -538,10 +540,12 @@ pub enum UserCommand {
         /// Project key (e.g., FOO)
         #[arg(long, short = 'p')]
         project: String,
-        /// Maximum number of results
+        /// Cap the number of rows shown (default 30). Caps the single Jira
+        /// page locally; does not reduce the API fetch.
         #[arg(long)]
         limit: Option<u32>,
-        /// Fetch all results (no default limit)
+        /// Disable the default local cap. Jira still returns a single page
+        /// (up to 50 results by default, capped at 100 server-side).
         #[arg(long, conflicts_with = "limit")]
         all: bool,
     },

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -547,11 +547,11 @@ pub enum UserCommand {
     },
     /// Look up a user by accountId
     ///
-    /// Returns full user details (displayName, email when visible, active,
-    /// timeZone). Use this to resolve accountIds surfaced in JSON output
-    /// from other commands (e.g., `jr issue view --output json`).
+    /// Resolves an accountId to displayName, email (when visible), and
+    /// active status. Use this when you have an accountId and need the
+    /// human-readable identity.
     View {
-        /// Atlassian accountId (e.g., 5b10ac8d82e05b22cc7d4349)
+        /// Atlassian accountId
         account_id: String,
     },
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,7 @@ pub mod project;
 pub mod queue;
 pub mod sprint;
 pub mod team;
+pub mod user;
 pub mod worklog;
 
 use clap::{Parser, Subcommand, ValueEnum};
@@ -91,6 +92,11 @@ pub enum Command {
     Team {
         #[command(subcommand)]
         command: TeamCommand,
+    },
+    /// Manage users
+    User {
+        #[command(subcommand)]
+        command: UserCommand,
     },
     /// Manage JSM queues
     Queue {
@@ -505,6 +511,48 @@ pub enum TeamCommand {
         /// Force refresh from API, ignoring cache
         #[arg(long)]
         refresh: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum UserCommand {
+    /// Search for users by display name or email
+    ///
+    /// Results depend on the "Browse users and groups" global permission.
+    /// Empty results may indicate either no matches or missing permission.
+    /// Email is hidden when the target user's privacy settings opt out.
+    Search {
+        /// Search string (matches displayName and emailAddress substrings)
+        query: String,
+        /// Maximum number of results
+        #[arg(long)]
+        limit: Option<u32>,
+        /// Fetch all results (no default limit)
+        #[arg(long, conflicts_with = "limit")]
+        all: bool,
+    },
+    /// List users assignable to a project
+    ///
+    /// Results depend on the "Browse users and groups" global permission.
+    List {
+        /// Project key (e.g., FOO)
+        #[arg(long, short = 'p')]
+        project: String,
+        /// Maximum number of results
+        #[arg(long)]
+        limit: Option<u32>,
+        /// Fetch all results (no default limit)
+        #[arg(long, conflicts_with = "limit")]
+        all: bool,
+    },
+    /// Look up a user by accountId
+    ///
+    /// Returns full user details (displayName, email when visible, active,
+    /// timeZone). Use this to resolve accountIds surfaced in JSON output
+    /// from other commands (e.g., `jr issue view --output json`).
+    View {
+        /// Atlassian accountId (e.g., 5b10ac8d82e05b22cc7d4349)
+        account_id: String,
     },
 }
 

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -1,0 +1,152 @@
+use anyhow::{Result, anyhow};
+use colored::Colorize;
+
+use crate::api::client::JiraClient;
+use crate::cli::{OutputFormat, UserCommand, resolve_effective_limit};
+use crate::error::JrError;
+use crate::output;
+use crate::types::jira::User;
+
+pub async fn handle(
+    command: UserCommand,
+    output_format: &OutputFormat,
+    client: &JiraClient,
+) -> Result<()> {
+    match command {
+        UserCommand::Search { query, limit, all } => {
+            handle_search(&query, limit, all, output_format, client).await
+        }
+        UserCommand::List {
+            project,
+            limit,
+            all,
+        } => handle_list(&project, limit, all, output_format, client).await,
+        UserCommand::View { account_id } => handle_view(&account_id, output_format, client).await,
+    }
+}
+
+async fn handle_search(
+    query: &str,
+    limit: Option<u32>,
+    all: bool,
+    output_format: &OutputFormat,
+    client: &JiraClient,
+) -> Result<()> {
+    let effective = resolve_effective_limit(limit, all);
+    let mut users = client.search_users(query).await?;
+    if let Some(cap) = effective {
+        users.truncate(cap as usize);
+    }
+    print_user_list(&users, output_format)
+}
+
+async fn handle_list(
+    project: &str,
+    limit: Option<u32>,
+    all: bool,
+    output_format: &OutputFormat,
+    client: &JiraClient,
+) -> Result<()> {
+    let effective = resolve_effective_limit(limit, all);
+    let mut users = client
+        .search_assignable_users_by_project("", project)
+        .await?;
+    if let Some(cap) = effective {
+        users.truncate(cap as usize);
+    }
+    print_user_list(&users, output_format)
+}
+
+async fn handle_view(
+    account_id: &str,
+    output_format: &OutputFormat,
+    client: &JiraClient,
+) -> Result<()> {
+    let user = match client.get_user(account_id).await {
+        Ok(u) => u,
+        Err(e) => {
+            if let Some(JrError::ApiError { status, .. }) = e.downcast_ref::<JrError>() {
+                if *status == 404 || *status == 400 {
+                    return Err(anyhow!("User with accountId '{account_id}' not found."));
+                }
+            }
+            return Err(e);
+        }
+    };
+
+    let rows = vec![
+        vec!["Account ID".into(), user.account_id.clone()],
+        vec!["Display Name".into(), user.display_name.clone()],
+        vec![
+            "Email".into(),
+            user.email_address.clone().unwrap_or_else(|| "—".into()),
+        ],
+        vec!["Active".into(), format_active(user.active)],
+    ];
+
+    output::print_output(output_format, &["Field", "Value"], &rows, &user)
+}
+
+fn print_user_list(users: &[User], output_format: &OutputFormat) -> Result<()> {
+    let rows: Vec<Vec<String>> = users.iter().map(format_user_row).collect();
+    output::print_output(
+        output_format,
+        &["Display Name", "Email", "Active", "Account ID"],
+        &rows,
+        &users,
+    )
+}
+
+fn format_user_row(user: &User) -> Vec<String> {
+    vec![
+        user.display_name.clone(),
+        user.email_address.clone().unwrap_or_else(|| "—".into()),
+        format_active(user.active),
+        user.account_id.clone(),
+    ]
+}
+
+fn format_active(active: Option<bool>) -> String {
+    match active {
+        Some(true) => "✓".green().to_string(),
+        Some(false) => "✗".red().to_string(),
+        None => "—".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn row_shows_display_name_email_and_id() {
+        let user = User {
+            account_id: "acc-1".into(),
+            display_name: "Alice".into(),
+            email_address: Some("alice@acme.io".into()),
+            active: Some(true),
+        };
+        let row = format_user_row(&user);
+        assert_eq!(row[0], "Alice");
+        assert_eq!(row[1], "alice@acme.io");
+        assert!(row[2].contains('✓'));
+        assert_eq!(row[3], "acc-1");
+    }
+
+    #[test]
+    fn row_renders_dash_for_missing_email() {
+        let user = User {
+            account_id: "acc-2".into(),
+            display_name: "Privacy User".into(),
+            email_address: None,
+            active: Some(true),
+        };
+        let row = format_user_row(&user);
+        assert_eq!(row[1], "—");
+    }
+
+    #[test]
+    fn active_formatter_handles_missing() {
+        assert_eq!(format_active(None), "—");
+    }
+}

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use colored::Colorize;
 
 use crate::api::client::JiraClient;
@@ -67,7 +67,10 @@ async fn handle_view(
         Err(e) => {
             if let Some(JrError::ApiError { status, .. }) = e.downcast_ref::<JrError>() {
                 if *status == 404 || *status == 400 {
-                    return Err(anyhow!("User with accountId '{account_id}' not found."));
+                    return Err(JrError::UserError(format!(
+                        "User with accountId '{account_id}' not found."
+                    ))
+                    .into());
                 }
             }
             return Err(e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,6 +158,11 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 let client = api::client::JiraClient::from_config(&config, cli.verbose)?;
                 cli::team::handle(command, &cli.output, &config, &client).await
             }
+            cli::Command::User { command } => {
+                let config = config::Config::load()?;
+                let client = api::client::JiraClient::from_config(&config, cli.verbose)?;
+                cli::user::handle(command, &cli.output, &client).await
+            }
             cli::Command::Queue { command } => {
                 let config = config::Config::load()?;
                 let client = api::client::JiraClient::from_config(&config, cli.verbose)?;

--- a/tests/user_commands.rs
+++ b/tests/user_commands.rs
@@ -262,7 +262,7 @@ async fn user_view_hidden_email_renders_dash() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn user_view_json_hidden_email_omits_field() {
+async fn user_view_json_hidden_email_is_null() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))

--- a/tests/user_commands.rs
+++ b/tests/user_commands.rs
@@ -142,6 +142,7 @@ async fn user_list_by_project_returns_users() {
     Mock::given(method("GET"))
         .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
         .and(query_param("projectKeys", "FOO"))
+        .and(query_param("query", ""))
         .respond_with(ResponseTemplate::new(200).set_body_json(
             fixtures::multi_project_user_search_response(vec![
                 ("acc-1", "Alice"),
@@ -230,7 +231,12 @@ async fn user_view_404_shows_friendly_error() {
         .output()
         .unwrap();
 
-    assert!(!output.status.success());
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "view on unknown accountId should exit 64 (JrError::UserError convention), got: {:?}",
+        output.status.code()
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("User with accountId 'does-not-exist' not found"),

--- a/tests/user_commands.rs
+++ b/tests/user_commands.rs
@@ -286,9 +286,11 @@ async fn user_view_json_hidden_email_omits_field() {
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
     assert_eq!(parsed["accountId"], "private-user");
     assert_eq!(parsed["displayName"], "Private Person");
+    let email = parsed
+        .get("emailAddress")
+        .expect("emailAddress key should be present (serialized as null), not omitted");
     assert!(
-        parsed["emailAddress"].is_null(),
-        "emailAddress should be null (not the em-dash placeholder) when privacy hides it, got: {}",
-        parsed["emailAddress"]
+        email.is_null(),
+        "emailAddress should serialize to JSON null when privacy hides it (not the em-dash placeholder), got: {email}"
     );
 }

--- a/tests/user_commands.rs
+++ b/tests/user_commands.rs
@@ -1,0 +1,262 @@
+#[allow(dead_code)]
+mod common;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use common::fixtures;
+
+fn jr_cmd(base_url: &str) -> Command {
+    let mut cmd = Command::cargo_bin("jr").unwrap();
+    cmd.env("JR_BASE_URL", base_url)
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .arg("--no-input");
+    cmd
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_search_returns_matching_users() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "jane"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(fixtures::user_search_response(vec![
+                ("acc-1", "Jane Smith", true),
+                ("acc-2", "Jane Doe", true),
+            ])),
+        )
+        .mount(&server)
+        .await;
+
+    jr_cmd(&server.uri())
+        .args(["user", "search", "jane"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Jane Smith"))
+        .stdout(predicate::str::contains("Jane Doe"))
+        .stdout(predicate::str::contains("acc-1"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_search_empty_result_prints_no_results() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&server)
+        .await;
+
+    jr_cmd(&server.uri())
+        .args(["user", "search", "nobody"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No results found."));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_search_json_output_is_array() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(fixtures::user_search_response(vec![(
+                "acc-1",
+                "Jane Smith",
+                true,
+            )])),
+        )
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri())
+        .args(["--output", "json", "user", "search", "jane"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON array");
+    assert!(parsed.is_array());
+    assert_eq!(parsed.as_array().unwrap().len(), 1);
+    assert_eq!(parsed[0]["accountId"], "acc-1");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_search_limit_truncates_results() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(fixtures::user_search_response(vec![
+                ("acc-1", "Alice One", true),
+                ("acc-2", "Alice Two", true),
+                ("acc-3", "Alice Three", true),
+            ])),
+        )
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri())
+        .args([
+            "--output", "json", "user", "search", "alice", "--limit", "2",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(parsed.as_array().unwrap().len(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_list_requires_project_flag() {
+    // No server needed — clap should fail before any HTTP call.
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", "http://127.0.0.1:1")
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["--no-input", "user", "list"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "missing --project should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--project") || stderr.contains("required"),
+        "expected error mentions missing --project, got: {stderr}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_list_by_project_returns_users() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
+        .and(query_param("projectKeys", "FOO"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            fixtures::multi_project_user_search_response(vec![
+                ("acc-1", "Alice"),
+                ("acc-2", "Bob"),
+            ]),
+        ))
+        .mount(&server)
+        .await;
+
+    jr_cmd(&server.uri())
+        .args(["user", "list", "--project", "FOO"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("Bob"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_view_returns_detail_rows() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user"))
+        .and(query_param("accountId", "acc-xyz"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "accountId": "acc-xyz",
+            "displayName": "Jane Smith",
+            "emailAddress": "jane@acme.io",
+            "active": true
+        })))
+        .mount(&server)
+        .await;
+
+    jr_cmd(&server.uri())
+        .args(["user", "view", "acc-xyz"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Jane Smith"))
+        .stdout(predicate::str::contains("jane@acme.io"))
+        .stdout(predicate::str::contains("acc-xyz"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_view_json_emits_user_object() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user"))
+        .and(query_param("accountId", "acc-xyz"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "accountId": "acc-xyz",
+            "displayName": "Jane Smith",
+            "emailAddress": "jane@acme.io",
+            "active": true
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri())
+        .args(["--output", "json", "user", "view", "acc-xyz"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(parsed["accountId"], "acc-xyz");
+    assert_eq!(parsed["displayName"], "Jane Smith");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_view_404_shows_friendly_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user"))
+        .and(query_param("accountId", "does-not-exist"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "errorMessages": ["User not found"]
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri())
+        .args(["user", "view", "does-not-exist"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("User with accountId 'does-not-exist' not found"),
+        "expected friendly not-found message, got: {stderr}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_view_hidden_email_renders_dash() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user"))
+        .and(query_param("accountId", "private-user"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "accountId": "private-user",
+            "displayName": "Private Person",
+            "active": true
+        })))
+        .mount(&server)
+        .await;
+
+    jr_cmd(&server.uri())
+        .args(["user", "view", "private-user"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Private Person"))
+        .stdout(predicate::str::contains("—"));
+}

--- a/tests/user_commands.rs
+++ b/tests/user_commands.rs
@@ -260,3 +260,35 @@ async fn user_view_hidden_email_renders_dash() {
         .stdout(predicate::str::contains("Private Person"))
         .stdout(predicate::str::contains("—"));
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_view_json_hidden_email_omits_field() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user"))
+        .and(query_param("accountId", "private-user"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "accountId": "private-user",
+            "displayName": "Private Person",
+            "active": true
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri())
+        .args(["--output", "json", "user", "view", "private-user"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(parsed["accountId"], "private-user");
+    assert_eq!(parsed["displayName"], "Private Person");
+    assert!(
+        parsed["emailAddress"].is_null(),
+        "emailAddress should be null (not the em-dash placeholder) when privacy hides it, got: {}",
+        parsed["emailAddress"]
+    );
+}

--- a/tests/user_commands.rs
+++ b/tests/user_commands.rs
@@ -47,6 +47,7 @@ async fn user_search_empty_result_prints_no_results() {
 
     Mock::given(method("GET"))
         .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "nobody"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
         .mount(&server)
         .await;
@@ -64,6 +65,7 @@ async fn user_search_json_output_is_array() {
 
     Mock::given(method("GET"))
         .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "jane"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(fixtures::user_search_response(vec![(
                 "acc-1",
@@ -93,6 +95,7 @@ async fn user_search_limit_truncates_results() {
 
     Mock::given(method("GET"))
         .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "alice"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(fixtures::user_search_response(vec![
                 ("acc-1", "Alice One", true),


### PR DESCRIPTION
## Summary

Adds three new CLI commands for resolving Jira user identities — closes #114.

- `jr user search <query>` — fuzzy match by displayName or email via `/rest/api/3/user/search`
- `jr user list --project <KEY>` — list users assignable to a project via `/user/assignable/multiProjectSearch`
- `jr user view <accountId>` — exact lookup via `/rest/api/3/user?accountId=X` (new `get_user` client method)

Closes the AI-agent reverse-resolution loop: when `jr issue view --output json` surfaces an `accountId`, you can now resolve it to a human name in one call.

## Design notes

- No `--email` flag — validated (Perplexity + Atlassian docs + community): `/user/search` `query` parameter already matches both displayName and emailAddress substrings
- No truncation of accountIds — follows existing codebase convention (`src/cli/issue/helpers.rs`) and matches `gh` CLI behavior
- `--all` disables our local 30-row cap; Jira still returns a single page (default 50, server-capped at 100). True multi-page pagination is filed as #189
- 404/400 on `view` both map to friendly "User with accountId 'X' not found." — Jira is inconsistent which status it returns
- No caching — users change too frequently; search/list are discovery ops where stale results would mislead
- Spec: `docs/superpowers/specs/2026-04-13-user-search-lookup-design.md`
- Plan: `docs/superpowers/plans/2026-04-13-user-commands.md`

## Also includes doc-only backfills from already-merged work

These were committed locally on `develop` before this branch started and came along via rebase. Content-only, no behavior change. Listed explicitly so reviewers can mentally scope the diff:

- `docs/superpowers/specs/2026-04-05-jsm-internal-comments-design.md` + plan — spec/plan for #103 (already merged via #170)
- `docs/superpowers/specs/2026-04-10-429-retry-exhaustion-warning-design.md` + plan — spec/plan for #172 (already merged via #179)
- `docs/superpowers/specs/2026-04-12-stderr-stdout-separation-design.md` + plan — spec/plan for #134 (already merged via #180)

## Test Plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — all 480+ tests pass
- [x] 11 new wiremock integration tests in `tests/user_commands.rs`
- [x] 3 new unit tests in `src/cli/user.rs` for formatting
- [x] 2 new deserialization tests in `src/api/jira/users.rs`
- [x] Help text verified: `jr user search --help` and `jr user list --help` surface the "Browse users and groups" permission caveat
- [x] JSON output preserves `"emailAddress": null` for privacy-hidden users (AI-agent contract locked via `user_view_json_hidden_email_is_null`)

## Deferred follow-ups (filed)

- #186 — behavioral coverage for `--all` flag across list commands
- #187 — per-command 5xx/401/network error test audit
- #189 — true multi-page pagination for `search_users` / `search_assignable_users_by_project`