### PR TITLE
fix: strict name matching + team field on issue view (#181, #182)

### DIFF
--- a/docs/superpowers/plans/2026-04-15-team-field-and-strict-matching.md
+++ b/docs/superpowers/plans/2026-04-15-team-field-and-strict-matching.md
@@ -405,7 +405,7 @@ async fn test_view_omits_team_row_when_field_unconfigured() {
 
 - `src/cache.rs:60-68` — `cache_dir()` honors `XDG_CACHE_HOME`.
 - `src/config.rs:130-140` — config loader honors `XDG_CONFIG_HOME`.
-- **CRITICAL** — `cli_handler.rs` tests spawn the `jr` binary via `assert_cmd::Command::cargo_bin("jr")`. Env vars set via `std::env::set_var` in the test body do **not** propagate to the spawned child (Perplexity-validated 2026-04-15). The existing `project_meta.rs` pattern uses `set_var` because it invokes `jr::` library functions in-process — that pattern is **not applicable here**. Instead, pass XDG vars explicitly via `.env()` on the `Command` builder:
+- **CRITICAL** — `cli_handler.rs` tests spawn the `jr` binary via `assert_cmd::Command::cargo_bin("jr")`. While env vars set via `std::env::set_var` are inherited by spawned children at process spawn, `set_var` mutates process-global state and can cause cross-test interference when tests run in parallel. The existing `project_meta.rs` pattern uses `set_var` because it invokes `jr::` library functions in-process — that pattern is **not applicable here**. For these spawned-binary tests, pass XDG vars explicitly via `.env()` on the `Command` builder so each command gets isolated environment configuration:
 
 ```rust
 let cache_dir = tempfile::tempdir().unwrap();

--- a/docs/superpowers/plans/2026-04-15-team-field-and-strict-matching.md
+++ b/docs/superpowers/plans/2026-04-15-team-field-and-strict-matching.md
@@ -1,0 +1,659 @@
+# Strict Name Matching + Team Field on `issue view` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the silent mis-resolution in `partial_match` (the root cause of #181) and expose the team field on `jr issue view` (#182). Together they close #181, #182, and #192.
+
+**Architecture:** One-line change to `partial_match.rs` collapses the `1 => Exact` substring-fallback arm into `Ambiguous`, so every existing call site routes single-hit substrings through its existing disambiguation branch (TTY prompt / `--no-input` error). Separately, `handle_view` gains a team row by extending the `extra_fields` fetch and adding a render block modeled on the story-points pattern.
+
+**Tech Stack:** Rust, wiremock, assert_cmd, predicates, anyhow, serde_json
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/partial_match.rs` | Modify | Collapse substring `1 => Exact` arm into `Ambiguous`; update unit tests |
+| `tests/input_validation.rs` | Modify | Update `valid_status_partial_match_resolves` to expect `Ambiguous` |
+| `src/types/jira/issue.rs` | Modify | Add `team_id(field_id) -> Option<String>` helper on `IssueFields` |
+| `src/cli/issue/list.rs` | Modify | Extend `extra_fields` with team field id; render team row in `handle_view` |
+| `tests/common/fixtures.rs` | Modify | Add `issue_response_with_team(key, summary, status, team_field_id, team_uuid)` fixture |
+| `tests/cli_handler.rs` | Modify | Add four handler tests (team cached / team uncached / field unconfigured / substring-rejects-under-no-input) |
+
+---
+
+### Task 1: Core — `partial_match` rejects silent substring hits
+
+**Files:**
+- Modify: `src/partial_match.rs:39-42` (the match arm) and the unit tests at `src/partial_match.rs:66-100`
+- Modify: `tests/input_validation.rs:124-160` (the `valid_status_partial_match_resolves` test)
+
+- [ ] **Step 1.1: Update the unit test `test_partial_match_unique` to expect the new behavior**
+
+In `src/partial_match.rs`, find:
+
+```rust
+#[test]
+fn test_partial_match_unique() {
+    match partial_match("prog", &candidates()) {
+        MatchResult::Exact(s) => assert_eq!(s, "In Progress"),
+        _ => panic!("Expected unique match"),
+    }
+}
+```
+
+Replace with:
+
+```rust
+#[test]
+fn test_partial_match_single_substring_is_ambiguous() {
+    // Single substring hits route through Ambiguous so callers can
+    // prompt (TTY) or error (--no-input) — never silently resolve.
+    match partial_match("prog", &candidates()) {
+        MatchResult::Ambiguous(matches) => {
+            assert_eq!(matches, vec!["In Progress".to_string()]);
+        }
+        other => panic!("Expected Ambiguous, got {:?}", other),
+    }
+}
+```
+
+- [ ] **Step 1.2: Update the unit test `test_blocked_unique` to expect the new behavior**
+
+In `src/partial_match.rs`, find:
+
+```rust
+#[test]
+fn test_blocked_unique() {
+    match partial_match("block", &candidates()) {
+        MatchResult::Exact(s) => assert_eq!(s, "Blocked"),
+        _ => panic!("Expected unique match"),
+    }
+}
+```
+
+Replace with:
+
+```rust
+#[test]
+fn test_blocked_single_substring_is_ambiguous() {
+    match partial_match("block", &candidates()) {
+        MatchResult::Ambiguous(matches) => {
+            assert_eq!(matches, vec!["Blocked".to_string()]);
+        }
+        other => panic!("Expected Ambiguous, got {:?}", other),
+    }
+}
+```
+
+- [ ] **Step 1.3: Run the unit tests to confirm they fail**
+
+Run:
+```bash
+cargo test --lib partial_match
+```
+
+Expected: FAIL — the two renamed tests fail because the current code returns `Exact` not `Ambiguous` for single substring hits.
+
+- [ ] **Step 1.4: Update the integration test that locks the old behavior**
+
+In `tests/input_validation.rs`, find the body of `valid_status_partial_match_resolves` (around line 155):
+
+```rust
+    let result = jr::partial_match::partial_match("in prog", &names);
+    match result {
+        jr::partial_match::MatchResult::Exact(name) => assert_eq!(name, "In Progress"),
+        other => panic!("Expected Exact, got {:?}", std::mem::discriminant(&other)),
+    }
+}
+```
+
+Replace with:
+
+```rust
+    let result = jr::partial_match::partial_match("in prog", &names);
+    match result {
+        jr::partial_match::MatchResult::Ambiguous(matches) => {
+            assert_eq!(matches, vec!["In Progress".to_string()]);
+        }
+        other => panic!("Expected Ambiguous, got {:?}", std::mem::discriminant(&other)),
+    }
+}
+```
+
+Also rename the test function for clarity:
+
+```rust
+async fn valid_status_single_substring_is_ambiguous() {
+```
+
+- [ ] **Step 1.5: Apply the one-line fix**
+
+In `src/partial_match.rs`, find:
+
+```rust
+    match matches.len() {
+        0 => MatchResult::None(candidates.to_vec()),
+        1 => MatchResult::Exact(matches.into_iter().next().unwrap()),
+        _ => MatchResult::Ambiguous(matches),
+    }
+```
+
+Replace with:
+
+```rust
+    match matches.len() {
+        0 => MatchResult::None(candidates.to_vec()),
+        _ => MatchResult::Ambiguous(matches),
+    }
+```
+
+- [ ] **Step 1.6: Run the full test suite**
+
+Run:
+```bash
+cargo test
+```
+
+Expected: all tests pass. If any additional tests rely on the old `1 => Exact` behavior, they surface here and get updated in the same commit. Likely suspects: none — the codebase audit found only the two tests above, but re-run to be certain.
+
+- [ ] **Step 1.7: Run lint and format checks**
+
+Run:
+```bash
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: both clean.
+
+- [ ] **Step 1.8: Commit**
+
+```bash
+git add src/partial_match.rs tests/input_validation.rs
+git commit -m "fix: reject silent substring resolution in partial_match (#181, #192)"
+```
+
+---
+
+### Task 2: Add `team_id` helper to `IssueFields`
+
+**Files:**
+- Modify: `src/types/jira/issue.rs` (add helper + unit test adjacent to `story_points`)
+
+- [ ] **Step 2.1: Write a failing unit test for the helper**
+
+In `src/types/jira/issue.rs`, find the existing `impl IssueFields` block that defines `story_points`:
+
+```rust
+impl IssueFields {
+    pub fn story_points(&self, field_id: &str) -> Option<f64> {
+        self.extra.get(field_id)?.as_f64()
+    }
+}
+```
+
+Below that block, add a test module (or extend the existing one if present — check the bottom of the file first):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn fields_with_extra(key: &str, value: serde_json::Value) -> IssueFields {
+        let mut fields = IssueFields::default();
+        fields.extra.insert(key.to_string(), value);
+        fields
+    }
+
+    #[test]
+    fn team_id_reads_string_value() {
+        let fields = fields_with_extra(
+            "customfield_10001",
+            json!("36885b3c-1bf0-4f85-a357-c5b858c31de4"),
+        );
+        assert_eq!(
+            fields.team_id("customfield_10001"),
+            Some("36885b3c-1bf0-4f85-a357-c5b858c31de4".to_string())
+        );
+    }
+
+    #[test]
+    fn team_id_returns_none_for_null_value() {
+        let fields = fields_with_extra("customfield_10001", json!(null));
+        assert_eq!(fields.team_id("customfield_10001"), None);
+    }
+
+    #[test]
+    fn team_id_returns_none_for_missing_key() {
+        let fields = IssueFields::default();
+        assert_eq!(fields.team_id("customfield_10001"), None);
+    }
+}
+```
+
+Note: if a `#[cfg(test)] mod tests` block already exists in the file, add just the three test functions inside it instead of creating a new one.
+
+- [ ] **Step 2.2: Run the test to see it fail**
+
+Run:
+```bash
+cargo test --lib types::jira::issue::tests::team_id
+```
+
+Expected: FAIL — `team_id` is not yet defined.
+
+- [ ] **Step 2.3: Implement the helper**
+
+In the same `impl IssueFields` block, add the helper below `story_points`:
+
+```rust
+impl IssueFields {
+    pub fn story_points(&self, field_id: &str) -> Option<f64> {
+        self.extra.get(field_id)?.as_f64()
+    }
+
+    pub fn team_id(&self, field_id: &str) -> Option<String> {
+        self.extra.get(field_id)?.as_str().map(String::from)
+    }
+}
+```
+
+- [ ] **Step 2.4: Run the tests to verify they pass**
+
+Run:
+```bash
+cargo test --lib types::jira::issue::tests::team_id
+```
+
+Expected: PASS (all three cases).
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/types/jira/issue.rs
+git commit -m "feat: add team_id helper to IssueFields (#182)"
+```
+
+---
+
+### Task 3: Surface team field on `issue view`
+
+**Files:**
+- Modify: `src/cli/issue/list.rs` (`handle_view` — around lines 699 and 908)
+- Modify: `tests/common/fixtures.rs` (add fixture helper)
+- Modify: `tests/cli_handler.rs` (add three handler tests)
+
+- [ ] **Step 3.1: Add a fixture helper for an issue with a team field set**
+
+In `tests/common/fixtures.rs`, add near the other `issue_response_with_*` helpers:
+
+```rust
+pub fn issue_response_with_team(
+    key: &str,
+    summary: &str,
+    team_field_id: &str,
+    team_uuid: &str,
+) -> Value {
+    let mut response = issue_response(key, summary, "To Do");
+    response["fields"][team_field_id] = json!(team_uuid);
+    response
+}
+```
+
+The existing `issue_response` produces the base JSON; we inject the team customfield into `fields`.
+
+- [ ] **Step 3.2: Write failing handler tests**
+
+In `tests/cli_handler.rs`, append three new tests at the end of the file. First, a constant for the test field id near the other helpers at the top:
+
+```rust
+const TEST_TEAM_FIELD_ID: &str = "customfield_10100";
+```
+
+Then the three tests:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_view_renders_team_name_when_cached() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/HDL-500"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            common::fixtures::issue_response_with_team(
+                "HDL-500",
+                "Team cached",
+                TEST_TEAM_FIELD_ID,
+                "team-uuid-abc",
+            ),
+        ))
+        .mount(&server)
+        .await;
+
+    // For this test to work, the team cache must contain team-uuid-abc => "Platform".
+    // The subagent must configure TEST_JR_CONFIG_DIR / pre-populate
+    // ~/.cache/jr/teams.json via an env var override. If no such override exists,
+    // inspect cache.rs to see what env var controls the cache directory and use
+    // a tempdir — then pre-write the team cache before running jr.
+    //
+    // Also, JR_CONFIG_FILE (or equivalent) must set team_field_id = TEST_TEAM_FIELD_ID
+    // in the [fields] section. Inspect config.rs for the env var / config path override.
+    //
+    // If no such overrides exist, add them as a minimal scaffolding change in this task
+    // (e.g., JR_CACHE_DIR and JR_CONFIG_PATH env vars that config.rs / cache.rs honor
+    // only when set). Keep the scaffolding generic — do not hard-code team-specific
+    // paths.
+
+    jr_cmd(&server.uri())
+        .args(["issue", "view", "HDL-500"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "\"{}\": \"team-uuid-abc\"",
+            TEST_TEAM_FIELD_ID
+        )));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_view_renders_team_uuid_when_not_cached() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/HDL-501"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            common::fixtures::issue_response_with_team(
+                "HDL-501",
+                "Team uncached",
+                TEST_TEAM_FIELD_ID,
+                "team-uuid-unknown",
+            ),
+        ))
+        .mount(&server)
+        .await;
+
+    jr_cmd(&server.uri())
+        .args(["issue", "view", "HDL-501"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("team-uuid-unknown"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_view_omits_team_row_when_field_unconfigured() {
+    // In this test, the test config must have team_field_id = None.
+    // Response still contains the field but should be ignored.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/HDL-502"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            common::fixtures::issue_response("HDL-502", "No team field", "To Do"),
+        ))
+        .mount(&server)
+        .await;
+
+    // Assert the JSON output succeeds — row omission is a table-mode concern,
+    // so this test just confirms no crash and no team-related output appears.
+    jr_cmd(&server.uri())
+        .args(["issue", "view", "HDL-502"])
+        .assert()
+        .success();
+}
+```
+
+**Test scaffolding pattern:**
+
+- `src/cache.rs:60-68` — `cache_dir()` honors `XDG_CACHE_HOME`.
+- `src/config.rs:130-140` — config loader honors `XDG_CONFIG_HOME`.
+- **CRITICAL** — `cli_handler.rs` tests spawn the `jr` binary via `assert_cmd::Command::cargo_bin("jr")`. Env vars set via `std::env::set_var` in the test body do **not** propagate to the spawned child (Perplexity-validated 2026-04-15). The existing `project_meta.rs` pattern uses `set_var` because it invokes `jr::` library functions in-process — that pattern is **not applicable here**. Instead, pass XDG vars explicitly via `.env()` on the `Command` builder:
+
+```rust
+let cache_dir = tempfile::tempdir().unwrap();
+let config_dir = tempfile::tempdir().unwrap();
+
+// Pre-populate team cache
+let teams_dir = cache_dir.path().join("jr");
+std::fs::create_dir_all(&teams_dir).unwrap();
+let cache = jr::cache::TeamCache {
+    fetched_at: chrono::Utc::now(),
+    teams: vec![
+        jr::cache::CachedTeam {
+            id: "team-uuid-abc".into(),
+            name: "Platform".into(),
+        },
+        jr::cache::CachedTeam {
+            id: "team-uuid-platform-ops".into(),
+            name: "Platform Ops".into(),
+        },
+    ],
+};
+std::fs::write(
+    teams_dir.join("teams.json"),
+    serde_json::to_string(&cache).unwrap(),
+).unwrap();
+
+// Pre-populate config with team_field_id
+let conf_dir = config_dir.path().join("jr");
+std::fs::create_dir_all(&conf_dir).unwrap();
+std::fs::write(
+    conf_dir.join("config.toml"),
+    "[fields]\nteam_field_id = \"customfield_10100\"\n",
+).unwrap();
+
+// Use a bespoke command builder that sets XDG vars via .env()
+let mut cmd = assert_cmd::Command::cargo_bin("jr").unwrap();
+cmd.env("JR_BASE_URL", server.uri())
+    .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+    .env("XDG_CACHE_HOME", cache_dir.path())
+    .env("XDG_CONFIG_HOME", config_dir.path())
+    .arg("--no-input")
+    .arg("--output")
+    .arg("json");
+// then cmd.args(...).assert().success()...
+```
+
+Since the existing `jr_cmd()` helper in `cli_handler.rs` does not accept XDG overrides, extract a new helper `jr_cmd_with_xdg(server_uri, cache_dir, config_dir)` at the top of the file (next to the existing `jr_cmd`) and use it for the team-related tests. Keep the existing `jr_cmd` unchanged for tests that don't need XDG overrides.
+
+**Env mutex is NOT needed** for this approach — each `Command` carries its own explicit env, so there's no shared process-wide state to serialize. Tests can stay at `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]` to match other handler tests in the file.
+
+- [ ] **Step 3.3: Run the tests to verify they fail**
+
+Run:
+```bash
+cargo test --test cli_handler test_view_renders_team
+cargo test --test cli_handler test_view_omits_team_row
+```
+
+Expected: FAIL — the JSON output currently does not include the team customfield because `extra_fields` doesn't fetch it.
+
+- [ ] **Step 3.4: Extend `extra_fields` in `handle_view`**
+
+In `src/cli/issue/list.rs`, find the block around line 699:
+
+```rust
+    let mut extra: Vec<&str> = sp_field_id.iter().copied().collect();
+    for f in &cmdb_field_id_list {
+        extra.push(f.as_str());
+    }
+    let mut issue = client.get_issue(&key, &extra).await?;
+```
+
+Replace with:
+
+```rust
+    let team_field_id: Option<&str> = config.global.fields.team_field_id.as_deref();
+
+    let mut extra: Vec<&str> = sp_field_id.iter().copied().collect();
+    for f in &cmdb_field_id_list {
+        extra.push(f.as_str());
+    }
+    if let Some(t) = team_field_id {
+        extra.push(t);
+    }
+    let mut issue = client.get_issue(&key, &extra).await?;
+```
+
+- [ ] **Step 3.5: Render the team row in the table output**
+
+In the same `handle_view` function, find the block that renders the story points row (around lines 908-915):
+
+```rust
+    if let Some(field_id) = sp_field_id {
+        let points_display = ...
+        rows.push(vec!["Points".into(), points_display]);
+    }
+```
+
+Add a similar block immediately after for the team row:
+
+```rust
+    if let Some(field_id) = team_field_id {
+        if let Some(team_uuid) = issue.fields.team_id(field_id) {
+            let team_display = match crate::cache::read_team_cache()
+                .ok()
+                .flatten()
+                .and_then(|c| c.teams.into_iter().find(|t| t.id == team_uuid))
+            {
+                Some(cached) => cached.name,
+                None => format!(
+                    "{} (name not cached — run 'jr team list --refresh')",
+                    team_uuid
+                ),
+            };
+            rows.push(vec!["Team".into(), team_display]);
+        }
+    }
+```
+
+Verify `crate::cache::read_team_cache` returns the type suggested — if the cache module uses different names (e.g., `CachedTeamList`, `.teams` vs `.data`), adapt the lookup accordingly by reading `src/cache.rs`. The structure check was already confirmed in the helpers module (`helpers.rs:29-32`), so this pattern mirrors what's already used for team resolution.
+
+- [ ] **Step 3.6: Run the failing tests to verify they now pass**
+
+Run:
+```bash
+cargo test --test cli_handler test_view_renders_team
+cargo test --test cli_handler test_view_omits_team_row
+```
+
+Expected: PASS.
+
+- [ ] **Step 3.7: Run the full test suite**
+
+Run:
+```bash
+cargo test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3.8: Run lint and format checks**
+
+Run:
+```bash
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: both clean.
+
+- [ ] **Step 3.9: Commit**
+
+```bash
+git add src/cli/issue/list.rs tests/cli_handler.rs tests/common/fixtures.rs
+git commit -m "feat: show team field on issue view (#182)"
+```
+
+
+---
+
+### Task 4: Handler test — strict matching rejects `--team` substring under `--no-input`
+
+**Files:**
+- Modify: `tests/cli_handler.rs` (append one new test)
+
+- [ ] **Step 4.1: Write the failing test**
+
+Append to `tests/cli_handler.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_edit_team_substring_rejects_under_no_input() {
+    let server = MockServer::start().await;
+
+    // No PUT mock — if the assertion is right, no HTTP call should happen.
+    // The cache must contain a team like "Platform Ops" so that "Ops" would
+    // have matched as a substring under the old behavior.
+    //
+    // Pre-populate the team cache via the test override from Task 3 so that
+    // the single-team entry is "Platform Ops" with id "team-uuid-platform-ops".
+
+    jr_cmd(&server.uri())
+        .args(["issue", "edit", "HDL-600", "--team", "Ops"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Ambiguous"))
+        .stderr(predicate::str::contains("Platform Ops"));
+}
+```
+
+- [ ] **Step 4.2: Run the test**
+
+Run:
+```bash
+cargo test --test cli_handler test_edit_team_substring_rejects_under_no_input
+```
+
+Expected: PASS (this is already the new behavior after Task 1 — this test locks the guarantee).
+
+If it fails, verify the team cache fixture setup from Task 3 is producing the expected cached team and the subagent is pre-populating it for this test.
+
+- [ ] **Step 4.3: Run the full test suite**
+
+Run:
+```bash
+cargo test
+```
+
+Expected: all pass.
+
+- [ ] **Step 4.4: Run lint and format checks**
+
+```bash
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add tests/cli_handler.rs
+git commit -m "test: lock strict matching behavior for --team under --no-input (#181)"
+```
+
+---
+
+## Spec Coverage Checklist
+
+| Spec Requirement | Task |
+|------------------|------|
+| `partial_match` collapses `1 => Exact` into `Ambiguous` | Task 1 (Step 1.5) |
+| Existing unit tests updated to expect new behavior | Task 1 (Steps 1.1, 1.2) |
+| Existing integration test updated | Task 1 (Step 1.4) |
+| All 8 call sites route `Ambiguous` correctly | Codebase audit in spec — no code change needed; verified by `cargo test` passing in Task 1 Step 1.6 |
+| `team_id` helper on `IssueFields` | Task 2 |
+| `extra_fields` extended with team field in view | Task 3 (Step 3.4) |
+| Team row rendered in view table | Task 3 (Step 3.5) |
+| Row omitted when team field unconfigured | Task 3 (Step 3.5 — guarded by `if let Some(field_id) = team_field_id`) |
+| Row omitted when UUID absent or null | Task 3 (Step 3.5 — guarded by `team_id()` returning `None`) |
+| Fallback text when UUID not in cache | Task 3 (Step 3.5 — match arm on `read_team_cache`) |
+| JSON output unchanged (raw customfield passes through) | Task 3 (Step 3.2 — the team-cached test asserts on JSON output containing the raw UUID) |
+| Handler test: team cached + rendered | Task 3 (Step 3.2) |
+| Handler test: team UUID uncached fallback | Task 3 (Step 3.2) |
+| Handler test: field unconfigured | Task 3 (Step 3.2) |
+| Handler test: --team substring under --no-input errors | Task 4 |
+
+## Self-review notes
+
+- **Config/cache overrides** (Task 3 Step 3.2): the test scaffolding needs env var overrides for config and cache paths. If these don't already exist, the subagent adds them as minimal, purpose-neutral additions (not team-specific). This is a prerequisite for Task 3 and Task 4 — inspect before writing the tests.
+- **Render ordering**: the team row sits next to the story points row in the view table. Position it after Points for consistency with the existing columns (both are custom fields).
+- **TTY single-item prompt UX**: not tested under TTY (handler tests run headless with `--no-input`). The TTY path continues to work via the existing `dialoguer::Select` code — no new test coverage added since `--no-input` is the assertion surface that matters for agents.

--- a/docs/superpowers/specs/2026-04-15-team-field-and-strict-matching-design.md
+++ b/docs/superpowers/specs/2026-04-15-team-field-and-strict-matching-design.md
@@ -1,0 +1,176 @@
+# Strict Name Matching + Team Field on `issue view`
+
+> **Issues:** #181 — `issue create/edit: --team silently dropped when value not in cache`
+> **Issues:** #182 — `issue view: team field missing from fetch whitelist`
+> **Also closes:** #192 — `refactor: apply exact→prefix→disambiguate matching to user/status/asset/queue resolvers`
+
+## Problem
+
+### #181 — silent mis-resolution (root cause)
+
+`partial_match` currently returns `MatchResult::Exact(first)` when exactly one **substring** match is found (`src/partial_match.rs:40`). This means `--team "Ops"` silently resolves to `"Platform Ops"` if that's the only team containing "Ops" in the cache. The user intends to reference a different team that isn't cached, but the CLI applies the wrong value without warning.
+
+The issue title says "silently dropped" but the actual behavior is silent **mis-resolution** — the PUT succeeds with the wrong team ID. From the user's perspective it reads as dropped because `jr issue view` can't show the team value (issue #182), and filtering `jr issue list --team "<intended>"` returns the same empty result as if the team were never set.
+
+This footgun exists across all eight `partial_match` call sites: team, user, status (move + list filter), link type (link + unlink), queue, asset. Every one of them silently picks a substring match when there's exactly one hit.
+
+### #182 — team field not visible on view
+
+`BASE_ISSUE_FIELDS` (`src/api/jira/issues.rs:12-29`) does not include the team custom field. `handle_view` (`src/cli/issue/list.rs:699`) only adds story points + CMDB fields to `extra_fields`. Even when a team is set correctly, `jr issue view` has no way to display it — the user cannot verify their own `--team` assignments.
+
+## Design
+
+### Core Change — `partial_match` rejects silent substring hits
+
+Change the substring-fallback arm in `src/partial_match.rs`:
+
+```rust
+// before
+match matches.len() {
+    0 => MatchResult::None(candidates.to_vec()),
+    1 => MatchResult::Exact(matches.into_iter().next().unwrap()),
+    _ => MatchResult::Ambiguous(matches),
+}
+
+// after
+match matches.len() {
+    0 => MatchResult::None(candidates.to_vec()),
+    _ => MatchResult::Ambiguous(matches),
+}
+```
+
+This collapses `1` and `n>1` into the same `Ambiguous` branch. Callers already route `Ambiguous` to an interactive prompt (TTY) or a bail with candidate list (`--no-input`). No new disambiguation code needed.
+
+`MatchResult::Exact` is now only produced by the case-insensitive **exact** match path (`src/partial_match.rs:19-29`). This is the invariant the name is supposed to carry.
+
+Validation: `gh` and `kubectl` both use exact-only resource resolution — silent substring matching is an anti-pattern (Perplexity/Context7 validation, 2026-04-15).
+
+### Impact on call sites
+
+All eight call sites already handle `Ambiguous` correctly — they were designed for the `n>1` case and the same code path handles `n==1` without modification:
+
+| File | Behavior (TTY) | Behavior (`--no-input`) |
+|---|---|---|
+| `src/cli/issue/helpers.rs` (team) | `dialoguer::Select` prompt | `bail!` with candidate list |
+| `src/cli/issue/helpers.rs` (user via `disambiguate_user`) | `dialoguer::Select` prompt | `bail!` with candidate list |
+| `src/cli/issue/workflow.rs` (status transition) | numbered `prompt_input` | `bail!` with candidate list |
+| `src/cli/issue/list.rs` (status filter) | n/a — no TTY prompt for list filter | `JrError::UserError` with candidate list |
+| `src/cli/issue/links.rs` (link + unlink) | `dialoguer::Select` prompt | `bail!` with candidate list |
+| `src/cli/queue.rs` (queue resolve x2) | `dialoguer::Select` via existing list-match path | error with candidates |
+
+`list.rs`'s status filter currently errors in all modes (no TTY prompt) — this is existing behavior and we keep it. A status filter is pipe-friendly and prompting there would block scripts.
+
+### User-visible behavior change
+
+Before this change:
+```
+$ jr issue move FOO-1 "prog"         # TTY or --no-input: silently resolves to "In Progress"
+Moved FOO-1 to In Progress
+```
+
+After:
+```
+$ jr issue move FOO-1 "prog" --no-input
+Error: Ambiguous transition "prog". Matches: In Progress
+
+$ jr issue move FOO-1 "prog"          # TTY
+Ambiguous match for "prog". Did you mean one of:
+  1. In Progress
+Select (number): 1
+Moved FOO-1 to In Progress
+```
+
+Single-item prompts are slightly awkward UX but acceptable — the existing `Ambiguous` path renders them without crashing. This is a follow-up refinement candidate, not a blocker.
+
+### Team Field on `issue view` (#182)
+
+Four ordered changes in `src/cli/issue/list.rs` (inside `handle_view`):
+
+1. **Extend `extra_fields`** — after the existing `sp_field_id` and `cmdb_field_id_list` collection, append `config.global.fields.team_field_id` when set.
+2. **Read the field value** — after `client.get_issue(&key, &extra).await?`, extract the UUID from `issue.fields.extra.get(team_field_id)` (the `extra: HashMap<String, Value>` field is `#[serde(flatten)]` and already captures all custom fields; the existing `story_points(field_id)` helper uses the same map). Add a sibling helper `team_id(field_id: &str) -> Option<String>` that returns `self.extra.get(field_id)?.as_str().map(String::from)`. Atlassian Teams field returns a bare UUID string per Perplexity validation against `developer.atlassian.com/platform/teams/components/team-field-in-jira-rest-api/`. When the field has never been set, Jira **omits the key entirely** from the response (it is not returned as explicit `null`); `extra.get(field_id)` returns `None` in that case. The rare explicit-`null` case (e.g. from a changelog or webhook expansion) also yields `None` via `.as_str()`, so both are handled by a single helper that returns `Option<String>`.
+3. **Resolve UUID → name** via `cache::read_team_cache()` (already populated by `jr team list` / `jr init`). The cache lookup is synchronous and adds no API calls.
+4. **Render a row** in the table:
+
+| Scenario | Row |
+|---|---|
+| Field unconfigured (`team_field_id` is `None`) | row omitted |
+| Field absent from response (never set) or explicit `null` | row omitted |
+| UUID in cache | `Team: <Name>` |
+| UUID not in cache | `Team: <uuid> (name not cached — run 'jr team list --refresh')` |
+
+The row is inserted in the same block that handles story points (around `list.rs:908-915`) for consistency.
+
+JSON output is unchanged — the raw `customfield_<id>` passes through `serde_json::to_value` as before. Agents already parse it.
+
+### Out of scope (tracked separately)
+
+| Item | Issue |
+|---|---|
+| Auto-refresh team cache on miss + UUID pass-through | #190 |
+| Team column in `issue list` output | #191 |
+| Refine single-item `Ambiguous` prompt into y/N confirmation | not filed — minor UX polish |
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `src/partial_match.rs` | Collapse substring `1 => Exact` arm into `Ambiguous` |
+| `src/partial_match.rs` tests | Update `test_partial_match_unique` to expect `Ambiguous` (rename → `test_partial_match_single_substring_is_ambiguous`) |
+| `src/cli/issue/list.rs` | Add `team_field_id` to `extra_fields`; extract + render team row in `handle_view` |
+| `src/types/jira/issue.rs` | Add `team_id(field_id: &str) -> Option<String>` helper to `IssueFields` (mirrors the existing `story_points` helper) |
+| `tests/input_validation.rs` | Update `valid_status_partial_match_resolves` to expect `Ambiguous` |
+| `tests/cli_handler.rs` or new `tests/issue_view.rs` | Add handler tests: view renders team name when cached, fallback when uncached, row omitted when unconfigured |
+| `tests/issue_commands.rs` (if exists) or similar | Add test: `--team "partial-name"` under `--no-input` errors with candidate list; exact match still succeeds |
+
+Anything using substring-match behavior in existing tests surfaces during `cargo test` and updates in the same commit as `partial_match.rs`.
+
+## Error handling
+
+| Scenario | Behavior | Exit |
+|---|---|---|
+| `partial_match` returns `Ambiguous` with 1 hit, `--no-input` | `bail!` with candidate list, existing message per call site | 1 (anyhow) or 64 (`JrError::UserError`) — unchanged per call site |
+| `partial_match` returns `Ambiguous` with 1 hit, TTY | Existing `dialoguer::Select` or `prompt_input` — user picks or aborts | 0 on pick, 130 on Ctrl-C |
+| `view` with unconfigured team field | Row omitted, no error | 0 |
+| `view` with team UUID not in cache | Row renders with fallback text | 0 |
+| `view` JSON output | Raw customfield value in response — unchanged | 0 |
+
+## Testing
+
+**Unit tests** (`src/partial_match.rs`):
+- Exact CI match → `Exact` (unchanged)
+- Exact CI multiple → `ExactMultiple` (unchanged)
+- Substring 0 hits → `None` (unchanged)
+- Substring 1 hit → **`Ambiguous([hit])`** (changed)
+- Substring n>1 hits → `Ambiguous([hits])` (unchanged)
+
+**Integration tests** (`tests/input_validation.rs`):
+- `valid_status_partial_match_resolves` → updated to expect `Ambiguous`
+- `ambiguous_status_returns_multiple_matches` → unchanged (already tests n>1)
+
+**Handler tests** (`tests/cli_handler.rs` or dedicated file):
+- `issue view` with team field configured + UUID in cache → table row `Team: <Name>` appears, JSON has raw customfield
+- `issue view` with team field configured + UUID not in cache → row renders with fallback text
+- `issue view` with team field not configured → no team row, no error
+- `issue edit --team "<substring>" --no-input` → errors with candidate list, exit 1
+- `issue edit --team "<exact-name>" --no-input` → succeeds
+
+**Snapshot tests** (`insta`) — extend existing `issue view` snapshot if present to cover team row.
+
+## Alignment with project conventions
+
+- **Thin client, no abstraction layer** — change is in matching logic and an existing extra_fields extension pattern. No new abstraction.
+- **Machine-output-first** — `--output json` unchanged. Team field passes through raw.
+- **Non-interactive by default** — strict matching under `--no-input` is the whole point. TTY users get a one-item prompt (acceptable).
+- **Idempotent read operations** — `view` remains a pure GET.
+- **Breaking change, pre-1.0 tool** — matches the stderr/stdout migration (#134) and fits the documented project vision of being a tighter agentic CLI. Users relying on substring matching in scripts must switch to exact names; the migration path is already documented in error messages.
+
+## Validation
+
+- **Perplexity (2026-04-15):** `gh` uses exact API-level match; `kubectl` uses exact match (the `kubectl get pod nginx` call is literally a GET to `/api/v1/.../pods/nginx` — no client-side fuzzing); silent substring matching flagged as anti-pattern by both.
+- **Perplexity (2026-04-15):** Atlassian Teams custom field returns a bare UUID string on `GET /rest/api/3/issue/{key}?fields=customfield_NNNNN`. Read and write shapes are symmetric (same bare string). When the field has never been set, Jira **omits the key entirely** from the response rather than returning `null` — both cases converge to `None` in the helper. Source: `developer.atlassian.com/platform/teams/components/team-field-in-jira-rest-api/`.
+- **Perplexity (2026-04-15):** `#[serde(flatten)] HashMap<String, Value>` preserves the distinction — explicit `null` in JSON becomes `Value::Null` in the map; absent keys have no entry. Spec uses `.get(field_id).and_then(|v| v.as_str())` which collapses both cases safely.
+- **Perplexity (2026-04-15):** `dialoguer::Select` with a single-item list renders a normal prompt requiring Enter (no auto-select, no error). UX is functional; single-item `Ambiguous` prompts remain acceptable in TTY mode.
+- **Perplexity (2026-04-15):** Jira Cloud v3 returns custom field keys in response bodies verbatim in `customfield_NNNNN` form — no lowercase conversion, renaming, or aliasing. `HashMap::get("customfield_10001")` is safe without case-insensitive lookup. Confirmed by Context7-indexed example at `developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-fields/` (field creation response echoes `"id": "customfield_10101"` / `"key": "customfield_10101"` — same form used in issue GET responses).
+- **Perplexity (2026-04-15):** CLI convention for single-candidate "did you mean" disambiguation favors scriptable suggestion + bail under `--no-input`, prompt-if-you-can in TTY — which is exactly the existing `Ambiguous` branch behavior this spec routes single-hit substrings through. No new interaction pattern needed.
+- **Codebase audit:** all 8 `partial_match` call sites already route `Ambiguous` through the correct TTY/`--no-input` branches. No new wiring needed.
+- **Test audit:** only `test_partial_match_unique` (unit) and `valid_status_partial_match_resolves` (integration) assert the old `1 => Exact` behavior. Both update in the same commit as the core fix.

--- a/src/cli/assets.rs
+++ b/src/cli/assets.rs
@@ -827,14 +827,17 @@ mod tests {
     }
 
     #[test]
-    fn filter_status_partial_match() {
+    fn filter_status_single_substring_is_ambiguous() {
+        // Single substring hits are now Ambiguous — callers must use the exact name.
         let tickets = vec![
             make_ticket("A-1", "In Progress", "yellow"),
             make_ticket("A-2", "Done", "green"),
         ];
-        let result = filter_tickets(tickets, false, Some("prog")).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].key, "A-1");
+        let result = filter_tickets(tickets, false, Some("prog"));
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Ambiguous"), "got: {err}");
+        assert!(err.contains("In Progress"), "got: {err}");
     }
 
     #[test]
@@ -988,10 +991,13 @@ mod tests {
     }
 
     #[test]
-    fn resolve_schema_partial_name_match() {
+    fn resolve_schema_single_substring_is_ambiguous() {
+        // Single substring hits are now Ambiguous — callers must use the exact name.
         let schemas = vec![make_schema("10", "ITSM Assets"), make_schema("20", "HR")];
-        let result = super::resolve_schema("itsm", &schemas).unwrap();
-        assert_eq!(result.id, "10");
+        let err = super::resolve_schema("itsm", &schemas).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Ambiguous"), "got: {msg}");
+        assert!(msg.contains("ITSM Assets"), "got: {msg}");
     }
 
     #[test]

--- a/src/cli/issue/list.rs
+++ b/src/cli/issue/list.rs
@@ -920,16 +920,26 @@ pub(super) async fn handle_view(
 
             if let Some(field_id) = team_field_id {
                 if let Some(team_uuid) = issue.fields.team_id(field_id) {
-                    let team_display = match crate::cache::read_team_cache()
-                        .ok()
-                        .flatten()
-                        .and_then(|c| c.teams.into_iter().find(|t| t.id == team_uuid))
-                    {
-                        Some(cached) => cached.name,
-                        None => format!(
+                    let team_display = match crate::cache::read_team_cache() {
+                        Ok(Some(c)) => c
+                            .teams
+                            .into_iter()
+                            .find(|t| t.id == team_uuid)
+                            .map(|t| t.name)
+                            .unwrap_or_else(|| {
+                                format!(
+                                    "{} (name not cached — run 'jr team list --refresh')",
+                                    team_uuid
+                                )
+                            }),
+                        Ok(None) => format!(
                             "{} (name not cached — run 'jr team list --refresh')",
                             team_uuid
                         ),
+                        Err(e) => {
+                            eprintln!("warning: failed to read team cache: {e}");
+                            format!("{} (team cache unreadable)", team_uuid)
+                        }
                     };
                     rows.push(vec!["Team".into(), team_display]);
                 }

--- a/src/cli/issue/list.rs
+++ b/src/cli/issue/list.rs
@@ -690,11 +690,15 @@ pub(super) async fn handle_view(
     };
 
     let sp_field_id = config.global.fields.story_points_field_id.as_deref();
+    let team_field_id: Option<&str> = config.global.fields.team_field_id.as_deref();
     let cmdb_fields = get_or_fetch_cmdb_fields(client).await.unwrap_or_default();
     let cmdb_field_id_list = cmdb_field_ids(&cmdb_fields);
     let mut extra: Vec<&str> = sp_field_id.iter().copied().collect();
     for f in &cmdb_field_id_list {
         extra.push(f.as_str());
+    }
+    if let Some(t) = team_field_id {
+        extra.push(t);
     }
     let mut issue = client.get_issue(&key, &extra).await?;
 
@@ -912,6 +916,23 @@ pub(super) async fn handle_view(
                     .map(format::format_points)
                     .unwrap_or_else(|| "(none)".into());
                 rows.push(vec!["Points".into(), points_display]);
+            }
+
+            if let Some(field_id) = team_field_id {
+                if let Some(team_uuid) = issue.fields.team_id(field_id) {
+                    let team_display = match crate::cache::read_team_cache()
+                        .ok()
+                        .flatten()
+                        .and_then(|c| c.teams.into_iter().find(|t| t.id == team_uuid))
+                    {
+                        Some(cached) => cached.name,
+                        None => format!(
+                            "{} (name not cached — run 'jr team list --refresh')",
+                            team_uuid
+                        ),
+                    };
+                    rows.push(vec!["Team".into(), team_display]);
+                }
             }
 
             rows.push(vec!["Description".into(), desc_text]);

--- a/src/cli/queue.rs
+++ b/src/cli/queue.rs
@@ -225,9 +225,11 @@ mod tests {
     }
 
     #[test]
-    fn partial_match() {
+    fn single_substring_is_ambiguous() {
+        // Single substring hits are now Ambiguous — callers must use the exact name.
         let queues = vec![make_queue("10", "Triage"), make_queue("20", "In Progress")];
-        assert_eq!(find_queue_id("tri", &queues).unwrap(), "10");
+        let err = find_queue_id("tri", &queues).unwrap_err();
+        assert!(err.starts_with("ambiguous"), "got: {err}");
     }
 
     #[test]

--- a/src/partial_match.rs
+++ b/src/partial_match.rs
@@ -37,7 +37,6 @@ pub fn partial_match(input: &str, candidates: &[String]) -> MatchResult {
 
     match matches.len() {
         0 => MatchResult::None(candidates.to_vec()),
-        1 => MatchResult::Exact(matches.into_iter().next().unwrap()),
         _ => MatchResult::Ambiguous(matches),
     }
 }
@@ -64,10 +63,14 @@ mod tests {
     }
 
     #[test]
-    fn test_partial_match_unique() {
+    fn test_partial_match_single_substring_is_ambiguous() {
+        // Single substring hits route through Ambiguous so callers can
+        // prompt (TTY) or error (--no-input) — never silently resolve.
         match partial_match("prog", &candidates()) {
-            MatchResult::Exact(s) => assert_eq!(s, "In Progress"),
-            _ => panic!("Expected unique match"),
+            MatchResult::Ambiguous(matches) => {
+                assert_eq!(matches, vec!["In Progress".to_string()]);
+            }
+            other => panic!("Expected Ambiguous, got {:?}", other),
         }
     }
 
@@ -92,10 +95,12 @@ mod tests {
     }
 
     #[test]
-    fn test_blocked_unique() {
+    fn test_blocked_single_substring_is_ambiguous() {
         match partial_match("block", &candidates()) {
-            MatchResult::Exact(s) => assert_eq!(s, "Blocked"),
-            _ => panic!("Expected unique match"),
+            MatchResult::Ambiguous(matches) => {
+                assert_eq!(matches, vec!["Blocked".to_string()]);
+            }
+            other => panic!("Expected Ambiguous, got {:?}", other),
         }
     }
 

--- a/src/partial_match.rs
+++ b/src/partial_match.rs
@@ -5,7 +5,8 @@ pub enum MatchResult {
     Exact(String),
     /// Multiple candidates share the same exact (case-insensitive) name — carries the first matching candidate
     ExactMultiple(String),
-    /// Multiple matches — caller should prompt for disambiguation
+    /// Non-exact matches (one or more substring hits) — caller should prompt
+    /// for disambiguation (TTY) or error with the candidate list (--no-input)
     Ambiguous(Vec<String>),
     /// No matches
     None(Vec<String>),

--- a/src/types/jira/issue.rs
+++ b/src/types/jira/issue.rs
@@ -83,6 +83,10 @@ impl IssueFields {
     pub fn story_points(&self, field_id: &str) -> Option<f64> {
         self.extra.get(field_id)?.as_f64()
     }
+
+    pub fn team_id(&self, field_id: &str) -> Option<String> {
+        self.extra.get(field_id)?.as_str().map(String::from)
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -169,6 +173,36 @@ pub struct CreateIssueResponse {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    fn fields_with_extra(key: &str, value: serde_json::Value) -> IssueFields {
+        let mut fields = IssueFields::default();
+        fields.extra.insert(key.to_string(), value);
+        fields
+    }
+
+    #[test]
+    fn team_id_reads_string_value() {
+        let fields = fields_with_extra(
+            "customfield_10001",
+            json!("36885b3c-1bf0-4f85-a357-c5b858c31de4"),
+        );
+        assert_eq!(
+            fields.team_id("customfield_10001"),
+            Some("36885b3c-1bf0-4f85-a357-c5b858c31de4".to_string())
+        );
+    }
+
+    #[test]
+    fn team_id_returns_none_for_null_value() {
+        let fields = fields_with_extra("customfield_10001", json!(null));
+        assert_eq!(fields.team_id("customfield_10001"), None);
+    }
+
+    #[test]
+    fn team_id_returns_none_for_missing_key() {
+        let fields = IssueFields::default();
+        assert_eq!(fields.team_id("customfield_10001"), None);
+    }
 
     #[test]
     fn story_points_present() {

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -30,6 +30,30 @@ fn jr_api_cmd(server_uri: &str) -> Command {
     cmd
 }
 
+/// Build a `jr` command with explicit XDG overrides for cache and config dirs.
+///
+/// Required for tests that need to pre-populate the team cache or set a custom
+/// config (e.g. `team_field_id`). Env vars set via `std::env::set_var` do NOT
+/// propagate to spawned child processes — must use `.env()` on the Command.
+///
+/// Uses table output mode so the rendered team row is testable.
+fn jr_cmd_with_xdg(
+    server_uri: &str,
+    cache_dir: &std::path::Path,
+    config_dir: &std::path::Path,
+) -> Command {
+    let mut cmd = Command::cargo_bin("jr").unwrap();
+    cmd.env("JR_BASE_URL", server_uri)
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir)
+        .env("XDG_CONFIG_HOME", config_dir)
+        .arg("--no-input");
+    // Default output is table; no --output flag so we get the rendered table.
+    cmd
+}
+
+const TEST_TEAM_FIELD_ID: &str = "customfield_10100";
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_handler_assign_with_account_id() {
     let server = MockServer::start().await;
@@ -1411,4 +1435,135 @@ async fn test_create_table_mode_outputs_to_stderr() {
         .stdout(predicate::str::is_empty())
         .stderr(predicate::str::contains("Created issue HDL-300"))
         .stderr(predicate::str::contains("/browse/HDL-300"));
+}
+
+/// Helper: pre-populate team cache at the given XDG cache dir root.
+fn write_test_team_cache(cache_home: &std::path::Path) {
+    let teams_dir = cache_home.join("jr");
+    std::fs::create_dir_all(&teams_dir).unwrap();
+    let cache = jr::cache::TeamCache {
+        fetched_at: chrono::Utc::now(),
+        teams: vec![
+            jr::cache::CachedTeam {
+                id: "team-uuid-abc".into(),
+                name: "Platform".into(),
+            },
+            jr::cache::CachedTeam {
+                id: "team-uuid-platform-ops".into(),
+                name: "Platform Ops".into(),
+            },
+        ],
+    };
+    std::fs::write(
+        teams_dir.join("teams.json"),
+        serde_json::to_string(&cache).unwrap(),
+    )
+    .unwrap();
+}
+
+/// Helper: write a config.toml with team_field_id set to TEST_TEAM_FIELD_ID.
+fn write_test_config_with_team_field(config_home: &std::path::Path) {
+    let conf_dir = config_home.join("jr");
+    std::fs::create_dir_all(&conf_dir).unwrap();
+    std::fs::write(
+        conf_dir.join("config.toml"),
+        format!("[fields]\nteam_field_id = \"{TEST_TEAM_FIELD_ID}\"\n"),
+    )
+    .unwrap();
+}
+
+/// Team view tests use table mode (no --output flag) so that the Team row
+/// rendering is tested end-to-end, not just the raw JSON passthrough.
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_view_renders_team_name_when_cached() {
+    // Table mode: when team_field_id is configured and the UUID is in the local
+    // team cache, the view should display the resolved team name ("Platform").
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/HDL-500"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            common::fixtures::issue_response_with_team(
+                "HDL-500",
+                "Team cached",
+                TEST_TEAM_FIELD_ID,
+                "team-uuid-abc",
+            ),
+        ))
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    write_test_team_cache(cache_dir.path());
+    write_test_config_with_team_field(config_dir.path());
+
+    jr_cmd_with_xdg(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "view", "HDL-500"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Team"))
+        .stdout(predicate::str::contains("Platform"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_view_renders_team_uuid_fallback_when_not_cached() {
+    // Table mode: when team_field_id is configured but the UUID is not in the
+    // team cache, the view should display the raw UUID with a fallback hint.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/HDL-501"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            common::fixtures::issue_response_with_team(
+                "HDL-501",
+                "Team uncached",
+                TEST_TEAM_FIELD_ID,
+                "team-uuid-unknown",
+            ),
+        ))
+        .mount(&server)
+        .await;
+
+    // Empty cache dir (no teams.json) — UUID should appear with fallback text.
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    write_test_config_with_team_field(config_dir.path());
+
+    jr_cmd_with_xdg(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "view", "HDL-501"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Team"))
+        .stdout(predicate::str::contains("team-uuid-unknown"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_view_omits_team_row_when_field_unconfigured() {
+    // Table mode: when team_field_id is not configured, no "Team" row should
+    // appear. Confirms no crash and no team-related output.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/HDL-502"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(common::fixtures::issue_response(
+                "HDL-502",
+                "No team field",
+                "To Do",
+            )),
+        )
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    // Write a config without team_field_id (empty [fields] section)
+    let conf_dir = config_dir.path().join("jr");
+    std::fs::create_dir_all(&conf_dir).unwrap();
+    std::fs::write(conf_dir.join("config.toml"), "[fields]\n").unwrap();
+
+    jr_cmd_with_xdg(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "view", "HDL-502"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No team field")); // summary present
 }

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -48,7 +48,6 @@ fn jr_cmd_with_xdg(
         .env("XDG_CACHE_HOME", cache_dir)
         .env("XDG_CONFIG_HOME", config_dir)
         .arg("--no-input");
-    // Default output is table; no --output flag so we get the rendered table.
     cmd
 }
 
@@ -1472,13 +1471,8 @@ fn write_test_config_with_team_field(config_home: &std::path::Path) {
     .unwrap();
 }
 
-/// Team view tests use table mode (no --output flag) so that the Team row
-/// rendering is tested end-to-end, not just the raw JSON passthrough.
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_view_renders_team_name_when_cached() {
-    // Table mode: when team_field_id is configured and the UUID is in the local
-    // team cache, the view should display the resolved team name ("Platform").
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/rest/api/3/issue/HDL-500"))
@@ -1508,8 +1502,6 @@ async fn test_view_renders_team_name_when_cached() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_view_renders_team_uuid_fallback_when_not_cached() {
-    // Table mode: when team_field_id is configured but the UUID is not in the
-    // team cache, the view should display the raw UUID with a fallback hint.
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/rest/api/3/issue/HDL-501"))
@@ -1539,8 +1531,6 @@ async fn test_view_renders_team_uuid_fallback_when_not_cached() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_view_omits_team_row_when_field_unconfigured() {
-    // Table mode: when team_field_id is not configured, no "Team" row should
-    // appear. Confirms no crash and no team-related output.
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/rest/api/3/issue/HDL-502"))
@@ -1565,7 +1555,8 @@ async fn test_view_omits_team_row_when_field_unconfigured() {
         .args(["issue", "view", "HDL-502"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("No team field")); // summary present
+        .stdout(predicate::str::contains("No team field")) // summary present
+        .stdout(predicate::str::contains("│ Team").not());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1603,8 +1594,7 @@ async fn test_view_omits_team_row_when_field_absent_from_response() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_edit_team_substring_rejects_under_no_input() {
-    // Locks the guarantee that a single-hit substring does NOT silently resolve
-    // under --no-input (the old 1 => Exact behavior from before Task 1).
+    // Single-hit substring must NOT silently resolve under --no-input.
     //
     // Cache contains "Platform Ops" (id: team-uuid-platform-ops). Passing --team Ops
     // matches only "Platform Ops" as a substring → partial_match returns Ambiguous →

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1567,3 +1567,36 @@ async fn test_view_omits_team_row_when_field_unconfigured() {
         .success()
         .stdout(predicate::str::contains("No team field")); // summary present
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_view_omits_team_row_when_field_absent_from_response() {
+    // Table mode: team_field_id IS configured, but the Jira response does not
+    // include that custom field on the issue. The Team row must be omitted —
+    // team_id() returns None when the key is missing, and the outer
+    // `if let Some(team_uuid)` guard skips rendering entirely.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/ABC-123"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(common::fixtures::issue_response(
+                "ABC-123",
+                "No team set",
+                "To Do",
+            )),
+        )
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    write_test_team_cache(cache_dir.path());
+    write_test_config_with_team_field(config_dir.path());
+
+    jr_cmd_with_xdg(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "view", "ABC-123"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No team set")) // summary present
+        .stdout(predicate::str::contains("│ Team").not()) // no Team field row in table
+        .stdout(predicate::str::contains(TEST_TEAM_FIELD_ID).not()); // no field ID leaking
+}

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -33,10 +33,10 @@ fn jr_api_cmd(server_uri: &str) -> Command {
 /// Build a `jr` command with explicit XDG overrides for cache and config dirs.
 ///
 /// Required for tests that need to pre-populate the team cache or set a custom
-/// config (e.g. `team_field_id`). Env vars set via `std::env::set_var` do NOT
-/// propagate to spawned child processes — must use `.env()` on the Command.
-///
-/// Uses table output mode so the rendered team row is testable.
+/// config (e.g. `team_field_id`). Use `.env()` on the spawned `Command`
+/// instead of `std::env::set_var` so these overrides stay isolated to this
+/// child process and do not mutate the test process's global environment,
+/// which can cause interference when tests run in parallel.
 fn jr_cmd_with_xdg(
     server_uri: &str,
     cache_dir: &std::path::Path,
@@ -47,7 +47,9 @@ fn jr_cmd_with_xdg(
         .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
         .env("XDG_CACHE_HOME", cache_dir)
         .env("XDG_CONFIG_HOME", config_dir)
-        .arg("--no-input");
+        .arg("--no-input")
+        .arg("--output")
+        .arg("table");
     cmd
 }
 

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1600,3 +1600,27 @@ async fn test_view_omits_team_row_when_field_absent_from_response() {
         .stdout(predicate::str::contains("│ Team").not()) // no Team field row in table
         .stdout(predicate::str::contains(TEST_TEAM_FIELD_ID).not()); // no field ID leaking
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_edit_team_substring_rejects_under_no_input() {
+    // Locks the guarantee that a single-hit substring does NOT silently resolve
+    // under --no-input (the old 1 => Exact behavior from before Task 1).
+    //
+    // Cache contains "Platform Ops" (id: team-uuid-platform-ops). Passing --team Ops
+    // matches only "Platform Ops" as a substring → partial_match returns Ambiguous →
+    // resolve_team_field bails with an error before any HTTP call is made.
+    let server = MockServer::start().await;
+    // Intentionally no PUT or GET mocks — the command must fail before hitting the wire.
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    write_test_team_cache(cache_dir.path());
+    write_test_config_with_team_field(config_dir.path());
+
+    jr_cmd_with_xdg(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "edit", "HDL-600", "--team", "Ops"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Multiple teams match"))
+        .stderr(predicate::str::contains("Platform Ops"));
+}

--- a/tests/common/fixtures.rs
+++ b/tests/common/fixtures.rs
@@ -432,3 +432,15 @@ pub fn create_issue_response(key: &str) -> Value {
         "self": format!("https://test.atlassian.net/rest/api/3/issue/{}", key)
     })
 }
+
+/// Issue response with a team custom field set to a UUID string.
+pub fn issue_response_with_team(
+    key: &str,
+    summary: &str,
+    team_field_id: &str,
+    team_uuid: &str,
+) -> Value {
+    let mut response = issue_response(key, summary, "To Do");
+    response["fields"][team_field_id] = json!(team_uuid);
+    response
+}

--- a/tests/input_validation.rs
+++ b/tests/input_validation.rs
@@ -121,7 +121,7 @@ async fn invalid_status_with_project_returns_no_match() {
 }
 
 #[tokio::test]
-async fn valid_status_partial_match_resolves() {
+async fn valid_status_single_substring_is_ambiguous() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/rest/api/3/project/PROJ/statuses"))
@@ -154,8 +154,13 @@ async fn valid_status_partial_match_resolves() {
 
     let result = jr::partial_match::partial_match("in prog", &names);
     match result {
-        jr::partial_match::MatchResult::Exact(name) => assert_eq!(name, "In Progress"),
-        other => panic!("Expected Exact, got {:?}", std::mem::discriminant(&other)),
+        jr::partial_match::MatchResult::Ambiguous(matches) => {
+            assert_eq!(matches, vec!["In Progress".to_string()]);
+        }
+        other => panic!(
+            "Expected Ambiguous, got {:?}",
+            std::mem::discriminant(&other)
+        ),
     }
 }
 


### PR DESCRIPTION
## Summary
- **Eliminate silent mis-resolution in `partial_match`** — single-hit substring matches now route through the existing `Ambiguous` branch (prompt in TTY, error under `--no-input`) instead of silently picking the first match. Affects all 8 call sites: team, user, status, link type, queue, asset. Closes #181, #192.
- **Surface team field on `jr issue view`** — extends the fetch whitelist with the team custom field, resolves the UUID to a display name via the local team cache, and renders a `Team` row in table output with fallback text when uncached. Closes #182.
- **Surface cache I/O errors** — `read_team_cache()` errors are now warned to stderr instead of silently collapsing into "not cached".

## Test plan
- [x] `partial_match` unit tests updated: single substring hit → `Ambiguous` (not `Exact`)
- [x] Integration test updated: `valid_status_single_substring_is_ambiguous`
- [x] `team_id` helper: 3 unit tests (string value, null, missing key)
- [x] Handler test: view with team cached → renders team name
- [x] Handler test: view with team UUID not cached → fallback text
- [x] Handler test: view with field unconfigured → row omitted
- [x] Handler test: view with field absent from response → row omitted
- [x] Handler test: `--team "Ops" --no-input` rejects with "Multiple teams match" + candidate list
- [x] Assets/queue unit tests updated to assert new `Ambiguous` behavior
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` all clean