### PR TITLE
feat: log request body in verbose mode (#183)

### DIFF
--- a/docs/superpowers/plans/2026-04-16-verbose-request-body-logging.md
+++ b/docs/superpowers/plans/2026-04-16-verbose-request-body-logging.md
@@ -50,7 +50,7 @@ async fn test_verbose_logs_request_body_for_put() {
         .arg("--verbose")
         .arg("--output")
         .arg("json")
-        .args(["issue", "edit", "HDL-1", "-s", "new summary"])
+        .args(["issue", "edit", "HDL-1", "--summary", "new summary"])
         .assert()
         .success()
         .stderr(predicate::str::contains("[verbose] PUT"))

--- a/docs/superpowers/plans/2026-04-16-verbose-request-body-logging.md
+++ b/docs/superpowers/plans/2026-04-16-verbose-request-body-logging.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Two surgical edits to existing `if self.verbose { ... }` blocks in `src/api/client.rs` (`send` and `send_raw`). Use `reqwest::Body::as_bytes()` on the buffered JSON body produced by `RequestBuilder::json()`, format as `[verbose] body: {...}` on stderr. Three new handler tests in `tests/cli_handler.rs` lock the behavior end-to-end (PUT body present, GET body absent, `send_raw` body via `jr api`).
 
-**Tech Stack:** Rust, reqwest 0.12 (async), assert_cmd + predicates, wiremock
+**Tech Stack:** Rust, reqwest 0.13 (async), assert_cmd + predicates, wiremock
 
 ---
 
@@ -42,14 +42,8 @@ async fn test_verbose_logs_request_body_for_put() {
         .mount(&server)
         .await;
 
-    Command::cargo_bin("jr")
-        .unwrap()
-        .env("JR_BASE_URL", server.uri())
-        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
-        .arg("--no-input")
+    jr_cmd(&server.uri())
         .arg("--verbose")
-        .arg("--output")
-        .arg("json")
         .args(["issue", "edit", "HDL-1", "--summary", "new summary"])
         .assert()
         .success()
@@ -59,7 +53,7 @@ async fn test_verbose_logs_request_body_for_put() {
 }
 ```
 
-This test does NOT use the `jr_cmd` helper because that helper hardcodes `--output json` and we need to insert `--verbose` between the global flags and the subcommand. Building the command inline keeps the flag order explicit.
+Uses the `jr_cmd(&server.uri())` helper and appends `.arg("--verbose")` — clap global flags can appear before the subcommand in any order, so there is no need to reconstruct the command from scratch.
 
 The third `stderr` assertion (`"\"summary\":\"new summary\""`) is the strict check: it confirms the body line really contains the JSON the CLI sent, not just the prefix. Substring match (no leading `{`) tolerates whatever wrapping serde produces around it (e.g. `{"fields":{...}}`).
 
@@ -81,14 +75,8 @@ async fn test_verbose_omits_body_line_for_get() {
         .mount(&server)
         .await;
 
-    Command::cargo_bin("jr")
-        .unwrap()
-        .env("JR_BASE_URL", server.uri())
-        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
-        .arg("--no-input")
+    jr_cmd(&server.uri())
         .arg("--verbose")
-        .arg("--output")
-        .arg("json")
         .args(["issue", "view", "HDL-1"])
         .assert()
         .success()

--- a/docs/superpowers/plans/2026-04-16-verbose-request-body-logging.md
+++ b/docs/superpowers/plans/2026-04-16-verbose-request-body-logging.md
@@ -24,8 +24,8 @@ No new source code files or modules. No fixture changes — the existing `issue_
 ### Task 1: TDD — verbose mode logs request body
 
 **Files:**
-- Modify: `src/api/client.rs:170-174` and `src/api/client.rs:244-246`
-- Modify: `tests/cli_handler.rs` (append two tests)
+- Modify: `src/api/client.rs:170-174` (`send`) and `src/api/client.rs:244-246` (`send_raw`)
+- Modify: `tests/cli_handler.rs` (append three tests: PUT body, GET body absent, `send_raw` body via `jr api`)
 
 - [ ] **Step 1.1: Write the failing test for PUT body**
 
@@ -87,15 +87,52 @@ async fn test_verbose_omits_body_line_for_get() {
 
 `predicate::str::contains(...).not()` is the established negation pattern (predicates 3.x; already in use in this codebase via `predicates::prelude::*`).
 
-- [ ] **Step 1.3: Run both tests to verify they fail**
+- [ ] **Step 1.2b: Write the failing test for `send_raw` body (jr api)**
+
+`send_raw()` is a separate code path used by `jr api` and is not covered by the PUT test (which goes through `send()`). Append:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_verbose_logs_request_body_for_send_raw() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue/HDL-1/transitions"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    jr_api_cmd(&server.uri())
+        .arg("--verbose")
+        .args([
+            "api",
+            "/rest/api/3/issue/HDL-1/transitions",
+            "-X",
+            "post",
+            "-d",
+            r#"{"transition":{"id":"31"}}"#,
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[verbose] POST"))
+        .stderr(predicate::str::contains(
+            "[verbose] body: {\"transition\":{\"id\":\"31\"}}",
+        ));
+}
+```
+
+Note `jr_api_cmd` (not `jr_cmd`) — `jr api` does not accept `--output json` so the helper without that flag is appropriate. The `-d` payload is asserted byte-exact in stderr because `send_raw` does not re-serialize the body.
+
+- [ ] **Step 1.3: Run all three tests to verify they fail**
 
 Run:
 ```bash
-cargo test --test cli_handler test_verbose_logs_request_body_for_put -- --nocapture
-cargo test --test cli_handler test_verbose_omits_body_line_for_get -- --nocapture
+cargo test --test cli_handler test_verbose -- --nocapture
 ```
 
 Expected for `test_verbose_logs_request_body_for_put`: **FAIL** at the `"[verbose] body:"` assertion — current code only prints `[verbose] PUT <url>`, no body line.
+
+Expected for `test_verbose_logs_request_body_for_send_raw`: **FAIL** at the `"[verbose] body:"` assertion for the same reason.
 
 Expected for `test_verbose_omits_body_line_for_get`: **PASS** unexpectedly (the body line is already absent because no body is logged today). This is OK — keep the test as a regression guard for after the change.
 
@@ -154,15 +191,14 @@ Replace with:
 
 Note the difference: `send_raw` already has a built `reqwest::Request` (not a `RequestBuilder`), so `req.body()` works directly without the `try_clone().build()` dance.
 
-- [ ] **Step 1.6: Run both tests to verify they pass**
+- [ ] **Step 1.6: Run all three tests to verify they pass**
 
 Run:
 ```bash
-cargo test --test cli_handler test_verbose_logs_request_body_for_put -- --nocapture
-cargo test --test cli_handler test_verbose_omits_body_line_for_get -- --nocapture
+cargo test --test cli_handler test_verbose -- --nocapture
 ```
 
-Expected: both **PASS**.
+Expected: all three **PASS**.
 
 If `test_verbose_logs_request_body_for_put` still fails on the substring `"\"summary\":\"new summary\""`, dump the captured stderr (visible with `--nocapture`) and check whether serde produced spaces around the colon (e.g. `"summary": "new summary"`). If so, change the assertion to use a less brittle substring like `predicate::str::contains("new summary")` rather than weakening the structural check — but only after confirming the actual format. (`serde_json` defaults to compact, no spaces, so this should not be needed.)
 

--- a/docs/superpowers/plans/2026-04-16-verbose-request-body-logging.md
+++ b/docs/superpowers/plans/2026-04-16-verbose-request-body-logging.md
@@ -1,0 +1,228 @@
+# Verbose Request Body Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Print the JSON request body alongside the existing `[verbose] METHOD URL` line whenever `--verbose` is set, so users can debug Jira's silent field drops without reaching for `curl`.
+
+**Architecture:** Two surgical edits to existing `if self.verbose { ... }` blocks in `src/api/client.rs` (`send` and `send_raw`). Use `reqwest::Body::as_bytes()` on the buffered JSON body produced by `RequestBuilder::json()`, format as `[verbose] body: {...}` on stderr. Two new handler tests in `tests/cli_handler.rs` lock the behavior end-to-end.
+
+**Tech Stack:** Rust, reqwest 0.12 (async), assert_cmd + predicates, wiremock
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/api/client.rs` | Modify | Extend the existing `if self.verbose { ... }` block at line 170 (`send`) to also `eprintln!` the body bytes when present. Same change at line 244 (`send_raw`). |
+| `tests/cli_handler.rs` | Append | Two handler tests asserting that `--verbose` prints the body for PUT/POST and omits the body line for GET. |
+
+No new files. No new modules. No fixture changes — the existing `issue_response("HDL-1", "old summary", "To Do")` fixture is enough for the GET test.
+
+---
+
+### Task 1: TDD — verbose mode logs request body
+
+**Files:**
+- Modify: `src/api/client.rs:170-174` and `src/api/client.rs:244-246`
+- Modify: `tests/cli_handler.rs` (append two tests)
+
+- [ ] **Step 1.1: Write the failing test for PUT body**
+
+Append to `tests/cli_handler.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_verbose_logs_request_body_for_put() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/api/3/issue/HDL-1"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .arg("--no-input")
+        .arg("--verbose")
+        .arg("--output")
+        .arg("json")
+        .args(["issue", "edit", "HDL-1", "-s", "new summary"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[verbose] PUT"))
+        .stderr(predicate::str::contains("[verbose] body:"))
+        .stderr(predicate::str::contains("\"summary\":\"new summary\""));
+}
+```
+
+This test does NOT use the `jr_cmd` helper because that helper hardcodes `--output json` and we need to insert `--verbose` between the global flags and the subcommand. Building the command inline keeps the flag order explicit.
+
+The third `stderr` assertion (`"\"summary\":\"new summary\""`) is the strict check: it confirms the body line really contains the JSON the CLI sent, not just the prefix. Substring match (no leading `{`) tolerates whatever wrapping serde produces around it (e.g. `{"fields":{...}}`).
+
+- [ ] **Step 1.2: Write the failing test for GET (body line omitted)**
+
+Append immediately after the previous test:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_verbose_omits_body_line_for_get() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/HDL-1"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(common::fixtures::issue_response("HDL-1", "old summary", "To Do")),
+        )
+        .mount(&server)
+        .await;
+
+    Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .arg("--no-input")
+        .arg("--verbose")
+        .arg("--output")
+        .arg("json")
+        .args(["issue", "view", "HDL-1"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[verbose] GET"))
+        .stderr(predicate::str::contains("[verbose] body:").not());
+}
+```
+
+`predicate::str::contains(...).not()` is the established negation pattern (predicates 3.x; already in use in this codebase via `predicates::prelude::*`).
+
+- [ ] **Step 1.3: Run both tests to verify they fail**
+
+Run:
+```bash
+cargo test --test cli_handler test_verbose_logs_request_body_for_put -- --nocapture
+cargo test --test cli_handler test_verbose_omits_body_line_for_get -- --nocapture
+```
+
+Expected for `test_verbose_logs_request_body_for_put`: **FAIL** at the `"[verbose] body:"` assertion — current code only prints `[verbose] PUT <url>`, no body line.
+
+Expected for `test_verbose_omits_body_line_for_get`: **PASS** unexpectedly (the body line is already absent because no body is logged today). This is OK — keep the test as a regression guard for after the change.
+
+If the GET test happens to fail because of stderr noise we don't expect, capture the actual output via `--nocapture` and adjust the assertion before moving on. Do not weaken the assertion just to make it pass.
+
+- [ ] **Step 1.4: Implement body logging in `send`**
+
+Open `src/api/client.rs` and find this block (around line 170):
+
+```rust
+            if self.verbose {
+                if let Some(ref r) = req.try_clone().and_then(|r| r.build().ok()) {
+                    eprintln!("[verbose] {} {}", r.method(), r.url());
+                }
+            }
+```
+
+Replace with:
+
+```rust
+            if self.verbose {
+                if let Some(ref r) = req.try_clone().and_then(|r| r.build().ok()) {
+                    eprintln!("[verbose] {} {}", r.method(), r.url());
+                    if let Some(bytes) = r.body().and_then(|b| b.as_bytes()) {
+                        eprintln!("[verbose] body: {}", String::from_utf8_lossy(bytes));
+                    }
+                }
+            }
+```
+
+Why this works:
+- `RequestBuilder::json(&value)` calls `serde_json::to_vec(&value)` and stores the result via `*req.body_mut() = Some(body.into())`. The body is buffered in memory, not streamed.
+- `reqwest::Body::as_bytes() -> Option<&[u8]>` returns `Some` for buffered bodies. (`None` only happens for streaming bodies — which this codebase has zero of: a grep for `wrap_stream`, `body_stream`, and `reqwest::Body::from(` in `src/` returned no matches.)
+- `String::from_utf8_lossy` is the right call: JSON is UTF-8 by definition, but lossy-decode means a malformed body cannot panic the verbose log path — it just substitutes replacement characters, which is the right failure mode for a diagnostic.
+
+- [ ] **Step 1.5: Implement body logging in `send_raw`**
+
+In the same file, find this block (around line 244):
+
+```rust
+            if self.verbose {
+                eprintln!("[verbose] {} {}", req.method(), req.url());
+            }
+```
+
+Replace with:
+
+```rust
+            if self.verbose {
+                eprintln!("[verbose] {} {}", req.method(), req.url());
+                if let Some(bytes) = req.body().and_then(|b| b.as_bytes()) {
+                    eprintln!("[verbose] body: {}", String::from_utf8_lossy(bytes));
+                }
+            }
+```
+
+Note the difference: `send_raw` already has a built `reqwest::Request` (not a `RequestBuilder`), so `req.body()` works directly without the `try_clone().build()` dance.
+
+- [ ] **Step 1.6: Run both tests to verify they pass**
+
+Run:
+```bash
+cargo test --test cli_handler test_verbose_logs_request_body_for_put -- --nocapture
+cargo test --test cli_handler test_verbose_omits_body_line_for_get -- --nocapture
+```
+
+Expected: both **PASS**.
+
+If `test_verbose_logs_request_body_for_put` still fails on the substring `"\"summary\":\"new summary\""`, dump the captured stderr (visible with `--nocapture`) and check whether serde produced spaces around the colon (e.g. `"summary": "new summary"`). If so, change the assertion to use a less brittle substring like `predicate::str::contains("new summary")` rather than weakening the structural check — but only after confirming the actual format. (`serde_json` defaults to compact, no spaces, so this should not be needed.)
+
+- [ ] **Step 1.7: Run the full test suite**
+
+Run:
+```bash
+cargo test
+```
+
+Expected: all tests pass. The change is additive (only adds an `eprintln!` inside an `if self.verbose` block that defaults false), so no existing test should observe new behavior. Existing handler tests do not pass `--verbose`, so their stderr expectations remain untouched.
+
+If anything fails: read the failure carefully. If a test asserts on stderr and a prior `[verbose]` line snuck in (shouldn't happen — we only log when `verbose: true`), trace the source.
+
+- [ ] **Step 1.8: Run clippy and fmt**
+
+Run:
+```bash
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: both clean. The new code is two `if let Some(...)` chains and an `eprintln!` — nothing clippy should object to.
+
+If `cargo fmt --check` fails, run `cargo fmt --all` and re-stage. Do not skip this — CI runs `--check` and an unformatted PR will go red.
+
+- [ ] **Step 1.9: Commit**
+
+```bash
+git add src/api/client.rs tests/cli_handler.rs
+git commit -m "feat: log request body in verbose mode (#183)"
+```
+
+---
+
+## Spec Coverage Checklist
+
+| Spec Requirement | Task |
+|------------------|------|
+| Body logged after URL line in `send()` | Task 1, Step 1.4 |
+| Same change in `send_raw()` | Task 1, Step 1.5 |
+| Body line omitted entirely when no body | Task 1, Step 1.4 (`if let Some(bytes) = ...` skips); Task 1, Step 1.2 (test) |
+| Compact JSON, not pretty-printed | Task 1, Step 1.4 — the spec relies on `.json()` already producing compact bytes; we don't re-format |
+| `String::from_utf8_lossy` for invalid UTF-8 safety | Task 1, Step 1.4 |
+| `[verbose] body:` prefix mirrors `[verbose]` URL prefix | Task 1, Step 1.4 |
+| Output goes to stderr | Task 1, Step 1.4 (`eprintln!`); Task 1, Steps 1.1–1.2 (tests assert via `.stderr(...)`) |
+| Default (non-verbose) output unchanged | Task 1, Step 1.7 (full test suite) |
+| Handler test for PUT body present | Task 1, Step 1.1 |
+| Handler test for GET body absent | Task 1, Step 1.2 |
+| No header logging, no response body, no `--debug` flag | Spec out-of-scope items — no task needed |
+| OAuth credentials never traverse this path | Verified in spec; no task needed (separate `reqwest::Client` in `src/api/auth.rs`) |

--- a/docs/superpowers/plans/2026-04-16-verbose-request-body-logging.md
+++ b/docs/superpowers/plans/2026-04-16-verbose-request-body-logging.md
@@ -4,7 +4,7 @@
 
 **Goal:** Print the JSON request body alongside the existing `[verbose] METHOD URL` line whenever `--verbose` is set, so users can debug Jira's silent field drops without reaching for `curl`.
 
-**Architecture:** Two surgical edits to existing `if self.verbose { ... }` blocks in `src/api/client.rs` (`send` and `send_raw`). Use `reqwest::Body::as_bytes()` on the buffered JSON body produced by `RequestBuilder::json()`, format as `[verbose] body: {...}` on stderr. Two new handler tests in `tests/cli_handler.rs` lock the behavior end-to-end.
+**Architecture:** Two surgical edits to existing `if self.verbose { ... }` blocks in `src/api/client.rs` (`send` and `send_raw`). Use `reqwest::Body::as_bytes()` on the buffered JSON body produced by `RequestBuilder::json()`, format as `[verbose] body: {...}` on stderr. Three new handler tests in `tests/cli_handler.rs` lock the behavior end-to-end (PUT body present, GET body absent, `send_raw` body via `jr api`).
 
 **Tech Stack:** Rust, reqwest 0.12 (async), assert_cmd + predicates, wiremock
 
@@ -15,9 +15,9 @@
 | File | Action | Responsibility |
 |------|--------|----------------|
 | `src/api/client.rs` | Modify | Extend the existing `if self.verbose { ... }` block at line 170 (`send`) to also `eprintln!` the body bytes when present. Same change at line 244 (`send_raw`). |
-| `tests/cli_handler.rs` | Append | Two handler tests asserting that `--verbose` prints the body for PUT/POST and omits the body line for GET. |
+| `tests/cli_handler.rs` | Append | Three handler tests asserting that `--verbose` prints the body for PUT (via `send`), omits the body line for GET, and prints the body for POST through `send_raw` (via `jr api`). |
 
-No new files. No new modules. No fixture changes — the existing `issue_response("HDL-1", "old summary", "To Do")` fixture is enough for the GET test.
+No new source code files or modules. No fixture changes — the existing `issue_response("HDL-1", "old summary", "To Do")` fixture is enough for the GET test.
 
 ---
 

--- a/docs/superpowers/specs/2026-04-16-verbose-request-body-logging-design.md
+++ b/docs/superpowers/specs/2026-04-16-verbose-request-body-logging-design.md
@@ -1,0 +1,136 @@
+# Verbose Mode Logs Request Body
+
+> **Issue:** #183 — `verbose mode: does not include request body, making silent drops undebuggable`
+
+## Problem
+
+`jr --verbose` currently logs only the HTTP method and URL for outgoing requests:
+
+```
+[verbose] PUT https://<site>/rest/api/3/issue/<KEY>
+Updated <KEY>
+```
+
+When a Jira mutation silently drops a value (e.g. unknown team UUID, unsettable custom field), the user has no way to confirm what payload was actually sent. The only fallback is to hand-trace the source or reach for `curl` with raw credentials — both defeat the purpose of a CLI wrapper.
+
+This is the same diagnostic gap that obscured #181 (silent team mis-resolution) for users in the field. Atlassian's `PUT /rest/api/3/issue/{key}` returns **200 with no `warningMessages`** when fields are ignored ("Fields that are not settable will be ignored", per Atlassian REST v3 intro docs), so the response provides no signal either. The request body is the minimum information needed to debug from the client side.
+
+## Design
+
+### Core Change
+
+In `src/api/client.rs`, both `send()` and `send_raw()` already build a clone of the request for inspection (`req.try_clone().and_then(|r| r.build().ok())`). Extend that block to also log the body when present:
+
+```rust
+// before (src/api/client.rs:170-174)
+if self.verbose {
+    if let Some(ref r) = req.try_clone().and_then(|r| r.build().ok()) {
+        eprintln!("[verbose] {} {}", r.method(), r.url());
+    }
+}
+
+// after
+if self.verbose {
+    if let Some(ref r) = req.try_clone().and_then(|r| r.build().ok()) {
+        eprintln!("[verbose] {} {}", r.method(), r.url());
+        if let Some(bytes) = r.body().and_then(|b| b.as_bytes()) {
+            eprintln!("[verbose] body: {}", String::from_utf8_lossy(bytes));
+        }
+    }
+}
+```
+
+`send_raw()` (`client.rs:244-246`) gets the same treatment, except the request is already built (no `try_clone().build()` step).
+
+`reqwest::Body::as_bytes() -> Option<&[u8]>` returns `Some` for in-memory bodies (which `.json()` produces — it serializes via `serde_json::to_vec` and stores the bytes). It returns `None` for streaming bodies. We have no streaming body callers today, so the `None` arm is just defensive — no body line gets printed.
+
+### Output
+
+For a write call:
+
+```
+[verbose] PUT https://example.atlassian.net/rest/api/3/issue/HDL-1
+[verbose] body: {"fields":{"summary":"new summary","priority":{"name":"Medium"}}}
+```
+
+For a GET (no body):
+
+```
+[verbose] GET https://example.atlassian.net/rest/api/3/issue/HDL-1
+```
+
+The body line is omitted entirely when there is no body — no empty `body: ` line, no `body: null`. This keeps `--verbose` for read commands unchanged.
+
+### Format
+
+- **Compact JSON, not pretty-printed.** `.json(body)` already produces compact output via `serde_json::to_vec`. Don't re-parse and re-format — that adds CPU cost and risks transformation bugs (e.g. key reordering). The output is one line per request, easy to grep.
+- **`String::from_utf8_lossy`** rather than `from_utf8`: bodies are always JSON (UTF-8 by definition), but lossy-decode is cheap insurance against a malformed payload crashing the verbose log instead of producing a useful diagnostic.
+- **`[verbose] body:` prefix** mirrors the existing `[verbose]` prefix on the URL line, so a single `grep '\[verbose\]'` captures the whole trace.
+
+### What Does NOT Change
+
+| Item | Reason |
+|------|--------|
+| Default (non-verbose) output | Spec only touches the `if self.verbose` arm |
+| Response body | Out of scope — would require restructuring every typed wrapper (`get<T>`, `post<T>`, `put`, `post_no_content`, `delete`) to read bytes-then-parse. Filed as a follow-up |
+| `--debug` flag | Not introduced — see "Flag choice" below |
+| Header logging | Not requested in #183; `Authorization` would need redaction. Out of scope |
+| Body redaction | All `JiraClient::send()` bodies are user content (issue fields, comments, transitions). OAuth `client_secret` and `refresh_token` flow through a separate `reqwest::Client` in `src/api/auth.rs:163,222` that bypasses `send()` entirely, so the verbose path never sees credentials. The `jr api` raw passthrough (`send_raw`) could echo a user-typed `-d '{...}'` payload — caller responsibility, same as `curl -v` |
+
+### Flag Choice
+
+The issue accepts either `--verbose` or a new `--debug` flag. Sticking with `--verbose` because:
+
+- Convention (`curl -v`, `kubectl -v`, `gh -v`, `httpie -v`) keeps bodies out of `-v` to avoid drowning the user in TLS handshakes, redirect chains, and header dumps. Our `--verbose` currently emits **one URL line per call** — there is no noise budget being protected. Adding a body line moves us from "useless verbose" to "minimum useful verbose".
+- Issue author explicitly OK with `--verbose`: "verbose currently implies 'show me what you're doing' and the body is the most important part of that".
+- Avoids introducing a flag for noise that does not exist. If verbose ever grows headers/timing/response-body, that's the moment to add `--debug` or `-vv`.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/api/client.rs` | `send()` (~line 170): extend verbose block with body line |
+| `src/api/client.rs` | `send_raw()` (~line 244): extend verbose block with body line |
+| `tests/cli_handler.rs` | Add 2 handler tests: PUT body appears in stderr under `--verbose`; GET body line omitted |
+
+## Testing
+
+**Handler tests** (in `tests/cli_handler.rs` since this is end-to-end CLI behavior, not a unit boundary):
+
+1. **`test_verbose_logs_request_body_for_put`** — wiremock 204 for `PUT /rest/api/3/issue/HDL-1`, run `jr --verbose issue edit HDL-1 -s "new summary"`, assert stderr contains both `[verbose] PUT` and `[verbose] body: {"fields":` (substring match — exact serialized form depends on serde struct field order, so substring is more robust than exact-equality).
+2. **`test_verbose_omits_body_line_for_get`** — wiremock 200 for `GET /rest/api/3/issue/HDL-1`, run `jr --verbose issue view HDL-1 --output json`, assert stderr contains `[verbose] GET` and does **not** contain `[verbose] body:`.
+
+No new unit tests in `client.rs`. The verbose-logging branch has no return value or business logic — it's pure I/O. End-to-end tests are the right level.
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Body is not buffered (streaming) | `as_bytes()` returns `None` → no body line printed (defensive; no current callers) |
+| Body has invalid UTF-8 | `from_utf8_lossy` substitutes replacement chars; no panic |
+| `verbose` is false | Block is skipped entirely; zero overhead |
+
+## Alignment with Project Conventions
+
+- **Thin client, no abstraction layer** — change is in the existing `send()`/`send_raw()` methods, no new abstractions
+- **Machine-output-first** — verbose output goes to **stderr** (already established by existing `eprintln!`), so `cmd > out.json` keeps stdout clean and `cmd 2> trace.log --verbose` captures the trace
+- **Pipe-friendly** — body line is `[verbose] body: {...}` so `grep '\[verbose\] body:'` captures payloads cleanly
+- **Non-interactive by default** — verbose is opt-in, not affected by TTY detection
+- **Idempotent reads** — verbose adds zero behavioral change to requests, only logging
+
+## Validation
+
+- **Context7 (`/websites/rs_reqwest`):** `reqwest::Body::as_bytes(&self) -> Option<&[u8]>` exists on the async type and returns `Some(&[u8])` for buffered bodies. `.json(body)` produces a buffered body via `serde_json::to_vec`. The existing `try_clone().build()` pattern in `client.rs:171` is the supported way to produce an inspectable `Request` from a `RequestBuilder`.
+- **Perplexity (2026-04-16):** Atlassian docs confirm `PUT /rest/api/3/issue/{key}` returns 200 with no `warningMessages` and no error indicators when fields are silently ignored. The request body is the only client-side signal available.
+- **Perplexity (2026-04-16):** `curl -v` does NOT print request bodies (uses `--trace-ascii` for that); `httpie -v` shows headers, `-vv` adds bodies; `kubectl` reserves bodies for `-v=8+`; `gh -v` does not print bodies. Convention is bodies-out-of-verbose for tools whose `-v` already includes TLS/headers/timings. Our `--verbose` is currently empty of that detail, so the convention argument doesn't bind here.
+- **Codebase audit:** all OAuth credential exchanges (`src/api/auth.rs:163-186, 222-244`) use a separate `reqwest::Client::new()` and never traverse `JiraClient::send()`. The verbose-logging path will not see `client_secret` or `refresh_token` payloads.
+- **Codebase audit:** `src/api/client.rs:170-174, 244-246` are the only `[verbose]` log sites for outgoing requests. No third site to update.
+
+## Out of Scope (Follow-Ups)
+
+| Item | Why deferred |
+|------|--------------|
+| Response body logging | Touches every typed wrapper (`get<T>`, `post<T>`, `put`, etc.) — bytes-then-parse refactor. File as separate issue to keep this PR focused on the issue-as-filed |
+| Response status / headers | Same as above; out of #183 scope |
+| `--debug` flag with separate verbosity tier | YAGNI until verbose grows enough to need a noise budget |
+| Body redaction policy for `jr api` raw passthrough | User-typed `-d` payloads are caller responsibility; matches `curl -v` semantics |

--- a/docs/superpowers/specs/2026-04-16-verbose-request-body-logging-design.md
+++ b/docs/superpowers/specs/2026-04-16-verbose-request-body-logging-design.md
@@ -19,7 +19,7 @@ This is the same diagnostic gap that obscured #181 (silent team mis-resolution) 
 
 ### Core Change
 
-In `src/api/client.rs`, both `send()` and `send_raw()` already build a clone of the request for inspection (`req.try_clone().and_then(|r| r.build().ok())`). Extend that block to also log the body when present:
+In `src/api/client.rs`, `send()` already clones-and-builds the `RequestBuilder` for inspection (`req.try_clone().and_then(|r| r.build().ok())`), and `send_raw()` already operates on a pre-built `reqwest::Request`. Extend each verbose block to also log the body when present:
 
 ```rust
 // before (src/api/client.rs:170-174)
@@ -95,10 +95,11 @@ The issue accepts either `--verbose` or a new `--debug` flag. Sticking with `--v
 
 ## Testing
 
-**Handler tests** (in `tests/cli_handler.rs` since this is end-to-end CLI behavior, not a unit boundary):
+**Handler tests** (in `tests/cli_handler.rs` since this is end-to-end CLI behavior, not a unit boundary). All three are built on top of the existing `jr_cmd` / `jr_api_cmd` helpers with `.arg("--verbose")` appended (clap global flags can appear before the subcommand in any order):
 
-1. **`test_verbose_logs_request_body_for_put`** — wiremock 204 for `PUT /rest/api/3/issue/HDL-1`, run `jr --verbose issue edit HDL-1 -s "new summary"`, assert stderr contains both `[verbose] PUT` and `[verbose] body: {"fields":` (substring match — exact serialized form depends on serde struct field order, so substring is more robust than exact-equality).
-2. **`test_verbose_omits_body_line_for_get`** — wiremock 200 for `GET /rest/api/3/issue/HDL-1`, run `jr --verbose issue view HDL-1 --output json`, assert stderr contains `[verbose] GET` and does **not** contain `[verbose] body:`.
+1. **`test_verbose_logs_request_body_for_put`** — wiremock 204 for `PUT /rest/api/3/issue/HDL-1` (with a `body_partial_json({"fields":{"summary":"new summary"}})` matcher pinning the wire payload), run `jr --no-input --output json --verbose issue edit HDL-1 --summary "new summary"`, assert stderr contains `[verbose] PUT`, `[verbose] body:`, and the substring `"summary":"new summary"` (substring match — exact serialized form depends on serde field order, so substring is more robust than exact-equality).
+2. **`test_verbose_omits_body_line_for_get`** — wiremock 200 for `GET /rest/api/3/issue/HDL-1`, run `jr --no-input --output json --verbose issue view HDL-1`, assert stderr contains `[verbose] GET` and does **not** contain `[verbose] body:`.
+3. **`test_verbose_logs_request_body_for_send_raw`** — wiremock 204 for `POST /rest/api/3/issue/HDL-1/transitions`, run `jr --no-input --verbose api /rest/api/3/issue/HDL-1/transitions -X post -d '{"transition":{"id":"31"}}'`, assert stderr contains `[verbose] POST` and the literal `[verbose] body: {"transition":{"id":"31"}}`. Covers the `send_raw()` path used by `jr api` (independent of `send()`).
 
 No new unit tests in `client.rs`. The verbose-logging branch has no return value or business logic — it's pure I/O. End-to-end tests are the right level.
 

--- a/docs/superpowers/specs/2026-04-16-verbose-request-body-logging-design.md
+++ b/docs/superpowers/specs/2026-04-16-verbose-request-body-logging-design.md
@@ -91,7 +91,7 @@ The issue accepts either `--verbose` or a new `--debug` flag. Sticking with `--v
 |------|--------|
 | `src/api/client.rs` | `send()` (~line 170): extend verbose block with body line |
 | `src/api/client.rs` | `send_raw()` (~line 244): extend verbose block with body line |
-| `tests/cli_handler.rs` | Add 2 handler tests: PUT body appears in stderr under `--verbose`; GET body line omitted |
+| `tests/cli_handler.rs` | Add 3 handler tests: PUT body appears in stderr under `--verbose`; GET body line omitted; `send_raw` (used by `jr api`) emits the literal `-d` payload |
 
 ## Testing
 
@@ -121,7 +121,7 @@ No new unit tests in `client.rs`. The verbose-logging branch has no return value
 ## Validation
 
 - **Context7 (`/websites/rs_reqwest`):** `reqwest::Body::as_bytes(&self) -> Option<&[u8]>` exists on the async type and returns `Some(&[u8])` for buffered bodies. `.json(body)` produces a buffered body via `serde_json::to_vec`. The existing `try_clone().build()` pattern in `client.rs:171` is the supported way to produce an inspectable `Request` from a `RequestBuilder`.
-- **Perplexity (2026-04-16):** Atlassian docs confirm `PUT /rest/api/3/issue/{key}` returns 200 with no `warningMessages` and no error indicators when fields are silently ignored. The request body is the only client-side signal available.
+- **Perplexity (2026-04-16):** Atlassian docs confirm `PUT /rest/api/3/issue/{key}` returns 204 No Content (per JRACLOUD-37536) with no `warningMessages` and no error indicators when fields are silently ignored. The request body is the only client-side signal available.
 - **Perplexity (2026-04-16):** `curl -v` does NOT print request bodies (uses `--trace-ascii` for that); `httpie -v` shows headers, `-vv` adds bodies; `kubectl` reserves bodies for `-v=8+`; `gh -v` does not print bodies. Convention is bodies-out-of-verbose for tools whose `-v` already includes TLS/headers/timings. Our `--verbose` is currently empty of that detail, so the convention argument doesn't bind here.
 - **Codebase audit:** all OAuth credential exchanges (`src/api/auth.rs:163-186, 222-244`) use a separate `reqwest::Client::new()` and never traverse `JiraClient::send()`. The verbose-logging path will not see `client_secret` or `refresh_token` payloads.
 - **Codebase audit:** `src/api/client.rs:170-174, 244-246` are the only `[verbose]` log sites for outgoing requests. No third site to update.

--- a/docs/superpowers/specs/2026-04-16-verbose-request-body-logging-design.md
+++ b/docs/superpowers/specs/2026-04-16-verbose-request-body-logging-design.md
@@ -13,7 +13,7 @@ Updated <KEY>
 
 When a Jira mutation silently drops a value (e.g. unknown team UUID, unsettable custom field), the user has no way to confirm what payload was actually sent. The only fallback is to hand-trace the source or reach for `curl` with raw credentials — both defeat the purpose of a CLI wrapper.
 
-This is the same diagnostic gap that obscured #181 (silent team mis-resolution) for users in the field. Atlassian's `PUT /rest/api/3/issue/{key}` returns **200 with no `warningMessages`** when fields are ignored ("Fields that are not settable will be ignored", per Atlassian REST v3 intro docs), so the response provides no signal either. The request body is the minimum information needed to debug from the client side.
+This is the same diagnostic gap that obscured #181 (silent team mis-resolution) for users in the field. Atlassian's `PUT /rest/api/3/issue/{key}` returns **204 No Content with an empty body and no `warningMessages`** when fields are ignored ("Fields that are not settable will be ignored", per Atlassian REST v3 intro docs), so the response provides no signal either. The request body is the minimum information needed to debug from the client side.
 
 ## Design
 

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -170,6 +170,9 @@ impl JiraClient {
             if self.verbose {
                 if let Some(ref r) = req.try_clone().and_then(|r| r.build().ok()) {
                     eprintln!("[verbose] {} {}", r.method(), r.url());
+                    if let Some(bytes) = r.body().and_then(|b| b.as_bytes()) {
+                        eprintln!("[verbose] body: {}", String::from_utf8_lossy(bytes));
+                    }
                 }
             }
 
@@ -243,6 +246,9 @@ impl JiraClient {
 
             if self.verbose {
                 eprintln!("[verbose] {} {}", req.method(), req.url());
+                if let Some(bytes) = req.body().and_then(|b| b.as_bytes()) {
+                    eprintln!("[verbose] body: {}", String::from_utf8_lossy(bytes));
+                }
             }
 
             let response = match self.client.execute(req).await {

--- a/src/api/jira/fields.rs
+++ b/src/api/jira/fields.rs
@@ -73,7 +73,7 @@ pub fn filter_story_points_fields(fields: &[Field]) -> Vec<(String, String)> {
         })
         .collect();
 
-    matches.sort_by(|a, b| b.2.cmp(&a.2));
+    matches.sort_by_key(|m| std::cmp::Reverse(m.2));
     matches
         .into_iter()
         .map(|(id, name, _)| (id, name))

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1630,14 +1630,8 @@ async fn test_verbose_logs_request_body_for_put() {
         .mount(&server)
         .await;
 
-    Command::cargo_bin("jr")
-        .unwrap()
-        .env("JR_BASE_URL", server.uri())
-        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
-        .arg("--no-input")
+    jr_cmd(&server.uri())
         .arg("--verbose")
-        .arg("--output")
-        .arg("json")
         .args(["issue", "edit", "HDL-1", "--summary", "new summary"])
         .assert()
         .success()
@@ -1656,11 +1650,7 @@ async fn test_verbose_logs_request_body_for_send_raw() {
         .mount(&server)
         .await;
 
-    Command::cargo_bin("jr")
-        .unwrap()
-        .env("JR_BASE_URL", server.uri())
-        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
-        .arg("--no-input")
+    jr_api_cmd(&server.uri())
         .arg("--verbose")
         .args([
             "api",
@@ -1694,14 +1684,8 @@ async fn test_verbose_omits_body_line_for_get() {
         .mount(&server)
         .await;
 
-    Command::cargo_bin("jr")
-        .unwrap()
-        .env("JR_BASE_URL", server.uri())
-        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
-        .arg("--no-input")
+    jr_cmd(&server.uri())
         .arg("--verbose")
-        .arg("--output")
-        .arg("json")
         .args(["issue", "view", "HDL-1"])
         .assert()
         .success()

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1616,3 +1616,60 @@ async fn test_edit_team_substring_rejects_under_no_input() {
         .stderr(predicate::str::contains("Multiple teams match"))
         .stderr(predicate::str::contains("Platform Ops"));
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_verbose_logs_request_body_for_put() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/api/3/issue/HDL-1"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .arg("--no-input")
+        .arg("--verbose")
+        .arg("--output")
+        .arg("json")
+        .args(["issue", "edit", "HDL-1", "--summary", "new summary"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[verbose] PUT"))
+        .stderr(predicate::str::contains("[verbose] body:"))
+        .stderr(predicate::str::contains("\"summary\":\"new summary\""));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_verbose_omits_body_line_for_get() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/HDL-1"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(common::fixtures::issue_response(
+                "HDL-1",
+                "old summary",
+                "To Do",
+            )),
+        )
+        .mount(&server)
+        .await;
+
+    Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .arg("--no-input")
+        .arg("--verbose")
+        .arg("--output")
+        .arg("json")
+        .args(["issue", "view", "HDL-1"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[verbose] GET"))
+        .stderr(predicate::str::contains("[verbose] body:").not());
+}

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1623,6 +1623,9 @@ async fn test_verbose_logs_request_body_for_put() {
 
     Mock::given(method("PUT"))
         .and(path("/rest/api/3/issue/HDL-1"))
+        .and(body_partial_json(serde_json::json!({
+            "fields": {"summary": "new summary"}
+        })))
         .respond_with(ResponseTemplate::new(204))
         .mount(&server)
         .await;
@@ -1641,6 +1644,38 @@ async fn test_verbose_logs_request_body_for_put() {
         .stderr(predicate::str::contains("[verbose] PUT"))
         .stderr(predicate::str::contains("[verbose] body:"))
         .stderr(predicate::str::contains("\"summary\":\"new summary\""));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_verbose_logs_request_body_for_send_raw() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue/HDL-1/transitions"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .arg("--no-input")
+        .arg("--verbose")
+        .args([
+            "api",
+            "/rest/api/3/issue/HDL-1/transitions",
+            "-X",
+            "post",
+            "-d",
+            r#"{"transition":{"id":"31"}}"#,
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[verbose] POST"))
+        .stderr(predicate::str::contains(
+            "[verbose] body: {\"transition\":{\"id\":\"31\"}}",
+        ));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

- `--verbose` now prints the JSON request body alongside the existing `[verbose] METHOD URL` line, closing the diagnostic gap that made silent field drops (e.g. #181) undebuggable without `curl`.
- Surgical change to existing `if self.verbose { ... }` blocks in `JiraClient::send()` and `JiraClient::send_raw()` — no new abstractions, no new flags. Body line uses `String::from_utf8_lossy` over `Body::as_bytes()` (returned by buffered JSON bodies via `RequestBuilder::json`).
- Three handler tests lock the behavior end-to-end: PUT body appears with correct payload (mock matcher pins wire body), GET has no body line, `send_raw` (used by `jr api`) emits the literal `-d` payload.

Closes #183.

## Test Plan

- [x] All 3 verbose handler tests pass (`cargo test test_verbose`)
- [x] Full test suite passes (369 unit + all integration suites, 0 failures)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Local PR review (code, tests, errors, comments) iterated to clean — Round 1 found 4 actionable items (`send_raw` test gap, missing PUT body matcher, spec 200→204, plan `-s`→`--summary`); Round 2 confirmed all closed
- [x] Verbose-body output verified against built request via `as_bytes()` per Context7-confirmed reqwest API
- [x] Manual smoke: run `jr --verbose issue edit <KEY> --summary "x"` against real Jira and confirm body line shows actual payload