### PR TITLE
feat: full markdown-to-ADF conversion for --markdown flag (#197)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,6 +1132,7 @@ dependencies = [
  "open",
  "predicates",
  "proptest",
+ "pulldown-cmark",
  "reqwest",
  "serde",
  "serde_json",
@@ -1486,6 +1487,17 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -2346,6 +2358,12 @@ checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 futures = { version = "0.3", default-features = false, features = ["async-await"] }
 urlencoding = "2"
+pulldown-cmark = { version = "0.13", default-features = false }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/docs/superpowers/plans/2026-04-16-markdown-to-adf-conversion.md
+++ b/docs/superpowers/plans/2026-04-16-markdown-to-adf-conversion.md
@@ -19,7 +19,7 @@
 | `src/adf.rs #[cfg(test)]` | Add ~13 new feature-focused unit tests; regenerate the existing `test_markdown_to_adf_snapshot` |
 | `src/snapshots/jr__adf__tests__markdown_complex_to_adf.snap` | Regenerated (accepted via `cargo insta accept`) |
 
-No new files, no new modules. `tests/issue_commands.rs` is unchanged — its three call sites (`:589,:631,:671`) import `jr::adf::markdown_to_adf` and use it as the wiremock matcher's source-of-truth, so they auto-track whatever the new implementation emits.
+No new files, no new modules. `tests/issue_commands.rs` is unchanged — its markdown call site (`:631`) imports `jr::adf::markdown_to_adf` and uses it as the wiremock matcher's source-of-truth, so it auto-tracks whatever the new implementation emits. (Sibling tests at `:589` and `:671` use `text_to_adf` and are unaffected.)
 
 ## Task Decomposition
 

--- a/docs/superpowers/plans/2026-04-16-markdown-to-adf-conversion.md
+++ b/docs/superpowers/plans/2026-04-16-markdown-to-adf-conversion.md
@@ -1,0 +1,949 @@
+# Markdown-to-ADF Conversion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the hand-rolled `adf::markdown_to_adf()` with a `pulldown-cmark`-based event-to-ADF converter so `--markdown` produces structurally-correct ADF on `issue comment`, `issue create`, and `issue edit`.
+
+**Architecture:** Single-file change to `src/adf.rs`. A new private `AdfBuilder` consumes `pulldown_cmark::Event`s via a node stack and active-marks list, producing `serde_json::Value`. Public signature `fn markdown_to_adf(&str) -> Value` unchanged — three call sites untouched. Full design in `docs/superpowers/specs/2026-04-16-markdown-to-adf-conversion-design.md`.
+
+**Tech Stack:** Rust 2024 edition (MSRV 1.85), `pulldown-cmark = 0.13` (CommonMark parser), `serde_json::Value` (ADF carrier), `insta` (snapshot tests).
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `Cargo.toml` | Add `pulldown-cmark = { version = "0.13", default-features = false }` |
+| `src/adf.rs` | Rewrite `markdown_to_adf()` internals; add private `AdfBuilder`; keep `text_to_adf`, `adf_to_text` as-is; delete obsolete helpers `parse_heading`, `parse_inline`, `flush_list` |
+| `src/adf.rs #[cfg(test)]` | Add ~13 new feature-focused unit tests; regenerate the existing `test_markdown_to_adf_snapshot` |
+| `src/snapshots/jr__adf__tests__markdown_complex_to_adf.snap` | Regenerated (accepted via `cargo insta accept`) |
+
+No new files, no new modules. `tests/issue_commands.rs` is unchanged — its three call sites (`:589,:631,:671`) import `jr::adf::markdown_to_adf` and use it as the wiremock matcher's source-of-truth, so they auto-track whatever the new implementation emits.
+
+## Task Decomposition
+
+Four tasks, each a `RED → GREEN → COMMIT` cycle. Task 1 is the biggest (scaffolding + block nodes); Tasks 2–4 add incremental capabilities. All code edits happen inside `src/adf.rs`.
+
+---
+
+### Task 1: Add pulldown-cmark dep, scaffold `AdfBuilder`, implement block nodes and leaf events
+
+**Scope:** Wire up the replacement, handle block-level Tags and leaf events. This task keeps all pre-existing passing tests green and adds tests for the new block-level features (ordered-list `order` attr, hard break, rule, nested lists, blockquote). Inline marks come in Task 2.
+
+**Files:**
+- Modify: `Cargo.toml` (dependencies section)
+- Modify: `src/adf.rs` — replace `markdown_to_adf()` body (lines 18-75), delete `parse_heading` (86-98), `parse_inline` (100-144), `flush_list` (77-84); add new `AdfBuilder`
+- Modify: `src/adf.rs #[cfg(test)]` — update the complex snapshot test input to exercise more features
+
+- [ ] **Step 1.1: Add `pulldown-cmark` to `Cargo.toml`**
+
+Locate the `[dependencies]` section of `Cargo.toml` and add:
+
+```toml
+pulldown-cmark = { version = "0.13", default-features = false }
+```
+
+Run `cargo check` to fetch and confirm the dep compiles.
+
+Expected: `Compiling pulldown-cmark v0.13.x` followed by a clean compile.
+
+- [ ] **Step 1.2: RED — add a failing test for ordered lists with non-1 start**
+
+The current hand-rolled parser does not emit `orderedList` at all (it ignores `1.` prefixes). Add this test to the bottom of `src/adf.rs`'s `mod tests`:
+
+```rust
+#[test]
+fn test_markdown_ordered_list_sets_order_when_start_is_not_one() {
+    let adf = markdown_to_adf("5. first\n6. second");
+    assert_eq!(adf["content"][0]["type"], "orderedList");
+    assert_eq!(adf["content"][0]["attrs"]["order"], 5);
+    assert_eq!(adf["content"][0]["content"][0]["type"], "listItem");
+}
+```
+
+- [ ] **Step 1.3: Run the new test to verify it fails**
+
+Run: `cargo test --lib adf:: test_markdown_ordered_list_sets_order_when_start_is_not_one`
+
+Expected: FAIL. The current implementation has no concept of ordered lists; output is a `paragraph` with literal `"5. first\n6. second"` text.
+
+- [ ] **Step 1.4: GREEN — rewrite `markdown_to_adf()` using `pulldown-cmark` + `AdfBuilder`**
+
+Replace lines 18-144 of `src/adf.rs` (everything from `pub fn markdown_to_adf` through the end of `parse_inline` and `render_node`'s sibling helpers — keep `adf_to_text`, `render_node`, `render_children`, `text_to_adf` untouched) with:
+
+```rust
+use pulldown_cmark::{
+    Alignment, BlockQuoteKind, CodeBlockKind, Event, HeadingLevel, LinkType, Options, Parser,
+    Tag, TagEnd,
+};
+
+pub fn markdown_to_adf(markdown: &str) -> Value {
+    let options = Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH;
+    let parser = Parser::new_ext(markdown, options);
+    let mut builder = AdfBuilder::new();
+    for event in parser {
+        builder.process(event);
+    }
+    json!({
+        "version": 1,
+        "type": "doc",
+        "content": builder.finish(),
+    })
+}
+
+struct AdfBuilder {
+    // Top-level block nodes collected for the final `doc.content` array.
+    root: Vec<Value>,
+    // Open containers. Each holds the node-kind metadata needed to emit on close,
+    // plus its accumulated children.
+    stack: Vec<PartialNode>,
+    // Active inline marks applied to every Text event while any are open.
+    active_marks: Vec<Value>,
+    // Tracks whether we're between TableHead start/end so cells emit as tableHeader.
+    in_table_head: bool,
+}
+
+struct PartialNode {
+    // Serialized kind + attrs for the node to emit on End.
+    // We construct the Value at End time so `children` can be appended.
+    kind: NodeKind,
+    children: Vec<Value>,
+}
+
+enum NodeKind {
+    Paragraph,
+    Heading(u8),
+    BlockQuote,
+    CodeBlock { language: Option<String> },
+    BulletList,
+    OrderedList { start: u64 },
+    ListItem,
+    // For events we want to swallow entirely (e.g., Image contents, unhandled tags).
+    Sink,
+}
+
+// Tasks 2 and 3 will extend this enum with:
+// - `InlineMark` (Task 2) for Strong/Emphasis/Strikethrough/Link container tracking
+// - `Table`, `TableRow`, `TableCell { is_header: bool }` (Task 3) for GFM tables
+
+impl AdfBuilder {
+    fn new() -> Self {
+        Self {
+            root: Vec::new(),
+            stack: Vec::new(),
+            active_marks: Vec::new(),
+            in_table_head: false,
+        }
+    }
+
+    fn process(&mut self, event: Event<'_>) {
+        match event {
+            Event::Start(tag) => self.start(tag),
+            Event::End(tag_end) => self.end(tag_end),
+            Event::Text(text) => self.push_text(text.as_ref()),
+            Event::Code(text) => self.push_code(text.as_ref()),
+            Event::Html(html) | Event::InlineHtml(html) => self.push_text(html.as_ref()),
+            Event::SoftBreak => self.push_text(" "),
+            Event::HardBreak => self.append_child(json!({ "type": "hardBreak" })),
+            Event::Rule => self.append_child(json!({ "type": "rule" })),
+            // Footnotes / math / task markers with unset options: ignored.
+            _ => {}
+        }
+    }
+
+    fn start(&mut self, tag: Tag<'_>) {
+        // Task 2 fills in inline-mark arms (Strong, Emphasis, Strikethrough, Link).
+        // Task 3 fills in Table/TableHead/TableRow/TableCell arms.
+        match tag {
+            Tag::Paragraph => self.push(NodeKind::Paragraph),
+            Tag::Heading { level, .. } => self.push(NodeKind::Heading(heading_level_to_u8(level))),
+            Tag::BlockQuote(_) => self.push(NodeKind::BlockQuote),
+            Tag::CodeBlock(kind) => {
+                let language = match kind {
+                    CodeBlockKind::Fenced(lang) if !lang.is_empty() => Some(lang.into_string()),
+                    _ => None,
+                };
+                self.push(NodeKind::CodeBlock { language });
+            }
+            Tag::List(None) => self.push(NodeKind::BulletList),
+            Tag::List(Some(start)) => self.push(NodeKind::OrderedList { start }),
+            Tag::Item => self.push(NodeKind::ListItem),
+            Tag::Image { .. } => self.push(NodeKind::Sink),
+            // Everything else (inline marks, tables, html block, footnotes, etc.)
+            // handled in later tasks or ignored.
+            _ => self.push(NodeKind::Sink),
+        }
+    }
+
+    fn end(&mut self, _tag_end: TagEnd) {
+        let Some(partial) = self.stack.pop() else {
+            return;
+        };
+        let PartialNode { kind, children } = partial;
+        let node = match kind {
+            NodeKind::Paragraph => Some(json!({ "type": "paragraph", "content": children })),
+            NodeKind::Heading(level) => Some(json!({
+                "type": "heading",
+                "attrs": { "level": level },
+                "content": children,
+            })),
+            NodeKind::BlockQuote => Some(json!({ "type": "blockquote", "content": children })),
+            NodeKind::CodeBlock { language } => {
+                let mut node = json!({ "type": "codeBlock", "content": children });
+                if let Some(lang) = language {
+                    node["attrs"] = json!({ "language": lang });
+                }
+                Some(node)
+            }
+            NodeKind::BulletList => Some(json!({ "type": "bulletList", "content": children })),
+            NodeKind::OrderedList { start } => {
+                let mut node = json!({ "type": "orderedList", "content": children });
+                if start != 1 {
+                    node["attrs"] = json!({ "order": start });
+                }
+                Some(node)
+            }
+            NodeKind::ListItem => Some(json!({ "type": "listItem", "content": children })),
+            NodeKind::Sink => None,
+        };
+        if let Some(node) = node {
+            self.append_child(node);
+        }
+    }
+
+    fn push(&mut self, kind: NodeKind) {
+        self.stack.push(PartialNode {
+            kind,
+            children: Vec::new(),
+        });
+    }
+
+    fn append_child(&mut self, node: Value) {
+        if let Some(top) = self.stack.last_mut() {
+            if !matches!(top.kind, NodeKind::Sink) {
+                top.children.push(node);
+            }
+        } else {
+            self.root.push(node);
+        }
+    }
+
+    fn push_text(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        // Sink swallows text (e.g., inside images).
+        if let Some(top) = self.stack.last() {
+            if matches!(top.kind, NodeKind::Sink) {
+                return;
+            }
+        }
+        let mut node = json!({ "type": "text", "text": text });
+        if !self.active_marks.is_empty() {
+            node["marks"] = json!(self.active_marks);
+        }
+        self.append_child(node);
+    }
+
+    fn push_code(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        if let Some(top) = self.stack.last() {
+            if matches!(top.kind, NodeKind::Sink) {
+                return;
+            }
+        }
+        // Code events get the `code` mark alongside any active marks.
+        let mut marks = self.active_marks.clone();
+        marks.push(json!({ "type": "code" }));
+        self.append_child(json!({
+            "type": "text",
+            "text": text,
+            "marks": marks,
+        }));
+    }
+
+    fn finish(self) -> Vec<Value> {
+        self.root
+    }
+}
+
+fn heading_level_to_u8(level: HeadingLevel) -> u8 {
+    match level {
+        HeadingLevel::H1 => 1,
+        HeadingLevel::H2 => 2,
+        HeadingLevel::H3 => 3,
+        HeadingLevel::H4 => 4,
+        HeadingLevel::H5 => 5,
+        HeadingLevel::H6 => 6,
+    }
+}
+```
+
+Delete these unused items:
+- `fn flush_list` (was lines 77-84)
+- `fn parse_heading` (was lines 86-98)
+- `fn parse_inline` (was lines 100-144)
+
+Keep `text_to_adf`, `adf_to_text`, `render_node`, `render_children` intact (unchanged).
+
+The unused-import warning suppression: if `Alignment`, `BlockQuoteKind`, `LinkType` show as unused after this task (Task 2/3 use them), prefix with `#[allow(unused_imports)]` on the use statement OR drop them and re-add in the task that uses them. Prefer the latter: start with only the imports this task actually uses.
+
+**Minimal imports for Task 1:**
+
+```rust
+use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+```
+
+- [ ] **Step 1.5: Add remaining block-level tests**
+
+Add these tests to `mod tests` (after the existing ones):
+
+```rust
+#[test]
+fn test_markdown_ordered_list_omits_order_when_start_is_one() {
+    let adf = markdown_to_adf("1. alpha\n2. beta");
+    assert_eq!(adf["content"][0]["type"], "orderedList");
+    assert!(adf["content"][0]["attrs"].is_null());
+}
+
+#[test]
+fn test_markdown_hard_break() {
+    // Two trailing spaces then newline = hard break.
+    let adf = markdown_to_adf("line one  \nline two");
+    // The paragraph should contain text, hardBreak, text.
+    let para = &adf["content"][0];
+    assert_eq!(para["type"], "paragraph");
+    let contents = para["content"].as_array().unwrap();
+    assert!(contents.iter().any(|n| n["type"] == "hardBreak"));
+}
+
+#[test]
+fn test_markdown_horizontal_rule() {
+    let adf = markdown_to_adf("above\n\n---\n\nbelow");
+    let has_rule = adf["content"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|n| n["type"] == "rule");
+    assert!(has_rule, "expected a rule node, got: {adf}");
+}
+
+#[test]
+fn test_markdown_soft_break_becomes_space() {
+    // Single newline inside a paragraph = soft break, which we render as a space.
+    let adf = markdown_to_adf("first line\nsecond line");
+    let para = &adf["content"][0];
+    let text = para["content"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|n| n["text"].as_str())
+        .collect::<String>();
+    assert_eq!(text, "first line second line");
+}
+
+#[test]
+fn test_markdown_nested_bullet_list() {
+    let adf = markdown_to_adf("- outer\n  - inner");
+    let outer_list = &adf["content"][0];
+    assert_eq!(outer_list["type"], "bulletList");
+    let outer_item = &outer_list["content"][0];
+    assert_eq!(outer_item["type"], "listItem");
+    // The inner list is a block-level child of the outer listItem.
+    let has_inner = outer_item["content"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|n| n["type"] == "bulletList");
+    assert!(has_inner, "expected nested bulletList, got: {outer_item}");
+}
+
+#[test]
+fn test_markdown_blockquote_wraps_children() {
+    let adf = markdown_to_adf("> quoted text");
+    let bq = &adf["content"][0];
+    assert_eq!(bq["type"], "blockquote");
+    let para = &bq["content"][0];
+    assert_eq!(para["type"], "paragraph");
+    assert_eq!(para["content"][0]["text"], "quoted text");
+}
+
+#[test]
+fn test_markdown_code_block_with_language() {
+    let adf = markdown_to_adf("```rust\nfn x() {}\n```");
+    let block = &adf["content"][0];
+    assert_eq!(block["type"], "codeBlock");
+    assert_eq!(block["attrs"]["language"], "rust");
+    // Code content should be present as a text node.
+    assert_eq!(block["content"][0]["text"], "fn x() {}\n");
+}
+
+#[test]
+fn test_markdown_empty_input() {
+    let adf = markdown_to_adf("");
+    assert_eq!(adf["type"], "doc");
+    assert_eq!(adf["content"], json!([]));
+}
+```
+
+- [ ] **Step 1.6: Run the affected tests to confirm they pass**
+
+Run: `cargo test --lib adf::`
+
+Expected: All new tests pass. Pre-existing tests (`test_text_to_adf`, `test_adf_to_text_paragraph`, `test_markdown_heading`, `test_markdown_list`, `test_markdown_code_block`, `test_adf_roundtrip_heading`, `test_adf_to_text_unsupported`, `test_adf_to_text_snapshot`) also pass.
+
+The `test_markdown_to_adf_snapshot` will fail with a snapshot mismatch — that's expected and will be addressed in Task 4.
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock src/adf.rs
+git commit -m "$(cat <<'EOF'
+feat: scaffold pulldown-cmark-based AdfBuilder for markdown_to_adf (#197)
+
+Replaces the hand-rolled line-by-line parser with a pulldown-cmark Parser
+event stream consumed by a stateful AdfBuilder. This task covers block
+nodes (paragraph, heading, blockquote, lists, codeBlock) and leaf events
+(hardBreak, softBreak, rule). Inline marks and tables follow in
+subsequent tasks.
+
+Existing tests continue to pass; snapshot test will be regenerated in
+the cleanup task.
+EOF
+)"
+```
+
+---
+
+### Task 2: Inline marks — Strong, Emphasis, Strikethrough, Link
+
+**Scope:** Teach `AdfBuilder` about inline marks. Emphasis + Strong are core CommonMark and need no flag. Strikethrough is already enabled via `ENABLE_STRIKETHROUGH` set in Task 1. Links are core CommonMark.
+
+**Files:**
+- Modify: `src/adf.rs` — extend `NodeKind`, extend `start()` and `end()` match arms, add helpers for mark lifecycle
+
+- [ ] **Step 2.1: RED — add tests for each mark**
+
+Append to `mod tests`:
+
+```rust
+#[test]
+fn test_markdown_italic_to_em_mark() {
+    let adf = markdown_to_adf("*italic words*");
+    let text_node = &adf["content"][0]["content"][0];
+    assert_eq!(text_node["type"], "text");
+    assert_eq!(text_node["text"], "italic words");
+    assert_eq!(text_node["marks"][0]["type"], "em");
+}
+
+#[test]
+fn test_markdown_bold_to_strong_mark() {
+    let adf = markdown_to_adf("**bold words**");
+    let text_node = &adf["content"][0]["content"][0];
+    assert_eq!(text_node["text"], "bold words");
+    assert_eq!(text_node["marks"][0]["type"], "strong");
+}
+
+#[test]
+fn test_markdown_strikethrough_to_strike_mark() {
+    let adf = markdown_to_adf("~~gone~~");
+    let text_node = &adf["content"][0]["content"][0];
+    assert_eq!(text_node["text"], "gone");
+    assert_eq!(text_node["marks"][0]["type"], "strike");
+}
+
+#[test]
+fn test_markdown_link_preserves_href_and_no_title() {
+    let adf = markdown_to_adf("[jr](https://example.com/jr)");
+    let text_node = &adf["content"][0]["content"][0];
+    assert_eq!(text_node["text"], "jr");
+    let mark = &text_node["marks"][0];
+    assert_eq!(mark["type"], "link");
+    assert_eq!(mark["attrs"]["href"], "https://example.com/jr");
+    // Title is absent when not provided in markdown.
+    assert!(mark["attrs"]["title"].is_null());
+}
+
+#[test]
+fn test_markdown_link_preserves_href_and_title() {
+    let adf = markdown_to_adf(r#"[jr](https://example.com/jr "JR docs")"#);
+    let mark = &adf["content"][0]["content"][0]["marks"][0];
+    assert_eq!(mark["type"], "link");
+    assert_eq!(mark["attrs"]["href"], "https://example.com/jr");
+    assert_eq!(mark["attrs"]["title"], "JR docs");
+}
+
+#[test]
+fn test_markdown_mixed_marks() {
+    // "**bold *italic* bold**" — nested emphasis should produce two separate
+    // text nodes with overlapping/non-overlapping marks as pulldown-cmark parses them.
+    let adf = markdown_to_adf("**bold _italic_ bold**");
+    let content = adf["content"][0]["content"].as_array().unwrap();
+    // At minimum, every text node here should have the `strong` mark.
+    assert!(
+        content
+            .iter()
+            .all(|n| n["marks"].as_array().is_some_and(
+                |m| m.iter().any(|mk| mk["type"] == "strong")
+            )),
+        "every text node should carry strong, got: {content:?}"
+    );
+    // And at least one node should also carry `em`.
+    assert!(
+        content.iter().any(|n| n["marks"].as_array().is_some_and(
+            |m| m.iter().any(|mk| mk["type"] == "em")
+        )),
+        "expected at least one node with em + strong, got: {content:?}"
+    );
+}
+
+#[test]
+fn test_markdown_escape_literal_asterisk() {
+    let adf = markdown_to_adf(r"\*not italic\*");
+    let text_node = &adf["content"][0]["content"][0];
+    assert_eq!(text_node["text"], "*not italic*");
+    // No em mark because backslash escapes the asterisks.
+    assert!(text_node["marks"].is_null());
+}
+```
+
+- [ ] **Step 2.2: Run tests to verify they fail**
+
+Run: `cargo test --lib adf::test_markdown_italic adf::test_markdown_bold adf::test_markdown_strikethrough adf::test_markdown_link adf::test_markdown_mixed adf::test_markdown_escape`
+
+Expected: FAIL — text nodes emit without marks (all current NodeKind::Sink).
+
+- [ ] **Step 2.3: GREEN — implement inline-mark handling**
+
+In `src/adf.rs`, update the `use pulldown_cmark::...` line to include the additional identifiers for this task:
+
+```rust
+use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, LinkType, Options, Parser, Tag, TagEnd};
+```
+
+Add the `InlineMark` variant to `NodeKind`. Append to the `enum NodeKind` definition (after `Sink`):
+
+```rust
+    // Container for inline marks. Has no ADF node; just manages the active_marks stack
+    // so End events pop cleanly.
+    InlineMark,
+```
+
+Extend the `start()` match arms. Replace the existing `Tag::Image { .. } => self.push(NodeKind::Sink),` arm and append just before the final `_ => self.push(NodeKind::Sink),` catch-all:
+
+```rust
+            Tag::Strong => self.push_mark(json!({ "type": "strong" })),
+            Tag::Emphasis => self.push_mark(json!({ "type": "em" })),
+            Tag::Strikethrough => self.push_mark(json!({ "type": "strike" })),
+            Tag::Link { dest_url, title, .. } => {
+                let mut attrs = serde_json::Map::new();
+                attrs.insert("href".to_string(), json!(dest_url.as_ref()));
+                if !title.is_empty() {
+                    attrs.insert("title".to_string(), json!(title.as_ref()));
+                }
+                self.push_mark(json!({ "type": "link", "attrs": attrs }));
+            }
+            Tag::Image { .. } => self.push(NodeKind::Sink),
+```
+
+Add `push_mark` and `pop_mark` methods inside `impl AdfBuilder`:
+
+```rust
+    fn push_mark(&mut self, mark: Value) {
+        self.active_marks.push(mark);
+        self.push(NodeKind::InlineMark);
+    }
+
+    fn pop_mark(&mut self) {
+        self.active_marks.pop();
+    }
+```
+
+Update the `end()` method's match so `InlineMark` pops the mark. Replace the existing `NodeKind::Sink => None,` arm with:
+
+```rust
+            NodeKind::InlineMark => {
+                self.pop_mark();
+                None
+            }
+            NodeKind::Sink => None,
+```
+
+Note: the `LinkType` import may look unused — it isn't referenced directly by our match (we destructure `Link { dest_url, title, .. }` ignoring `link_type`). Drop `LinkType` from the `use` statement; keep only what's named:
+
+```rust
+use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+```
+
+(That's identical to Task 1's import line — no change actually needed for Task 2.)
+
+- [ ] **Step 2.4: Run the new tests to verify they pass**
+
+Run: `cargo test --lib adf::test_markdown_italic adf::test_markdown_bold adf::test_markdown_strikethrough adf::test_markdown_link adf::test_markdown_mixed adf::test_markdown_escape`
+
+Expected: all 7 pass.
+
+- [ ] **Step 2.5: Re-run the full adf test module to check for regressions**
+
+Run: `cargo test --lib adf::`
+
+Expected: all tests except `test_markdown_to_adf_snapshot` pass (the snapshot is still pending Task 4).
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add src/adf.rs
+git commit -m "feat: add inline-mark handling (strong, em, strike, link) to AdfBuilder (#197)"
+```
+
+---
+
+### Task 3: Tables — `Table`, `TableHead`, `TableRow`, `TableCell` with header cell distinction
+
+**Scope:** Handle the four table-related Tags. First row's cells emit as `tableHeader`; subsequent rows' cells emit as `tableCell`. We ignore column alignment (ADF has no per-column alignment attribute).
+
+**Important event-shape note:** pulldown-cmark emits `Tag::TableHead` containing `Tag::TableCell` events directly — there is NO `Tag::TableRow` inside `TableHead`. Only body rows emit `Tag::TableRow`. That's why our `Tag::TableHead` arm pushes a synthetic `NodeKind::TableRow` (so the header row still becomes an ADF `tableRow` node containing `tableHeader` cells, which is what the ADF schema requires).
+
+Event sequence for `| foo | bar |\n| --- | --- |\n| baz | qux |`:
+
+```
+Start(Table) → Start(TableHead) → Start(TableCell) → Text("foo") → End(TableCell) → ... → End(TableHead)
+             → Start(TableRow)  → Start(TableCell) → Text("baz") → End(TableCell) → ... → End(TableRow)
+             → End(Table)
+```
+
+**Files:**
+- Modify: `src/adf.rs` — extend `start()` / `end()` match arms for table tags, wire up the `in_table_head` flag
+
+- [ ] **Step 3.1: RED — add a table test**
+
+Append to `mod tests`:
+
+```rust
+#[test]
+fn test_markdown_table_cells_and_headers() {
+    let input = "| foo | bar |\n| --- | --- |\n| baz | qux |";
+    let adf = markdown_to_adf(input);
+    let table = &adf["content"][0];
+    assert_eq!(table["type"], "table");
+
+    let rows = table["content"].as_array().unwrap();
+    assert_eq!(rows.len(), 2, "expected 2 tableRows (header + body)");
+
+    // Header row's cells should be tableHeader.
+    let header_cells = rows[0]["content"].as_array().unwrap();
+    assert_eq!(header_cells[0]["type"], "tableHeader");
+    assert_eq!(header_cells[1]["type"], "tableHeader");
+
+    // Body row's cells should be tableCell.
+    let body_cells = rows[1]["content"].as_array().unwrap();
+    assert_eq!(body_cells[0]["type"], "tableCell");
+    assert_eq!(body_cells[1]["type"], "tableCell");
+
+    // Cells wrap their content in a paragraph, per ADF convention.
+    let first_header_text = &header_cells[0]["content"][0];
+    assert_eq!(first_header_text["type"], "paragraph");
+    assert_eq!(first_header_text["content"][0]["text"], "foo");
+}
+```
+
+- [ ] **Step 3.2: Run the table test to verify it fails**
+
+Run: `cargo test --lib adf::test_markdown_table_cells_and_headers`
+
+Expected: FAIL — tables currently produce nothing (Tag::Table falls through to `NodeKind::Sink`).
+
+- [ ] **Step 3.3: GREEN — implement table handling**
+
+Add the table `NodeKind` variants. Append to the `enum NodeKind` definition:
+
+```rust
+    Table,
+    TableRow,
+    TableCell { is_header: bool },
+```
+
+In `src/adf.rs`, extend the `start()` match arms. Replace the `_ => self.push(NodeKind::Sink),` catch-all with these arms followed by the catch-all:
+
+```rust
+            Tag::Table(_) => self.push(NodeKind::Table),
+            Tag::TableHead => {
+                self.in_table_head = true;
+                self.push(NodeKind::TableRow);
+            }
+            Tag::TableRow => self.push(NodeKind::TableRow),
+            Tag::TableCell => self.push(NodeKind::TableCell {
+                is_header: self.in_table_head,
+            }),
+            _ => self.push(NodeKind::Sink),
+```
+
+Extend the `end()` match arms. Add these arms immediately before the existing `NodeKind::InlineMark` / `NodeKind::Sink` arms:
+
+```rust
+            NodeKind::Table => Some(json!({ "type": "table", "content": children })),
+            NodeKind::TableRow => {
+                Some(json!({ "type": "tableRow", "content": children }))
+            }
+            NodeKind::TableCell { is_header } => {
+                // ADF requires cells to wrap content in a block (paragraph).
+                // pulldown-cmark emits Text events directly inside TableCell
+                // without a Paragraph wrapper, so we wrap here.
+                let cell_type = if is_header { "tableHeader" } else { "tableCell" };
+                let wrapped_content = if children
+                    .iter()
+                    .all(|n| n["type"].as_str().is_some_and(|t| matches!(t, "paragraph" | "bulletList" | "orderedList" | "blockquote" | "codeBlock" | "heading")))
+                {
+                    children
+                } else {
+                    vec![json!({ "type": "paragraph", "content": children })]
+                };
+                Some(json!({ "type": cell_type, "content": wrapped_content }))
+            }
+```
+
+Add the `in_table_head` reset to `end()` when closing `TableHead`. The cleanest place is to detect the TagEnd variant. Update the start of `end()`:
+
+```rust
+    fn end(&mut self, tag_end: TagEnd) {
+        if matches!(tag_end, TagEnd::TableHead) {
+            self.in_table_head = false;
+        }
+        let Some(partial) = self.stack.pop() else {
+            return;
+        };
+```
+
+- [ ] **Step 3.4: Run the table test to verify it passes**
+
+Run: `cargo test --lib adf::test_markdown_table_cells_and_headers`
+
+Expected: PASS.
+
+- [ ] **Step 3.5: Re-run the full adf test module**
+
+Run: `cargo test --lib adf::`
+
+Expected: all tests except `test_markdown_to_adf_snapshot` pass.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add src/adf.rs
+git commit -m "feat: convert GFM tables to ADF table/tableRow/tableHeader/tableCell nodes (#197)"
+```
+
+---
+
+### Task 4: Fallbacks, snapshot regeneration, integration-test verification, cleanup
+
+**Scope:** Add tests for the explicit non-mappings (images skipped, task list syntax preserved as text) and verify end-to-end flow. Regenerate the complex snapshot. Run the full CI-equivalent check set.
+
+**Files:**
+- Modify: `src/adf.rs #[cfg(test)]` — add tests, update the snapshot input to exercise union of features
+- Regenerated: `src/snapshots/jr__adf__tests__markdown_complex_to_adf.snap`
+
+- [ ] **Step 4.1: RED — add fallback tests and refresh the snapshot input**
+
+Append to `mod tests`:
+
+```rust
+#[test]
+fn test_markdown_image_is_skipped() {
+    let adf = markdown_to_adf("before ![alt](https://example.com/img.png) after");
+    let para_text: String = adf["content"][0]["content"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|n| n["text"].as_str())
+        .collect::<String>();
+    // Image should be omitted — only the surrounding text remains.
+    // "before " and " after" become "before  after" (double space where image was).
+    assert!(para_text.contains("before"), "got: {para_text:?}");
+    assert!(para_text.contains("after"), "got: {para_text:?}");
+    assert!(!para_text.contains("img.png"), "image URL should not leak: {para_text:?}");
+    // No image nodes emitted.
+    let has_image = adf.to_string().contains("\"image\"") || adf.to_string().contains("media");
+    assert!(!has_image, "no image/media nodes should be emitted: {adf}");
+}
+
+#[test]
+fn test_markdown_task_list_syntax_preserved_as_text() {
+    // ENABLE_TASKLISTS is not set, so `[x]` renders as literal text inside a bullet item.
+    let adf = markdown_to_adf("- [x] done task\n- [ ] pending task");
+    let list = &adf["content"][0];
+    assert_eq!(list["type"], "bulletList");
+    let items = list["content"].as_array().unwrap();
+    let text = |item: &Value| -> String {
+        item["content"][0]["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|n| n["text"].as_str())
+            .collect()
+    };
+    assert!(text(&items[0]).contains("[x]"), "got: {}", text(&items[0]));
+    assert!(text(&items[0]).contains("done task"));
+    assert!(text(&items[1]).contains("[ ]"));
+    assert!(text(&items[1]).contains("pending task"));
+}
+```
+
+Next, update the existing `test_markdown_to_adf_snapshot` input to exercise the union of features. Replace the current test body:
+
+```rust
+    #[test]
+    fn test_markdown_to_adf_snapshot() {
+        let input = "## Root cause\n\nThe auth module had a **critical bug** in `validate_token`.\n\n- Missing null check\n- Wrong error type\n\n```rust\nfn validate() -> bool {\n    true\n}\n```";
+        let adf = markdown_to_adf(input);
+        insta::assert_json_snapshot!("markdown_complex_to_adf", adf);
+    }
+```
+
+with:
+
+```rust
+    #[test]
+    fn test_markdown_to_adf_snapshot() {
+        let input = concat!(
+            "# Header 1\n",
+            "\n",
+            "Paragraph with **bold**, *italic*, ~~strike~~, `inline code`, and a ",
+            "[link](https://example.com \"title\").\n",
+            "\n",
+            "## Header 2\n",
+            "\n",
+            "- bullet one\n",
+            "- bullet two\n",
+            "  - nested bullet\n",
+            "\n",
+            "1. ordered\n",
+            "2. items\n",
+            "\n",
+            "> blockquoted text\n",
+            "\n",
+            "| Col A | Col B |\n",
+            "| ----- | ----- |\n",
+            "| a1    | b1    |\n",
+            "| a2    | b2    |\n",
+            "\n",
+            "---\n",
+            "\n",
+            "```rust\n",
+            "fn validate() -> bool { true }\n",
+            "```\n",
+        );
+        let adf = markdown_to_adf(input);
+        insta::assert_json_snapshot!("markdown_complex_to_adf", adf);
+    }
+```
+
+- [ ] **Step 4.2: Run all adf tests**
+
+Run: `cargo test --lib adf::`
+
+Expected: the two new fallback tests pass; the snapshot test fails with "snapshot assertion" until we accept the new snap file.
+
+- [ ] **Step 4.3: Review and accept the new snapshot**
+
+Run: `cargo install cargo-insta 2>/dev/null || true` (idempotent — installs if missing).
+
+Run: `cargo insta review`
+
+In the TUI, inspect the new snapshot of `markdown_complex_to_adf`. Verify by eye:
+- `heading` nodes with `attrs.level = 1` and `attrs.level = 2`
+- `paragraph` with `strong`, `em`, `strike`, `code` marks on the text nodes
+- `link` mark with `attrs.href = "https://example.com"` and `attrs.title = "title"`
+- `bulletList` with nested `bulletList` inside one `listItem`
+- `orderedList` with no `attrs.order` (since start = 1)
+- `blockquote` wrapping a `paragraph`
+- `table` with `tableRow` containing `tableHeader` first row and `tableCell` subsequent rows
+- `rule` block at the `---` location
+- `codeBlock` with `attrs.language = "rust"`
+
+Press `a` to accept. If the structure is wrong, abort the review, fix the builder, and re-run.
+
+Alternative non-interactive path if the TUI is unavailable: `cargo insta accept` after verifying the `.snap.new` file manually.
+
+- [ ] **Step 4.4: Run the integration tests to confirm end-to-end**
+
+Run: `cargo test --test issue_commands`
+
+Expected: all tests pass, including the three that call `jr::adf::markdown_to_adf` at `:589`, `:631`, `:671`. These drive wiremock `body_partial_json` matchers with the output of the new builder — if the client is POSTing what the new builder emits, they pass.
+
+- [ ] **Step 4.5: Full CI-equivalent check set**
+
+Run each, in order, fixing failures before proceeding:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+Expected: all three clean.
+
+If `cargo fmt --check` fails, run `cargo fmt --all` and recommit. If `clippy` flags `unused_imports` or `too_many_arguments`, refactor per project convention (no `#[allow]` without justification — see CLAUDE.md "No lint suppression without refactoring").
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add src/adf.rs src/snapshots/
+git commit -m "$(cat <<'EOF'
+test: regenerate markdown-to-ADF snapshot covering full feature matrix (#197)
+
+Replaces the previous simple snapshot with input exercising headings,
+all inline marks (strong/em/strike/code/link), nested lists, ordered
+lists, blockquote, table (with header and body rows), horizontal rule,
+and fenced code block with language. Adds tests for explicit fallbacks:
+images are skipped, task list syntax passes through as literal text.
+
+Closes #197.
+EOF
+)"
+```
+
+---
+
+## Self-Review Checklist (for the engineer)
+
+Before marking the plan complete, verify:
+
+**Spec coverage:**
+- [ ] `markdown_to_adf(&str) -> Value` signature unchanged — call sites in `workflow.rs:417`, `create.rs:98`, `create.rs:199` untouched
+- [ ] All block nodes from spec "Feature Mapping" are implemented: heading, paragraph, blockquote, codeBlock, bulletList, orderedList, listItem, table, tableRow, tableCell, tableHeader
+- [ ] All inline marks: strong, em, strike, code, link (with href + title)
+- [ ] All leaf events: Text, Code, SoftBreak (space), HardBreak, Rule
+- [ ] All fallbacks: Image (skip), Html/InlineHtml (literal text), FootnoteReference (ignore), task list syntax (literal brackets in text)
+- [ ] Per-column table alignment silently dropped (no `align` attr emitted; no warning)
+- [ ] `orderedList.attrs.order` omitted when start = 1, emitted when start ≠ 1
+
+**Test coverage:**
+- [ ] Unit tests exist for every row in the "Feature Mapping" table
+- [ ] Snapshot test covers the union of features
+- [ ] Integration tests in `tests/issue_commands.rs` pass without modification
+
+**Code quality:**
+- [ ] `parse_heading`, `parse_inline`, `flush_list` removed (no dead code)
+- [ ] `text_to_adf` and `adf_to_text` untouched
+- [ ] `cargo fmt --all -- --check` clean
+- [ ] `cargo clippy --all-targets -- -D warnings` clean
+- [ ] No `#[allow]` added without refactor (CLAUDE.md policy)
+
+**Dependencies:**
+- [ ] `Cargo.toml` adds `pulldown-cmark = { version = "0.13", default-features = false }` only
+- [ ] No other dependencies added
+
+---
+
+## Out of Scope (Do Not Add)
+
+- `adf_to_text` reverse-direction support for tables/links/marks — separate issue if needed
+- `--markdown` flag on `jr worklog add` — out of #197 scope
+- Wiki markup (`--wiki`) conversion — separate feature, not this PR
+- Markdown images via media-upload — requires attachment flow, out of scope
+- `--debug` verbose flag, response body logging — unrelated
+- Refactoring `text_to_adf` or `adf_to_text` — unchanged in this PR

--- a/docs/superpowers/specs/2026-04-16-markdown-to-adf-conversion-design.md
+++ b/docs/superpowers/specs/2026-04-16-markdown-to-adf-conversion-design.md
@@ -67,7 +67,7 @@ Stack-based builder — the idiomatic pattern for event-stream → tree conversi
 struct AdfBuilder {
     root: Vec<Value>,              // Top-level block nodes
     stack: Vec<PartialNode>,       // Open containers (Heading, Paragraph, List, Item, BlockQuote, Table, Row, Cell, ...)
-    active_marks: Vec<Value>,      // Currently-open inline marks (strong, em, code, strike, link)
+    active_marks: Vec<Value>,      // Currently-open inline marks (strong, em, strike, link). The `code` mark is not tracked here — it attaches per-event in `push_code`.
     in_table_head: bool,           // For distinguishing tableHeader from tableCell
 }
 
@@ -117,7 +117,7 @@ Inline marks use a parallel `active_marks` list. When `Text(s)` fires while mark
 | Event | ADF handling |
 |---|---|
 | `Text(s)` | Append `{"type":"text","text":s, "marks"?: [...active_marks]}` to current container |
-| `Code(s)` | Append `{"type":"text","text":s,"marks":[{"type":"code"}, ...active_marks]}` |
+| `Code(s)` | Append `{"type":"text","text":s,"marks":[...active_marks, {"type":"code"}]}` |
 | `SoftBreak` | Emit a single space — ADF has no soft-break node |
 | `HardBreak` | Emit `{"type":"hardBreak"}` |
 | `Rule` | Emit `{"type":"rule"}` at block level |

--- a/docs/superpowers/specs/2026-04-16-markdown-to-adf-conversion-design.md
+++ b/docs/superpowers/specs/2026-04-16-markdown-to-adf-conversion-design.md
@@ -49,6 +49,9 @@ Replace the internals of `adf::markdown_to_adf()` with a `pulldown_cmark::Parser
 ```
 &str
   ↓ Parser::new_ext(input, Options::ENABLE_TABLES | ENABLE_STRIKETHROUGH)
+  ↓ TextMergeStream::new(...)        // merges adjacent Event::Text runs so
+                                      // marks and escape sequences coalesce
+                                      // into a single text node
   ↓ Iterator<Event<'_>>
   ↓ AdfBuilder.process(event) for each event
   ↓ Vec<Value> (root block-level nodes)
@@ -71,9 +74,10 @@ struct AdfBuilder {
 struct PartialNode {
     kind: NodeKind,                // Which ADF node this will become
     children: Vec<Value>,
-    attrs: Option<Map<String, Value>>,
 }
 ```
+
+Attributes (heading level, code block language, ordered-list `order`, tableCell `is_header`) are carried on the `NodeKind` variant itself (e.g. `Heading(u8)`, `CodeBlock { language }`, `OrderedList { start }`, `TableCell { is_header }`) rather than on a separate `attrs` field, so the emission logic in `end()` can destructure the kind and build the final JSON object in one step.
 
 `Event::Start(Tag::X)` pushes a `PartialNode`. `Event::End(TagEnd::X)` pops the stack, wraps `children` into the partial's content, and appends the completed `Value` to the parent's children (or to `root` if the stack is empty). Text / inline events append leaves to the current top-of-stack's children.
 

--- a/docs/superpowers/specs/2026-04-16-markdown-to-adf-conversion-design.md
+++ b/docs/superpowers/specs/2026-04-16-markdown-to-adf-conversion-design.md
@@ -181,7 +181,7 @@ Kept tests: the existing `test_markdown_heading`, `test_markdown_list`, `test_ma
 
 **Snapshot test:** `test_markdown_to_adf_snapshot` (existing) — updated to exercise the union of features in one realistic prose block. Catches regressions from pulldown-cmark version bumps and builder refactors. Snapshot file regenerates on first run.
 
-**Integration tests:** `tests/issue_commands.rs:589,631,671` use `jr::adf::markdown_to_adf()` as the wiremock `body_partial_json` matcher source-of-truth. They auto-track whatever the new implementation emits — no test code change needed. They verify the full CLI → client → HTTP path ships the new ADF shape.
+**Integration tests:** `tests/issue_commands.rs:631` uses `jr::adf::markdown_to_adf()` as the wiremock `body_partial_json` matcher source-of-truth for the `--markdown` write path. (Sibling tests at `:589` and `:671` exercise `text_to_adf` and are unaffected.) The markdown test auto-tracks whatever the new implementation emits — no test code change needed. It verifies the full CLI → client → HTTP path ships the new ADF shape.
 
 **No proptest.** The codebase uses proptest only for pure symbolic round-trip functions (`partial_match`, `jql`, `duration`). Markdown→ADF is stateful event-driven; pulldown-cmark already passes the CommonMark spec suite upstream. Our responsibility is the mapping, not the parser.
 

--- a/docs/superpowers/specs/2026-04-16-markdown-to-adf-conversion-design.md
+++ b/docs/superpowers/specs/2026-04-16-markdown-to-adf-conversion-design.md
@@ -8,11 +8,11 @@
 
 | Command | Call site |
 |---|---|
-| `jr issue comment --markdown` | `src/cli/issue/workflow.rs:417-420` |
-| `jr issue create --markdown` (description) | `src/cli/issue/create.rs:98-102` |
-| `jr issue edit --markdown` (description) | `src/cli/issue/create.rs:199-202` |
+| `jr issue comment --markdown` | `cli/issue/workflow.rs` (`handle_comment`) |
+| `jr issue create --markdown` (description) | `cli/issue/create.rs` (`handle_create`) |
+| `jr issue edit --markdown` (description) | `cli/issue/create.rs` (`handle_edit`) |
 
-All three route through `adf::markdown_to_adf()`. Today that function is a hand-rolled line-by-line parser (`src/adf.rs:18-144`) that handles only a partial subset of markdown: headings, bullet lists, code blocks, bold (`**`), inline code (`` ` ``).
+All three routed through `adf::markdown_to_adf()`. Before this change, that function was a hand-rolled line-by-line parser in `src/adf.rs` that handled only a partial subset of markdown: headings, bullet lists, code blocks, bold (`**`), inline code (`` ` ``).
 
 **What is silently dropped:**
 
@@ -28,19 +28,19 @@ All three route through `adf::markdown_to_adf()`. Today that function is a hand-
 - Escape sequences (`\*not italic\*`)
 - Interleaved inline marks (`**bold _italic_ bold**`)
 
-Each of these falls through to literal text inside a single `paragraph > text` node, which Jira renders as raw source syntax. The issue's "wiki markup" half is out of scope — `jr` has never claimed wiki markup support, and the `--markdown` flag only covers markdown.
+Each of these fell through to literal text inside a single `paragraph > text` node, which Jira rendered as raw source syntax. The issue's "wiki markup" half is out of scope — `jr` has never claimed wiki markup support, and the `--markdown` flag only covers markdown.
 
-The bug's blast radius is all three commands simultaneously. A user running `jr issue create --markdown` today gets a broken description stored on the issue exactly as badly as `jr issue comment --markdown` gets a broken comment body.
+The bug's blast radius was all three commands simultaneously. A user running `jr issue create --markdown` got a broken description stored on the issue exactly as badly as `jr issue comment --markdown` produced a broken comment body.
 
 ## Design
 
 ### Core Change
 
-Replace the internals of `adf::markdown_to_adf()` with a `pulldown_cmark::Parser` event stream and a stateful `AdfBuilder`. The public signature stays `fn markdown_to_adf(markdown: &str) -> serde_json::Value` — callers at `workflow.rs:417`, `create.rs:98`, `create.rs:199` don't change.
+Replace the internals of `adf::markdown_to_adf()` with a `pulldown_cmark::Parser` event stream and a stateful `AdfBuilder`. The public signature stays `fn markdown_to_adf(markdown: &str) -> serde_json::Value` — the three callers in `workflow.rs` and `create.rs` don't change.
 
 **Dependency:** `pulldown-cmark = { version = "0.13", default-features = false }` added to `Cargo.toml`. Default features (`simd`, `html`, `serde`) are unused by our event-iteration path; disabling them keeps the dep light.
 
-**Why pulldown-cmark vs extending the hand-rolled parser:** the existing parser has correctness gaps even in code paths we already ship (`parse_inline` at `adf.rs:100-144` can only match the first delimiter of each type, no escape handling, emphasis vs bold disambiguation collides with `*` / `**`). Adding each missing feature (links, italics, tables, nested lists, escape sequences, left/right flanking rules) means re-implementing CommonMark by hand — the spec pulldown-cmark already passes. Used by rustdoc and mdbook; de facto Rust CommonMark parser.
+**Why pulldown-cmark vs extending the hand-rolled parser:** the old parser had correctness gaps even in the features it claimed to support (its `parse_inline` helper could only match the first delimiter of each type, had no escape handling, and its emphasis-vs-bold disambiguation collided on `*` / `**`). Adding each missing feature (links, italics, tables, nested lists, escape sequences, left/right flanking rules) would have meant re-implementing CommonMark by hand — the spec pulldown-cmark already passes. Used by rustdoc and mdbook; de facto Rust CommonMark parser.
 
 **Why pulldown-cmark vs comrak:** comrak bundles an HTML renderer we'd never use and is heavier. markdown-rs (mdast) is less mature. pulldown-cmark's event-driven API maps cleanly to building an ADF tree.
 
@@ -223,9 +223,9 @@ Infallible signature — `markdown_to_adf(&str) → Value` does not return `Resu
   - Malformed tables revert to paragraph at the parser level — no `Tag::Table` event emitted
 - **Local verification (2026-04-16):** `cargo search pulldown-cmark` confirms latest `0.13.3`; project MSRV `rust-version = "1.85"` (`Cargo.toml:7`) well above pulldown-cmark's 1.74 requirement
 - **Codebase audit:**
-  - All three `--markdown` call sites (`workflow.rs:417-420`, `create.rs:98-102`, `create.rs:199-202`) use the identical `if markdown { markdown_to_adf } else { text_to_adf }` pattern — one rewrite fixes all three
-  - `adf_to_text` read-path (`list.rs:651,666,756`) operates on ADF `Value`s; no coupling to the write-path parser shape
-  - Existing insta snapshot lives at `src/snapshots/jr__adf__tests__markdown_complex_to_adf.snap` — regeneration on first test run is the convention
+  - All three `--markdown` call sites (in `cli/issue/workflow.rs` and `cli/issue/create.rs`) use the identical `if markdown { markdown_to_adf } else { text_to_adf }` pattern — one rewrite fixes all three
+  - The `adf_to_text` read-path (invoked from `cli/issue/list.rs` when displaying comments and descriptions) operates on ADF `Value`s; no coupling to the write-path parser shape
+  - The insta snapshot at `src/snapshots/jr__adf__tests__markdown_complex_to_adf.snap` is regenerated on first test run per the codebase convention
 
 ## Out of Scope (Follow-Ups)
 

--- a/docs/superpowers/specs/2026-04-16-markdown-to-adf-conversion-design.md
+++ b/docs/superpowers/specs/2026-04-16-markdown-to-adf-conversion-design.md
@@ -1,0 +1,239 @@
+# Markdown-to-ADF Conversion (Replace Hand-Rolled Parser)
+
+> **Issue:** #197 — `bug: issue comment --markdown and wiki markup both render as plain text — no ADF conversion`
+
+## Problem
+
+`jr` accepts a `--markdown` flag on three commands that produce ADF bodies for Jira:
+
+| Command | Call site |
+|---|---|
+| `jr issue comment --markdown` | `src/cli/issue/workflow.rs:417-420` |
+| `jr issue create --markdown` (description) | `src/cli/issue/create.rs:98-102` |
+| `jr issue edit --markdown` (description) | `src/cli/issue/create.rs:199-202` |
+
+All three route through `adf::markdown_to_adf()`. Today that function is a hand-rolled line-by-line parser (`src/adf.rs:18-144`) that handles only a partial subset of markdown: headings, bullet lists, code blocks, bold (`**`), inline code (`` ` ``).
+
+**What is silently dropped:**
+
+- `*italic*` / `_italic_` — emphasis
+- `[text](url)` — inline links
+- `1. item` — ordered lists
+- `| a | b |` — tables
+- `~~strike~~` — strikethrough
+- `> blockquote` — blockquotes
+- `---` — horizontal rules
+- Hard breaks (two trailing spaces)
+- Nested lists
+- Escape sequences (`\*not italic\*`)
+- Interleaved inline marks (`**bold _italic_ bold**`)
+
+Each of these falls through to literal text inside a single `paragraph > text` node, which Jira renders as raw source syntax. The issue's "wiki markup" half is out of scope — `jr` has never claimed wiki markup support, and the `--markdown` flag only covers markdown.
+
+The bug's blast radius is all three commands simultaneously. A user running `jr issue create --markdown` today gets a broken description stored on the issue exactly as badly as `jr issue comment --markdown` gets a broken comment body.
+
+## Design
+
+### Core Change
+
+Replace the internals of `adf::markdown_to_adf()` with a `pulldown_cmark::Parser` event stream and a stateful `AdfBuilder`. The public signature stays `fn markdown_to_adf(markdown: &str) -> serde_json::Value` — callers at `workflow.rs:417`, `create.rs:98`, `create.rs:199` don't change.
+
+**Dependency:** `pulldown-cmark = { version = "0.13", default-features = false }` added to `Cargo.toml`. Default features (`simd`, `html`, `serde`) are unused by our event-iteration path; disabling them keeps the dep light.
+
+**Why pulldown-cmark vs extending the hand-rolled parser:** the existing parser has correctness gaps even in code paths we already ship (`parse_inline` at `adf.rs:100-144` can only match the first delimiter of each type, no escape handling, emphasis vs bold disambiguation collides with `*` / `**`). Adding each missing feature (links, italics, tables, nested lists, escape sequences, left/right flanking rules) means re-implementing CommonMark by hand — the spec pulldown-cmark already passes. Used by rustdoc and mdbook; de facto Rust CommonMark parser.
+
+**Why pulldown-cmark vs comrak:** comrak bundles an HTML renderer we'd never use and is heavier. markdown-rs (mdast) is less mature. pulldown-cmark's event-driven API maps cleanly to building an ADF tree.
+
+### Data Flow
+
+```
+&str
+  ↓ Parser::new_ext(input, Options::ENABLE_TABLES | ENABLE_STRIKETHROUGH)
+  ↓ Iterator<Event<'_>>
+  ↓ AdfBuilder.process(event) for each event
+  ↓ Vec<Value> (root block-level nodes)
+  ↓ wrap in {"version":1,"type":"doc","content":[...]}
+serde_json::Value
+```
+
+### Builder Architecture
+
+Stack-based builder — the idiomatic pattern for event-stream → tree conversion (used internally by pulldown-cmark's HTML renderer; documented in pulldown-cmark's dev guide):
+
+```rust
+struct AdfBuilder {
+    root: Vec<Value>,              // Top-level block nodes
+    stack: Vec<PartialNode>,       // Open containers (Heading, Paragraph, List, Item, BlockQuote, Table, Row, Cell, ...)
+    active_marks: Vec<Value>,      // Currently-open inline marks (strong, em, code, strike, link)
+    in_table_head: bool,           // For distinguishing tableHeader from tableCell
+}
+
+struct PartialNode {
+    kind: NodeKind,                // Which ADF node this will become
+    children: Vec<Value>,
+    attrs: Option<Map<String, Value>>,
+}
+```
+
+`Event::Start(Tag::X)` pushes a `PartialNode`. `Event::End(TagEnd::X)` pops the stack, wraps `children` into the partial's content, and appends the completed `Value` to the parent's children (or to `root` if the stack is empty). Text / inline events append leaves to the current top-of-stack's children.
+
+Inline marks use a parallel `active_marks` list. When `Text(s)` fires while marks are active, the emitted `{"type":"text","text":s}` node gets `"marks": [...active_marks]` attached.
+
+### Feature Mapping
+
+**Block nodes** (emit via `Event::Start(Tag::_) → Event::End(TagEnd::_)` pair):
+
+| pulldown-cmark `Tag` | ADF node |
+|---|---|
+| `Heading { level, .. }` | `heading` with `attrs.level` (1-6) |
+| `Paragraph` | `paragraph` |
+| `BlockQuote(_)` | `blockquote` |
+| `CodeBlock(CodeBlockKind::Fenced(lang))` | `codeBlock` with `attrs.language` if non-empty |
+| `CodeBlock(CodeBlockKind::Indented)` | `codeBlock` with no language attr |
+| `List(None)` | `bulletList` |
+| `List(Some(1))` | `orderedList` (no `order` attr — defaults to 1) |
+| `List(Some(n))` where n ≠ 1 | `orderedList` with `attrs.order = n` |
+| `Item` | `listItem` |
+| `Table(_)` | `table` (no attrs; alignment Vec ignored — ADF has no per-column alignment) |
+| `TableHead` / `TableRow` | `tableRow` |
+| `TableCell` (inside `TableHead`) | `tableHeader` |
+| `TableCell` (elsewhere) | `tableCell` |
+
+**Inline marks** (applied to every `Text` event emitted while the mark is active):
+
+| pulldown-cmark `Tag` | ADF mark |
+|---|---|
+| `Strong` | `{"type": "strong"}` |
+| `Emphasis` | `{"type": "em"}` |
+| `Strikethrough` | `{"type": "strike"}` |
+| `Link { dest_url, title, .. }` | `{"type": "link", "attrs": {"href": <dest_url>, "title"?: <title>}}` |
+
+**Leaf events:**
+
+| Event | ADF handling |
+|---|---|
+| `Text(s)` | Append `{"type":"text","text":s, "marks"?: [...active_marks]}` to current container |
+| `Code(s)` | Append `{"type":"text","text":s,"marks":[{"type":"code"}, ...active_marks]}` |
+| `SoftBreak` | Emit a single space — ADF has no soft-break node |
+| `HardBreak` | Emit `{"type":"hardBreak"}` |
+| `Rule` | Emit `{"type":"rule"}` at block level |
+
+**Explicit non-mappings** (events we intentionally drop or render as fallback text):
+
+| Event | Behavior | Reason |
+|---|---|---|
+| `Start(Tag::Image { .. })` through `End(TagEnd::Image)` | Skip — suppress events between until end | Jira Cloud `media` nodes require pre-upload to the media API with a returned media ID; external URLs aren't reliably supported in comments |
+| `Html(s)` / `InlineHtml(s)` | Emit as literal text via `Text(s)` handling | Preserves user intent without attempting unsafe HTML-to-ADF mapping |
+| `FootnoteReference(_)` / `Start(Tag::FootnoteDefinition(_))` | Skip | ADF has no native footnote nodes; would require embedding as inline links, low ROI |
+| `TaskListMarker(checked)` | Prepend `[x] ` or `[ ] ` to the containing list item's first paragraph text | `taskList`/`taskItem`/`blockTaskItem` ADF support is Confluence-centric; safer to render as text marker inside a regular `bulletList` |
+| `Tag::DefinitionList` / `DefinitionListTitle` / `DefinitionListDefinition` | Not enabled via Options — events won't fire | Out of scope for scope (b) |
+| `Start(Tag::MetadataBlock(_))` | Not enabled via Options — events won't fire | Out of scope |
+
+### Alignment with Atlassian's Own Behavior
+
+Per-column table alignment (`|:---:|` center, `|---:|` right) is silently dropped. ADF's documented `tableCell` / `tableHeader` schema has no `align` or `text-align` attribute, and the only table-level `layout` values (`'center'`, `'align-start'`) control whole-table page alignment, not columns. Atlassian's own Jira web-UI markdown editor drops per-column alignment for the same reason. This is a graceful degradation consistent with the platform, not a bug in the converter.
+
+### What Does NOT Change
+
+| Item | Reason |
+|---|---|
+| Public signature of `markdown_to_adf` | Drop-in replacement; three call sites stay identical |
+| `text_to_adf()` | Separate function for plain-text bodies (no markdown flag). Untouched |
+| `adf_to_text()` | Reverse direction (ADF → text for `issue view`, `issue comments`). Separate concern; table/link render-back would be a follow-up issue if users ask |
+| `Cargo.toml` feature flags for `pulldown-cmark` | Default-features-off. No SIMD (tiny inputs, unneeded), no HTML renderer, no event-level serde |
+| Worklog comment path | `cli/worklog.rs:33` always uses `text_to_adf` (no `--markdown` flag exists there). Adding one is out of scope |
+| Wiki markup (Atlassian wiki syntax) | Never supported; would be a separate `--wiki` flag if ever requested. Out of scope for #197 |
+| `--verbose` body logging | PR #198 already ships request-body logging; users can diff ADF output via `jr --verbose ... 2>trace.log` |
+| HTTP client, auth, retry logic | ADF is the payload; transport is unaffected |
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `Cargo.toml` | Add `pulldown-cmark = { version = "0.13", default-features = false }` under `[dependencies]` |
+| `src/adf.rs` | Rewrite `markdown_to_adf()` body; keep `text_to_adf` and `adf_to_text` as-is; existing `parse_heading`, `parse_inline`, `flush_list` helpers deleted (replaced by builder) |
+| `src/adf.rs` | New private `AdfBuilder` struct + `impl` for event processing (~300 lines) |
+| `src/adf.rs` (tests) | Update existing `test_markdown_to_adf_snapshot` snapshot (richer output); add ~15 new feature-focused unit tests |
+| `src/snapshots/jr__adf__tests__markdown_complex_to_adf.snap` | Regenerated to reflect structurally-correct ADF from pulldown-cmark |
+
+## Testing
+
+**Unit tests** in `src/adf.rs #[cfg(test)] mod tests` — one focused test per feature, asserting top-level ADF shape (not every byte). Matches the existing convention in `adf.rs` and pulldown-cmark's own `specs/*.txt` test pattern.
+
+New tests:
+- `test_markdown_italic_to_em_mark`
+- `test_markdown_link_preserves_href_and_title`
+- `test_markdown_ordered_list_omits_order_when_start_is_one`
+- `test_markdown_ordered_list_sets_order_when_start_is_not_one`
+- `test_markdown_strikethrough_to_strike_mark`
+- `test_markdown_blockquote_wraps_children`
+- `test_markdown_horizontal_rule`
+- `test_markdown_hard_break`
+- `test_markdown_nested_bullet_list`
+- `test_markdown_table_cells_and_headers` — verify first row uses `tableHeader`, subsequent rows `tableCell`
+- `test_markdown_image_is_skipped`
+- `test_markdown_soft_break_becomes_space`
+- `test_markdown_task_list_marker_becomes_text_prefix`
+- `test_markdown_escape_literal_asterisk`
+- `test_markdown_mixed_marks` — `**bold _italic_ bold**` preserves nested marks
+
+Kept tests: the existing `test_markdown_heading`, `test_markdown_list`, `test_markdown_code_block`, `test_adf_roundtrip_heading`, `test_text_to_adf`, `test_adf_to_text_paragraph`, `test_adf_to_text_unsupported`, `test_adf_to_text_snapshot` — still valid, no rewrite.
+
+**Snapshot test:** `test_markdown_to_adf_snapshot` (existing) — updated to exercise the union of features in one realistic prose block. Catches regressions from pulldown-cmark version bumps and builder refactors. Snapshot file regenerates on first run.
+
+**Integration tests:** `tests/issue_commands.rs:589,631,671` use `jr::adf::markdown_to_adf()` as the wiremock `body_partial_json` matcher source-of-truth. They auto-track whatever the new implementation emits — no test code change needed. They verify the full CLI → client → HTTP path ships the new ADF shape.
+
+**No proptest.** The codebase uses proptest only for pure symbolic round-trip functions (`partial_match`, `jql`, `duration`). Markdown→ADF is stateful event-driven; pulldown-cmark already passes the CommonMark spec suite upstream. Our responsibility is the mapping, not the parser.
+
+## Error Handling
+
+Infallible signature — `markdown_to_adf(&str) → Value` does not return `Result`. Same as today.
+
+| Scenario | Behavior |
+|---|---|
+| Empty or whitespace-only input | Emit `{"version":1,"type":"doc","content":[]}` (same as today) |
+| Malformed markdown (unclosed fences, unmatched emphasis) | pulldown-cmark treats as literal text; we consume events as-is. No error |
+| Invalid UTF-8 | Not possible — `&str` input is UTF-8 by type |
+| Adversarial / deeply nested input | pulldown-cmark has built-in DoS protections: `LINK_MAX_NESTED_PARENS = 32`, `MAX_AUTOCOMPLETED_CELLS = 2^18`, `link_ref_expansion_limit = max(text.len(), 100_000)`, brace-nesting switches from tracking to counting at 25 levels. Inherited for free |
+| Malformed table (header/delimiter column mismatch) | pulldown-cmark emits paragraph events with literal `\|` text — we never see `Tag::Table`. No error path needed |
+| `Parser::new_ext` | Never panics or returns `Result`. Always yields events, even for adversarial input. Confirmed: no known CVEs or DoS reports for pulldown-cmark |
+
+## Alignment with Project Conventions
+
+- **Thin client, no abstraction layer** — change is confined to `adf.rs`; no new module, no wrapper trait, no conversion pipeline
+- **Single-responsibility module** — `adf.rs` grows from ~200 LOC to ~500 LOC but remains focused on ADF conversions (both directions)
+- **Machine-output-first** — output is still deterministic JSON `Value`; no user-visible text changes from `jr` itself
+- **Non-interactive** — no new prompts, flags, or interactive paths
+- **TDD** — every new feature ships with a focused unit test; snapshot test pins end-to-end ADF shape
+
+## Validation
+
+- **Perplexity (2026-04-16):** pulldown-cmark is the de facto Rust CommonMark parser (used by rustdoc, mdbook). Alternatives (comrak, markdown-rs) are heavier or less mature. Stack-based builder is the idiomatic event→tree conversion pattern.
+- **Perplexity + Atlassian dev docs (2026-04-16):**
+  - `orderedList.attrs.order` (integer ≥ 0) IS supported — authoritative docs at `developer.atlassian.com/cloud/jira/platform/apis/document/nodes/orderedList/` confirm, overriding an earlier-less-reliable Perplexity answer
+  - `table` node attrs are `layout` (`'center' | 'align-start'`), `isNumberColumnEnabled`, `width`, `displayMode` — per-column alignment not in schema
+  - Header rows distinguished by `tableHeader` vs `tableCell` node type per cell
+  - `link` mark: `href` required, `title` optional
+  - Jira `media` nodes require pre-upload; external URLs unreliable — justifies skipping markdown images
+- **Context7 `/pulldown-cmark/pulldown-cmark`:**
+  - `Event::End(TagEnd)` (not `Event::End(Tag)`) — current API in 0.12+
+  - `CowStr<'a>` carries event text (owned via `.to_string()` when building `Value`)
+  - Stack-based builder matches pulldown-cmark's own HTML renderer approach
+  - Built-in DoS protections documented (`LINK_MAX_NESTED_PARENS`, `MAX_AUTOCOMPLETED_CELLS`)
+  - Malformed tables revert to paragraph at the parser level — no `Tag::Table` event emitted
+- **Local verification (2026-04-16):** `cargo search pulldown-cmark` confirms latest `0.13.3`; project MSRV `rust-version = "1.85"` (`Cargo.toml:7`) well above pulldown-cmark's 1.74 requirement
+- **Codebase audit:**
+  - All three `--markdown` call sites (`workflow.rs:417-420`, `create.rs:98-102`, `create.rs:199-202`) use the identical `if markdown { markdown_to_adf } else { text_to_adf }` pattern — one rewrite fixes all three
+  - `adf_to_text` read-path (`list.rs:651,666,756`) operates on ADF `Value`s; no coupling to the write-path parser shape
+  - Existing insta snapshot lives at `src/snapshots/jr__adf__tests__markdown_complex_to_adf.snap` — regeneration on first test run is the convention
+
+## Out of Scope (Follow-Ups)
+
+| Item | Why deferred |
+|---|---|
+| `adf_to_text` support for tables, links, strikethrough | Reverse direction; display-side concern. File as separate issue if `jr issue view` readers report raw ADF artifacts |
+| Task list native `taskList`/`taskItem` mapping | ADF schema support for Jira (vs Confluence) is unclear per available docs. Text prefix fallback is safe; native mapping can land if/when Atlassian documents it for Jira |
+| Markdown images via media-upload flow | Requires attachment upload, media ID lookup, error handling for auth/size — substantial scope on its own |
+| Wiki markup (`h2. `, `*bold*`, etc.) → ADF | Atlassian-specific legacy format. Would need a new `--wiki` flag. File separately if requested |
+| `--markdown` on `jr worklog add` | Not in issue scope; users have not requested worklog markdown. File separately if asked |
+| Footnotes, definition lists, subscript, math | No clean ADF mapping; rare in Jira automation. Low ROI |

--- a/docs/superpowers/specs/2026-04-16-markdown-to-adf-conversion-design.md
+++ b/docs/superpowers/specs/2026-04-16-markdown-to-adf-conversion-design.md
@@ -125,7 +125,7 @@ Inline marks use a parallel `active_marks` list. When `Text(s)` fires while mark
 | `Start(Tag::Image { .. })` through `End(TagEnd::Image)` | Skip — suppress events between until end | Jira Cloud `media` nodes require pre-upload to the media API with a returned media ID; external URLs aren't reliably supported in comments |
 | `Html(s)` / `InlineHtml(s)` | Emit as literal text via `Text(s)` handling | Preserves user intent without attempting unsafe HTML-to-ADF mapping |
 | `FootnoteReference(_)` / `Start(Tag::FootnoteDefinition(_))` | Skip | ADF has no native footnote nodes; would require embedding as inline links, low ROI |
-| `TaskListMarker(checked)` | Prepend `[x] ` or `[ ] ` to the containing list item's first paragraph text | `taskList`/`taskItem`/`blockTaskItem` ADF support is Confluence-centric; safer to render as text marker inside a regular `bulletList` |
+| `- [x] task` / `- [ ] task` (GFM task list syntax) | `ENABLE_TASKLISTS` left unset — pulldown-cmark parses `[x]` and `[ ]` as literal text inside the list item, producing a regular `bulletList` with the brackets preserved in-text | ADF's `taskList`/`taskItem` / `blockTaskItem` schema support for Jira (vs Confluence) is unclear per available docs. Letting the brackets render as text is equivalent to manual prefixing but requires no extra event handling |
 | `Tag::DefinitionList` / `DefinitionListTitle` / `DefinitionListDefinition` | Not enabled via Options — events won't fire | Out of scope for scope (b) |
 | `Start(Tag::MetadataBlock(_))` | Not enabled via Options — events won't fire | Out of scope |
 
@@ -173,7 +173,7 @@ New tests:
 - `test_markdown_table_cells_and_headers` — verify first row uses `tableHeader`, subsequent rows `tableCell`
 - `test_markdown_image_is_skipped`
 - `test_markdown_soft_break_becomes_space`
-- `test_markdown_task_list_marker_becomes_text_prefix`
+- `test_markdown_task_list_syntax_preserved_as_text` — `- [x] foo` ends up as a bullet item containing literal `[x] foo`
 - `test_markdown_escape_literal_asterisk`
 - `test_markdown_mixed_marks` — `**bold _italic_ bold**` preserves nested marks
 

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -163,17 +163,25 @@ impl AdfBuilder {
                 Some(node)
             }
             NodeKind::ListItem => {
-                // ADF requires listItem content to be block-level (paragraph,
-                // bulletList, orderedList, codeBlock, mediaSingle). pulldown-cmark
-                // emits Text events directly inside Item for tight lists, and a
-                // nested list appears as a block sibling after those inlines.
+                // The documented ADF listItem schema lists paragraph, bulletList,
+                // orderedList, codeBlock, and mediaSingle as accepted content.
+                // pulldown-cmark, however, legitimately emits blockquote, heading,
+                // table, and rule inside Item for markdown like `- > quoted` or
+                // `- # heading`. We recognize those as blocks (don't wrap them in a
+                // paragraph — that would produce `paragraph > blockquote`, invalid
+                // at a lower level than `listItem > blockquote`). Jira's renderer
+                // handles the latter shape leniently; the former it does not.
                 let wrapped = wrap_inlines_as_blocks(
                     children,
                     &[
                         "paragraph",
                         "bulletList",
                         "orderedList",
+                        "blockquote",
                         "codeBlock",
+                        "heading",
+                        "table",
+                        "rule",
                         "mediaSingle",
                     ],
                 );
@@ -611,6 +619,22 @@ mod tests {
             mark_types.contains(&"code") && mark_types.contains(&"strong"),
             "expected code + strong on the inline-code inside bold, got: {mark_types:?}"
         );
+    }
+
+    #[test]
+    fn test_markdown_blockquote_inside_list_item_is_nested_not_paragraph_wrapped() {
+        // `- > quoted` → pulldown-cmark emits blockquote inside Item. The block
+        // must be a direct child of the listItem; wrapping in a paragraph would
+        // produce `paragraph > blockquote`, which violates paragraph's inline-only
+        // content rule at a lower level than `listItem > blockquote` does.
+        let adf = markdown_to_adf("- > quoted text");
+        let item = &adf["content"][0]["content"][0];
+        assert_eq!(item["type"], "listItem");
+        let first_child = &item["content"][0];
+        assert_eq!(first_child["type"], "blockquote");
+        let inner_para = &first_child["content"][0];
+        assert_eq!(inner_para["type"], "paragraph");
+        assert_eq!(inner_para["content"][0]["text"], "quoted text");
     }
 
     #[test]

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -15,132 +15,193 @@ pub fn text_to_adf(text: &str) -> Value {
     })
 }
 
+use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+
 pub fn markdown_to_adf(markdown: &str) -> Value {
-    let mut content: Vec<Value> = Vec::new();
-    let mut in_code_block = false;
-    let mut code_lines: Vec<String> = Vec::new();
-    let mut list_items: Vec<Value> = Vec::new();
+    let options = Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH;
+    let parser = Parser::new_ext(markdown, options);
+    let mut builder = AdfBuilder::new();
+    for event in parser {
+        builder.process(event);
+    }
+    json!({
+        "version": 1,
+        "type": "doc",
+        "content": builder.finish(),
+    })
+}
 
-    for line in markdown.lines() {
-        if line.trim_start().starts_with("```") {
-            if in_code_block {
-                content.push(json!({
-                    "type": "codeBlock",
-                    "content": [{ "type": "text", "text": code_lines.join("\n") }]
-                }));
-                code_lines.clear();
-                in_code_block = false;
-            } else {
-                flush_list(&mut list_items, &mut content);
-                in_code_block = true;
-            }
-            continue;
-        }
+struct AdfBuilder {
+    root: Vec<Value>,
+    stack: Vec<PartialNode>,
+    active_marks: Vec<Value>,
+    // Task 3 will add `in_table_head: bool` here for GFM table header tracking.
+}
 
-        if in_code_block {
-            code_lines.push(line.to_string());
-            continue;
-        }
+struct PartialNode {
+    kind: NodeKind,
+    children: Vec<Value>,
+}
 
-        if !line.trim_start().starts_with("- ") && !list_items.is_empty() {
-            flush_list(&mut list_items, &mut content);
-        }
+enum NodeKind {
+    Paragraph,
+    Heading(u8),
+    BlockQuote,
+    CodeBlock { language: Option<String> },
+    BulletList,
+    OrderedList { start: u64 },
+    ListItem,
+    Sink,
+}
 
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
+// Tasks 2 and 3 will extend this enum with:
+// - `InlineMark` (Task 2) for Strong/Emphasis/Strikethrough/Link container tracking
+// - `Table`, `TableRow`, `TableCell { is_header: bool }` (Task 3) for GFM tables
 
-        if let Some(heading) = parse_heading(trimmed) {
-            content.push(heading);
-        } else if let Some(stripped) = trimmed.strip_prefix("- ") {
-            list_items.push(json!({
-                "type": "listItem",
-                "content": [{
-                    "type": "paragraph",
-                    "content": parse_inline(stripped)
-                }]
-            }));
-        } else {
-            content.push(json!({
-                "type": "paragraph",
-                "content": parse_inline(trimmed)
-            }));
+impl AdfBuilder {
+    fn new() -> Self {
+        Self {
+            root: Vec::new(),
+            stack: Vec::new(),
+            active_marks: Vec::new(),
         }
     }
 
-    flush_list(&mut list_items, &mut content);
+    fn process(&mut self, event: Event<'_>) {
+        match event {
+            Event::Start(tag) => self.start(tag),
+            Event::End(tag_end) => self.end(tag_end),
+            Event::Text(text) => self.push_text(text.as_ref()),
+            Event::Code(text) => self.push_code(text.as_ref()),
+            Event::Html(html) | Event::InlineHtml(html) => self.push_text(html.as_ref()),
+            Event::SoftBreak => self.push_text(" "),
+            Event::HardBreak => self.append_child(json!({ "type": "hardBreak" })),
+            Event::Rule => self.append_child(json!({ "type": "rule" })),
+            _ => {}
+        }
+    }
 
-    json!({ "version": 1, "type": "doc", "content": content })
-}
+    fn start(&mut self, tag: Tag<'_>) {
+        match tag {
+            Tag::Paragraph => self.push(NodeKind::Paragraph),
+            Tag::Heading { level, .. } => self.push(NodeKind::Heading(heading_level_to_u8(level))),
+            Tag::BlockQuote(_) => self.push(NodeKind::BlockQuote),
+            Tag::CodeBlock(kind) => {
+                let language = match kind {
+                    CodeBlockKind::Fenced(lang) if !lang.is_empty() => Some(lang.into_string()),
+                    _ => None,
+                };
+                self.push(NodeKind::CodeBlock { language });
+            }
+            Tag::List(None) => self.push(NodeKind::BulletList),
+            Tag::List(Some(start)) => self.push(NodeKind::OrderedList { start }),
+            Tag::Item => self.push(NodeKind::ListItem),
+            Tag::Image { .. } => self.push(NodeKind::Sink),
+            _ => self.push(NodeKind::Sink),
+        }
+    }
 
-fn flush_list(items: &mut Vec<Value>, content: &mut Vec<Value>) {
-    if !items.is_empty() {
-        content.push(json!({
-            "type": "bulletList",
-            "content": std::mem::take(items)
+    fn end(&mut self, _tag_end: TagEnd) {
+        let Some(partial) = self.stack.pop() else {
+            return;
+        };
+        let PartialNode { kind, children } = partial;
+        let node = match kind {
+            NodeKind::Paragraph => Some(json!({ "type": "paragraph", "content": children })),
+            NodeKind::Heading(level) => Some(json!({
+                "type": "heading",
+                "attrs": { "level": level },
+                "content": children,
+            })),
+            NodeKind::BlockQuote => Some(json!({ "type": "blockquote", "content": children })),
+            NodeKind::CodeBlock { language } => {
+                let mut node = json!({ "type": "codeBlock", "content": children });
+                if let Some(lang) = language {
+                    node["attrs"] = json!({ "language": lang });
+                }
+                Some(node)
+            }
+            NodeKind::BulletList => Some(json!({ "type": "bulletList", "content": children })),
+            NodeKind::OrderedList { start } => {
+                let mut node = json!({ "type": "orderedList", "content": children });
+                if start != 1 {
+                    node["attrs"] = json!({ "order": start });
+                }
+                Some(node)
+            }
+            NodeKind::ListItem => Some(json!({ "type": "listItem", "content": children })),
+            NodeKind::Sink => None,
+        };
+        if let Some(node) = node {
+            self.append_child(node);
+        }
+    }
+
+    fn push(&mut self, kind: NodeKind) {
+        self.stack.push(PartialNode {
+            kind,
+            children: Vec::new(),
+        });
+    }
+
+    fn append_child(&mut self, node: Value) {
+        if let Some(top) = self.stack.last_mut() {
+            if !matches!(top.kind, NodeKind::Sink) {
+                top.children.push(node);
+            }
+        } else {
+            self.root.push(node);
+        }
+    }
+
+    fn push_text(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        if let Some(top) = self.stack.last() {
+            if matches!(top.kind, NodeKind::Sink) {
+                return;
+            }
+        }
+        let mut node = json!({ "type": "text", "text": text });
+        if !self.active_marks.is_empty() {
+            node["marks"] = json!(self.active_marks);
+        }
+        self.append_child(node);
+    }
+
+    fn push_code(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        if let Some(top) = self.stack.last() {
+            if matches!(top.kind, NodeKind::Sink) {
+                return;
+            }
+        }
+        let mut marks = self.active_marks.clone();
+        marks.push(json!({ "type": "code" }));
+        self.append_child(json!({
+            "type": "text",
+            "text": text,
+            "marks": marks,
         }));
     }
-}
 
-fn parse_heading(line: &str) -> Option<Value> {
-    let level = line.chars().take_while(|c| *c == '#').count();
-    if (1..=6).contains(&level) && line.len() > level && line.as_bytes()[level] == b' ' {
-        let text = &line[level + 1..];
-        Some(json!({
-            "type": "heading",
-            "attrs": { "level": level },
-            "content": [{ "type": "text", "text": text }]
-        }))
-    } else {
-        None
+    fn finish(self) -> Vec<Value> {
+        self.root
     }
 }
 
-fn parse_inline(text: &str) -> Vec<Value> {
-    let mut result = Vec::new();
-    let mut remaining = text;
-
-    while !remaining.is_empty() {
-        if let Some(pos) = remaining.find("**") {
-            if pos > 0 {
-                result.push(json!({"type": "text", "text": &remaining[..pos]}));
-            }
-            let after = &remaining[pos + 2..];
-            if let Some(end) = after.find("**") {
-                result.push(json!({
-                    "type": "text", "text": &after[..end],
-                    "marks": [{"type": "strong"}]
-                }));
-                remaining = &after[end + 2..];
-                continue;
-            }
-        }
-
-        if let Some(pos) = remaining.find('`') {
-            if pos > 0 {
-                result.push(json!({"type": "text", "text": &remaining[..pos]}));
-            }
-            let after = &remaining[pos + 1..];
-            if let Some(end) = after.find('`') {
-                result.push(json!({
-                    "type": "text", "text": &after[..end],
-                    "marks": [{"type": "code"}]
-                }));
-                remaining = &after[end + 1..];
-                continue;
-            }
-        }
-
-        result.push(json!({"type": "text", "text": remaining}));
-        break;
+fn heading_level_to_u8(level: HeadingLevel) -> u8 {
+    match level {
+        HeadingLevel::H1 => 1,
+        HeadingLevel::H2 => 2,
+        HeadingLevel::H3 => 3,
+        HeadingLevel::H4 => 4,
+        HeadingLevel::H5 => 5,
+        HeadingLevel::H6 => 6,
     }
-
-    if result.is_empty() {
-        result.push(json!({"type": "text", "text": text}));
-    }
-
-    result
 }
 
 pub fn adf_to_text(adf: &Value) -> String {
@@ -271,6 +332,95 @@ mod tests {
         let input = "## Root cause\n\nThe auth module had a **critical bug** in `validate_token`.\n\n- Missing null check\n- Wrong error type\n\n```rust\nfn validate() -> bool {\n    true\n}\n```";
         let adf = markdown_to_adf(input);
         insta::assert_json_snapshot!("markdown_complex_to_adf", adf);
+    }
+
+    #[test]
+    fn test_markdown_ordered_list_sets_order_when_start_is_not_one() {
+        let adf = markdown_to_adf("5. first\n6. second");
+        assert_eq!(adf["content"][0]["type"], "orderedList");
+        assert_eq!(adf["content"][0]["attrs"]["order"], 5);
+        assert_eq!(adf["content"][0]["content"][0]["type"], "listItem");
+    }
+
+    #[test]
+    fn test_markdown_ordered_list_omits_order_when_start_is_one() {
+        let adf = markdown_to_adf("1. alpha\n2. beta");
+        assert_eq!(adf["content"][0]["type"], "orderedList");
+        assert!(adf["content"][0]["attrs"].is_null());
+    }
+
+    #[test]
+    fn test_markdown_hard_break() {
+        let adf = markdown_to_adf("line one  \nline two");
+        let para = &adf["content"][0];
+        assert_eq!(para["type"], "paragraph");
+        let contents = para["content"].as_array().unwrap();
+        assert!(contents.iter().any(|n| n["type"] == "hardBreak"));
+    }
+
+    #[test]
+    fn test_markdown_horizontal_rule() {
+        let adf = markdown_to_adf("above\n\n---\n\nbelow");
+        let has_rule = adf["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|n| n["type"] == "rule");
+        assert!(has_rule, "expected a rule node, got: {adf}");
+    }
+
+    #[test]
+    fn test_markdown_soft_break_becomes_space() {
+        let adf = markdown_to_adf("first line\nsecond line");
+        let para = &adf["content"][0];
+        let text = para["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|n| n["text"].as_str())
+            .collect::<String>();
+        assert_eq!(text, "first line second line");
+    }
+
+    #[test]
+    fn test_markdown_nested_bullet_list() {
+        let adf = markdown_to_adf("- outer\n  - inner");
+        let outer_list = &adf["content"][0];
+        assert_eq!(outer_list["type"], "bulletList");
+        let outer_item = &outer_list["content"][0];
+        assert_eq!(outer_item["type"], "listItem");
+        let has_inner = outer_item["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|n| n["type"] == "bulletList");
+        assert!(has_inner, "expected nested bulletList, got: {outer_item}");
+    }
+
+    #[test]
+    fn test_markdown_blockquote_wraps_children() {
+        let adf = markdown_to_adf("> quoted text");
+        let bq = &adf["content"][0];
+        assert_eq!(bq["type"], "blockquote");
+        let para = &bq["content"][0];
+        assert_eq!(para["type"], "paragraph");
+        assert_eq!(para["content"][0]["text"], "quoted text");
+    }
+
+    #[test]
+    fn test_markdown_code_block_with_language() {
+        let adf = markdown_to_adf("```rust\nfn x() {}\n```");
+        let block = &adf["content"][0];
+        assert_eq!(block["type"], "codeBlock");
+        assert_eq!(block["attrs"]["language"], "rust");
+        assert_eq!(block["content"][0]["text"], "fn x() {}\n");
+    }
+
+    #[test]
+    fn test_markdown_empty_input() {
+        let adf = markdown_to_adf("");
+        assert_eq!(adf["type"], "doc");
+        assert_eq!(adf["content"], json!([]));
     }
 
     #[test]

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -15,11 +15,13 @@ pub fn text_to_adf(text: &str) -> Value {
     })
 }
 
-use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{
+    CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd, TextMergeStream,
+};
 
 pub fn markdown_to_adf(markdown: &str) -> Value {
     let options = Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH;
-    let parser = Parser::new_ext(markdown, options);
+    let parser = TextMergeStream::new(Parser::new_ext(markdown, options));
     let mut builder = AdfBuilder::new();
     for event in parser {
         builder.process(event);
@@ -112,6 +114,9 @@ impl AdfBuilder {
                 }
                 self.push_mark(json!({ "type": "link", "attrs": attrs }));
             }
+            // Explicit for documentation; the final catch-all also handles this,
+            // but images are visibly named as intentionally suppressed per the
+            // spec's Feature Mapping (ADF `media` nodes require pre-upload).
             Tag::Image { .. } => self.push(NodeKind::Sink),
             _ => self.push(NodeKind::Sink),
         }
@@ -198,51 +203,11 @@ impl AdfBuilder {
                 return;
             }
         }
-        // Coalesce with the previous sibling text node when marks match. This keeps
-        // the output compact (e.g. when pulldown-cmark splits an escape sequence
-        // like `\*not italic\*` into two text events, both land in one text node).
-        if self.try_extend_prev_text(text) {
-            return;
-        }
         let mut node = json!({ "type": "text", "text": text });
         if !self.active_marks.is_empty() {
             node["marks"] = json!(self.active_marks);
         }
         self.append_child(node);
-    }
-
-    fn try_extend_prev_text(&mut self, text: &str) -> bool {
-        let siblings = match self.stack.last_mut() {
-            Some(top) => &mut top.children,
-            None => &mut self.root,
-        };
-        let Some(prev) = siblings.last_mut() else {
-            return false;
-        };
-        if prev.get("type").and_then(|t| t.as_str()) != Some("text") {
-            return false;
-        }
-        let prev_marks = prev.get("marks");
-        let same_marks = match (prev_marks, self.active_marks.is_empty()) {
-            (None, true) => true,
-            (Some(existing), false) => existing.as_array().is_some_and(|arr| {
-                arr.len() == self.active_marks.len()
-                    && arr.iter().zip(&self.active_marks).all(|(a, b)| a == b)
-            }),
-            _ => false,
-        };
-        if !same_marks {
-            return false;
-        }
-        if let Some(existing_text) = prev
-            .get_mut("text")
-            .and_then(|t| t.as_str().map(String::from))
-        {
-            let combined = existing_text + text;
-            prev["text"] = json!(combined);
-            return true;
-        }
-        false
     }
 
     fn push_code(&mut self, text: &str) {
@@ -546,23 +511,29 @@ mod tests {
 
     #[test]
     fn test_markdown_mixed_marks() {
-        // "**bold *italic* bold**" — nested emphasis should produce two separate
-        // text nodes with overlapping/non-overlapping marks as pulldown-cmark parses them.
         let adf = markdown_to_adf("**bold _italic_ bold**");
         let content = adf["content"][0]["content"].as_array().unwrap();
-        // At minimum, every text node here should have the `strong` mark.
+        // Every text node in this paragraph should carry `strong` (outer).
         assert!(
             content.iter().all(|n| n["marks"]
                 .as_array()
                 .is_some_and(|m| m.iter().any(|mk| mk["type"] == "strong"))),
             "every text node should carry strong, got: {content:?}"
         );
-        // And at least one node should also carry `em`.
+        // The node containing "italic" should also carry `em`.
+        let italic_node = content
+            .iter()
+            .find(|n| n["text"] == "italic")
+            .expect("expected a text node for 'italic'");
+        let italic_marks: Vec<&str> = italic_node["marks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|m| m["type"].as_str())
+            .collect();
         assert!(
-            content.iter().any(|n| n["marks"]
-                .as_array()
-                .is_some_and(|m| m.iter().any(|mk| mk["type"] == "em"))),
-            "expected at least one node with em + strong, got: {content:?}"
+            italic_marks.contains(&"strong") && italic_marks.contains(&"em"),
+            "expected strong + em on the italic node, got: {italic_marks:?}"
         );
     }
 

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -1,3 +1,6 @@
+use pulldown_cmark::{
+    CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd, TextMergeStream,
+};
 use serde_json::{Value, json};
 
 pub fn text_to_adf(text: &str) -> Value {
@@ -14,10 +17,6 @@ pub fn text_to_adf(text: &str) -> Value {
         ]
     })
 }
-
-use pulldown_cmark::{
-    CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd, TextMergeStream,
-};
 
 pub fn markdown_to_adf(markdown: &str) -> Value {
     let options = Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH;

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -411,7 +411,34 @@ mod tests {
 
     #[test]
     fn test_markdown_to_adf_snapshot() {
-        let input = "## Root cause\n\nThe auth module had a **critical bug** in `validate_token`.\n\n- Missing null check\n- Wrong error type\n\n```rust\nfn validate() -> bool {\n    true\n}\n```";
+        let input = concat!(
+            "# Header 1\n",
+            "\n",
+            "Paragraph with **bold**, *italic*, ~~strike~~, `inline code`, and a ",
+            "[link](https://example.com \"title\").\n",
+            "\n",
+            "## Header 2\n",
+            "\n",
+            "- bullet one\n",
+            "- bullet two\n",
+            "  - nested bullet\n",
+            "\n",
+            "1. ordered\n",
+            "2. items\n",
+            "\n",
+            "> blockquoted text\n",
+            "\n",
+            "| Col A | Col B |\n",
+            "| ----- | ----- |\n",
+            "| a1    | b1    |\n",
+            "| a2    | b2    |\n",
+            "\n",
+            "---\n",
+            "\n",
+            "```rust\n",
+            "fn validate() -> bool { true }\n",
+            "```\n",
+        );
         let adf = markdown_to_adf(input);
         insta::assert_json_snapshot!("markdown_complex_to_adf", adf);
     }
@@ -630,5 +657,89 @@ mod tests {
         });
         let text = adf_to_text(&adf);
         insta::assert_snapshot!("adf_to_text_complex", text);
+    }
+
+    #[test]
+    fn test_markdown_image_is_skipped() {
+        let adf = markdown_to_adf("before ![alt](https://example.com/img.png) after");
+        let para_text: String = adf["content"][0]["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|n| n["text"].as_str())
+            .collect::<String>();
+        // Image should be omitted — only the surrounding text remains.
+        assert!(para_text.contains("before"), "got: {para_text:?}");
+        assert!(para_text.contains("after"), "got: {para_text:?}");
+        assert!(
+            !para_text.contains("img.png"),
+            "image URL should not leak: {para_text:?}"
+        );
+        // No image nodes emitted.
+        let has_image = adf.to_string().contains("\"image\"") || adf.to_string().contains("media");
+        assert!(!has_image, "no image/media nodes should be emitted: {adf}");
+    }
+
+    #[test]
+    fn test_markdown_task_list_syntax_preserved_as_text() {
+        // ENABLE_TASKLISTS is not set, so `[x]` renders as literal text inside a bullet item.
+        // pulldown-cmark emits text directly inside the listItem (no paragraph wrapper
+        // for tight lists), so we collect text nodes from the item's direct children.
+        let adf = markdown_to_adf("- [x] done task\n- [ ] pending task");
+        let list = &adf["content"][0];
+        assert_eq!(list["type"], "bulletList");
+        let items = list["content"].as_array().unwrap();
+        let text = |item: &Value| -> String {
+            item["content"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter_map(|n| {
+                    // Tight list: text nodes sit directly inside listItem.
+                    // Loose list: text nodes are wrapped in a paragraph.
+                    if let Some(t) = n["text"].as_str() {
+                        Some(t.to_string())
+                    } else {
+                        n["content"].as_array().map(|children| {
+                            children
+                                .iter()
+                                .filter_map(|c| c["text"].as_str())
+                                .collect::<String>()
+                        })
+                    }
+                })
+                .collect()
+        };
+        assert!(text(&items[0]).contains("[x]"), "got: {}", text(&items[0]));
+        assert!(text(&items[0]).contains("done task"));
+        assert!(text(&items[1]).contains("[ ]"));
+        assert!(text(&items[1]).contains("pending task"));
+    }
+
+    #[test]
+    fn test_markdown_table_cell_with_inline_formatting() {
+        // Verify marks (Task 2) compose correctly with table cells (Task 3).
+        // Structure: doc > table > tableRow > tableHeader > paragraph > text.
+        let adf = markdown_to_adf("| **bold** | [link](https://x) |\n| - | - |\n| a | b |");
+        let header_row = &adf["content"][0]["content"][0];
+        assert_eq!(header_row["type"], "tableRow");
+
+        // First header cell -> paragraph -> text "bold" with strong mark.
+        let first_header_cell = &header_row["content"][0];
+        assert_eq!(first_header_cell["type"], "tableHeader");
+        let first_header_para = &first_header_cell["content"][0];
+        assert_eq!(first_header_para["type"], "paragraph");
+        let bold_text = &first_header_para["content"][0];
+        assert_eq!(bold_text["text"], "bold");
+        assert_eq!(bold_text["marks"][0]["type"], "strong");
+
+        // Second header cell -> paragraph -> text "link" with link mark.
+        let second_header_cell = &header_row["content"][1];
+        assert_eq!(second_header_cell["type"], "tableHeader");
+        let second_header_para = &second_header_cell["content"][0];
+        let link_text = &second_header_para["content"][0];
+        assert_eq!(link_text["text"], "link");
+        assert_eq!(link_text["marks"][0]["type"], "link");
+        assert_eq!(link_text["marks"][0]["attrs"]["href"], "https://x");
     }
 }

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -52,6 +52,9 @@ enum NodeKind {
     OrderedList { start: u64 },
     ListItem,
     Sink,
+    // Container for inline marks. Has no ADF node; just manages the active_marks stack
+    // so End events pop cleanly.
+    InlineMark,
 }
 
 // Tasks 2 and 3 will extend this enum with:
@@ -96,6 +99,19 @@ impl AdfBuilder {
             Tag::List(None) => self.push(NodeKind::BulletList),
             Tag::List(Some(start)) => self.push(NodeKind::OrderedList { start }),
             Tag::Item => self.push(NodeKind::ListItem),
+            Tag::Strong => self.push_mark(json!({ "type": "strong" })),
+            Tag::Emphasis => self.push_mark(json!({ "type": "em" })),
+            Tag::Strikethrough => self.push_mark(json!({ "type": "strike" })),
+            Tag::Link {
+                dest_url, title, ..
+            } => {
+                let mut attrs = serde_json::Map::new();
+                attrs.insert("href".to_string(), json!(dest_url.as_ref()));
+                if !title.is_empty() {
+                    attrs.insert("title".to_string(), json!(title.as_ref()));
+                }
+                self.push_mark(json!({ "type": "link", "attrs": attrs }));
+            }
             Tag::Image { .. } => self.push(NodeKind::Sink),
             _ => self.push(NodeKind::Sink),
         }
@@ -130,6 +146,16 @@ impl AdfBuilder {
                 Some(node)
             }
             NodeKind::ListItem => Some(json!({ "type": "listItem", "content": children })),
+            NodeKind::InlineMark => {
+                self.pop_mark();
+                // InlineMark is a transparent container: splice its collected text
+                // nodes (already tagged with marks via active_marks at the time of
+                // push_text) into the parent, rather than discarding them.
+                for child in children {
+                    self.append_child(child);
+                }
+                None
+            }
             NodeKind::Sink => None,
         };
         if let Some(node) = node {
@@ -142,6 +168,15 @@ impl AdfBuilder {
             kind,
             children: Vec::new(),
         });
+    }
+
+    fn push_mark(&mut self, mark: Value) {
+        self.active_marks.push(mark);
+        self.push(NodeKind::InlineMark);
+    }
+
+    fn pop_mark(&mut self) {
+        self.active_marks.pop();
     }
 
     fn append_child(&mut self, node: Value) {
@@ -163,11 +198,51 @@ impl AdfBuilder {
                 return;
             }
         }
+        // Coalesce with the previous sibling text node when marks match. This keeps
+        // the output compact (e.g. when pulldown-cmark splits an escape sequence
+        // like `\*not italic\*` into two text events, both land in one text node).
+        if self.try_extend_prev_text(text) {
+            return;
+        }
         let mut node = json!({ "type": "text", "text": text });
         if !self.active_marks.is_empty() {
             node["marks"] = json!(self.active_marks);
         }
         self.append_child(node);
+    }
+
+    fn try_extend_prev_text(&mut self, text: &str) -> bool {
+        let siblings = match self.stack.last_mut() {
+            Some(top) => &mut top.children,
+            None => &mut self.root,
+        };
+        let Some(prev) = siblings.last_mut() else {
+            return false;
+        };
+        if prev.get("type").and_then(|t| t.as_str()) != Some("text") {
+            return false;
+        }
+        let prev_marks = prev.get("marks");
+        let same_marks = match (prev_marks, self.active_marks.is_empty()) {
+            (None, true) => true,
+            (Some(existing), false) => existing.as_array().is_some_and(|arr| {
+                arr.len() == self.active_marks.len()
+                    && arr.iter().zip(&self.active_marks).all(|(a, b)| a == b)
+            }),
+            _ => false,
+        };
+        if !same_marks {
+            return false;
+        }
+        if let Some(existing_text) = prev
+            .get_mut("text")
+            .and_then(|t| t.as_str().map(String::from))
+        {
+            let combined = existing_text + text;
+            prev["text"] = json!(combined);
+            return true;
+        }
+        false
     }
 
     fn push_code(&mut self, text: &str) {
@@ -421,6 +496,83 @@ mod tests {
         let adf = markdown_to_adf("");
         assert_eq!(adf["type"], "doc");
         assert_eq!(adf["content"], json!([]));
+    }
+
+    #[test]
+    fn test_markdown_italic_to_em_mark() {
+        let adf = markdown_to_adf("*italic words*");
+        let text_node = &adf["content"][0]["content"][0];
+        assert_eq!(text_node["type"], "text");
+        assert_eq!(text_node["text"], "italic words");
+        assert_eq!(text_node["marks"][0]["type"], "em");
+    }
+
+    #[test]
+    fn test_markdown_bold_to_strong_mark() {
+        let adf = markdown_to_adf("**bold words**");
+        let text_node = &adf["content"][0]["content"][0];
+        assert_eq!(text_node["text"], "bold words");
+        assert_eq!(text_node["marks"][0]["type"], "strong");
+    }
+
+    #[test]
+    fn test_markdown_strikethrough_to_strike_mark() {
+        let adf = markdown_to_adf("~~gone~~");
+        let text_node = &adf["content"][0]["content"][0];
+        assert_eq!(text_node["text"], "gone");
+        assert_eq!(text_node["marks"][0]["type"], "strike");
+    }
+
+    #[test]
+    fn test_markdown_link_preserves_href_and_no_title() {
+        let adf = markdown_to_adf("[jr](https://example.com/jr)");
+        let text_node = &adf["content"][0]["content"][0];
+        assert_eq!(text_node["text"], "jr");
+        let mark = &text_node["marks"][0];
+        assert_eq!(mark["type"], "link");
+        assert_eq!(mark["attrs"]["href"], "https://example.com/jr");
+        // Title is absent when not provided in markdown.
+        assert!(mark["attrs"]["title"].is_null());
+    }
+
+    #[test]
+    fn test_markdown_link_preserves_href_and_title() {
+        let adf = markdown_to_adf(r#"[jr](https://example.com/jr "JR docs")"#);
+        let mark = &adf["content"][0]["content"][0]["marks"][0];
+        assert_eq!(mark["type"], "link");
+        assert_eq!(mark["attrs"]["href"], "https://example.com/jr");
+        assert_eq!(mark["attrs"]["title"], "JR docs");
+    }
+
+    #[test]
+    fn test_markdown_mixed_marks() {
+        // "**bold *italic* bold**" — nested emphasis should produce two separate
+        // text nodes with overlapping/non-overlapping marks as pulldown-cmark parses them.
+        let adf = markdown_to_adf("**bold _italic_ bold**");
+        let content = adf["content"][0]["content"].as_array().unwrap();
+        // At minimum, every text node here should have the `strong` mark.
+        assert!(
+            content.iter().all(|n| n["marks"]
+                .as_array()
+                .is_some_and(|m| m.iter().any(|mk| mk["type"] == "strong"))),
+            "every text node should carry strong, got: {content:?}"
+        );
+        // And at least one node should also carry `em`.
+        assert!(
+            content.iter().any(|n| n["marks"]
+                .as_array()
+                .is_some_and(|m| m.iter().any(|mk| mk["type"] == "em"))),
+            "expected at least one node with em + strong, got: {content:?}"
+        );
+    }
+
+    #[test]
+    fn test_markdown_escape_literal_asterisk() {
+        let adf = markdown_to_adf(r"\*not italic\*");
+        let text_node = &adf["content"][0]["content"][0];
+        assert_eq!(text_node["text"], "*not italic*");
+        // No em mark because backslash escapes the asterisks.
+        assert!(text_node["marks"].is_null());
     }
 
     #[test]

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -162,42 +162,52 @@ impl AdfBuilder {
                 }
                 Some(node)
             }
-            NodeKind::ListItem => Some(json!({ "type": "listItem", "content": children })),
+            NodeKind::ListItem => {
+                // ADF requires listItem content to be block-level (paragraph,
+                // bulletList, orderedList, codeBlock, mediaSingle). pulldown-cmark
+                // emits Text events directly inside Item for tight lists, and a
+                // nested list appears as a block sibling after those inlines.
+                let wrapped = wrap_inlines_as_blocks(
+                    children,
+                    &[
+                        "paragraph",
+                        "bulletList",
+                        "orderedList",
+                        "codeBlock",
+                        "mediaSingle",
+                    ],
+                );
+                Some(json!({ "type": "listItem", "content": wrapped }))
+            }
             NodeKind::Table => Some(json!({ "type": "table", "content": children })),
             NodeKind::TableRow => Some(json!({ "type": "tableRow", "content": children })),
             NodeKind::TableCell { is_header } => {
-                // ADF requires cells to wrap content in a block (paragraph).
-                // pulldown-cmark emits Text events directly inside TableCell
-                // without a Paragraph wrapper, so we wrap here.
+                // ADF requires cells to wrap content in a block. pulldown-cmark
+                // emits Text events directly inside TableCell without a Paragraph
+                // wrapper, so we wrap here.
                 let cell_type = if is_header {
                     "tableHeader"
                 } else {
                     "tableCell"
                 };
-                let wrapped_content = if children.iter().all(|n| {
-                    n["type"].as_str().is_some_and(|t| {
-                        matches!(
-                            t,
-                            "paragraph"
-                                | "bulletList"
-                                | "orderedList"
-                                | "blockquote"
-                                | "codeBlock"
-                                | "heading"
-                        )
-                    })
-                }) {
-                    children
-                } else {
-                    vec![json!({ "type": "paragraph", "content": children })]
-                };
-                Some(json!({ "type": cell_type, "content": wrapped_content }))
+                let wrapped = wrap_inlines_as_blocks(
+                    children,
+                    &[
+                        "paragraph",
+                        "bulletList",
+                        "orderedList",
+                        "blockquote",
+                        "codeBlock",
+                        "heading",
+                    ],
+                );
+                Some(json!({ "type": cell_type, "content": wrapped }))
             }
             NodeKind::InlineMark => {
                 self.pop_mark();
-                // InlineMark is a transparent container: splice its collected text
-                // nodes (already tagged with marks via active_marks at the time of
-                // push_text) into the parent, rather than discarding them.
+                // InlineMark has no ADF node of its own. Splice children (already
+                // tagged with marks at `push_text` time, plus any nested text or
+                // hardBreak nodes from inner mark spans) into the parent.
                 for child in children {
                     self.append_child(child);
                 }
@@ -273,6 +283,45 @@ impl AdfBuilder {
     fn finish(self) -> Vec<Value> {
         self.root
     }
+}
+
+/// Group a mixed list of inline and block nodes into pure block-level output.
+///
+/// ADF requires `listItem`, `tableCell`, and `tableHeader` content to be
+/// block-level (paragraph, lists, codeBlock, etc.). pulldown-cmark emits
+/// inline events (Text, hardBreak) directly inside tight list items and
+/// table cells without a paragraph wrapper, and nested block structures can
+/// appear alongside inline content (e.g., a tight list item with a nested
+/// bullet list: `[Text("outer"), bulletList]`).
+///
+/// Each run of consecutive inline nodes is wrapped in its own paragraph;
+/// block nodes (matching `block_types`) pass through as siblings. An empty
+/// input produces a single empty paragraph so the output always satisfies
+/// ADF's "at least one block" requirement.
+fn wrap_inlines_as_blocks(children: Vec<Value>, block_types: &[&str]) -> Vec<Value> {
+    if children.is_empty() {
+        return vec![json!({ "type": "paragraph", "content": [] })];
+    }
+    let is_block = |n: &Value| n["type"].as_str().is_some_and(|t| block_types.contains(&t));
+    let mut result: Vec<Value> = Vec::new();
+    let mut inline_run: Vec<Value> = Vec::new();
+    for child in children {
+        if is_block(&child) {
+            if !inline_run.is_empty() {
+                result.push(json!({
+                    "type": "paragraph",
+                    "content": std::mem::take(&mut inline_run),
+                }));
+            }
+            result.push(child);
+        } else {
+            inline_run.push(child);
+        }
+    }
+    if !inline_run.is_empty() {
+        result.push(json!({ "type": "paragraph", "content": inline_run }));
+    }
+    result
 }
 
 fn heading_level_to_u8(level: HeadingLevel) -> u8 {
@@ -530,6 +579,55 @@ mod tests {
         let adf = markdown_to_adf("");
         assert_eq!(adf["type"], "doc");
         assert_eq!(adf["content"], json!([]));
+    }
+
+    #[test]
+    fn test_markdown_inline_code_mark_and_composition() {
+        // Plain inline code: emits text with a `code` mark.
+        let adf = markdown_to_adf("see `foo` here");
+        let code_node = adf["content"][0]["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|n| n["text"] == "foo")
+            .expect("expected a text node for 'foo'");
+        assert_eq!(code_node["marks"][0]["type"], "code");
+
+        // Inline code inside bold: composes both marks on the same text node.
+        let adf = markdown_to_adf("**bold `code` bold**");
+        let code_node = adf["content"][0]["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|n| n["text"] == "code")
+            .expect("expected a text node for 'code'");
+        let mark_types: Vec<&str> = code_node["marks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|m| m["type"].as_str())
+            .collect();
+        assert!(
+            mark_types.contains(&"code") && mark_types.contains(&"strong"),
+            "expected code + strong on the inline-code inside bold, got: {mark_types:?}"
+        );
+    }
+
+    #[test]
+    fn test_markdown_inline_html_becomes_literal_text() {
+        // ENABLE_HTML is not set in Options; pulldown-cmark still emits Html/InlineHtml
+        // events which we forward to push_text so the literal source is preserved.
+        let adf = markdown_to_adf("before <span>x</span> after");
+        let para_text: String = adf["content"][0]["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|n| n["text"].as_str())
+            .collect();
+        assert!(
+            para_text.contains("<span>") && para_text.contains("</span>"),
+            "HTML should pass through as literal text, got: {para_text:?}"
+        );
     }
 
     #[test]

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -37,7 +37,7 @@ struct AdfBuilder {
     root: Vec<Value>,
     stack: Vec<PartialNode>,
     active_marks: Vec<Value>,
-    // Task 3 will add `in_table_head: bool` here for GFM table header tracking.
+    in_table_head: bool,
 }
 
 struct PartialNode {
@@ -57,11 +57,10 @@ enum NodeKind {
     // Container for inline marks. Has no ADF node; just manages the active_marks stack
     // so End events pop cleanly.
     InlineMark,
+    Table,
+    TableRow,
+    TableCell { is_header: bool },
 }
-
-// Tasks 2 and 3 will extend this enum with:
-// - `InlineMark` (Task 2) for Strong/Emphasis/Strikethrough/Link container tracking
-// - `Table`, `TableRow`, `TableCell { is_header: bool }` (Task 3) for GFM tables
 
 impl AdfBuilder {
     fn new() -> Self {
@@ -69,6 +68,7 @@ impl AdfBuilder {
             root: Vec::new(),
             stack: Vec::new(),
             active_marks: Vec::new(),
+            in_table_head: false,
         }
     }
 
@@ -114,6 +114,15 @@ impl AdfBuilder {
                 }
                 self.push_mark(json!({ "type": "link", "attrs": attrs }));
             }
+            Tag::Table(_) => self.push(NodeKind::Table),
+            Tag::TableHead => {
+                self.in_table_head = true;
+                self.push(NodeKind::TableRow);
+            }
+            Tag::TableRow => self.push(NodeKind::TableRow),
+            Tag::TableCell => self.push(NodeKind::TableCell {
+                is_header: self.in_table_head,
+            }),
             // Explicit for documentation; the final catch-all also handles this,
             // but images are visibly named as intentionally suppressed per the
             // spec's Feature Mapping (ADF `media` nodes require pre-upload).
@@ -122,7 +131,10 @@ impl AdfBuilder {
         }
     }
 
-    fn end(&mut self, _tag_end: TagEnd) {
+    fn end(&mut self, tag_end: TagEnd) {
+        if matches!(tag_end, TagEnd::TableHead) {
+            self.in_table_head = false;
+        }
         let Some(partial) = self.stack.pop() else {
             return;
         };
@@ -151,6 +163,36 @@ impl AdfBuilder {
                 Some(node)
             }
             NodeKind::ListItem => Some(json!({ "type": "listItem", "content": children })),
+            NodeKind::Table => Some(json!({ "type": "table", "content": children })),
+            NodeKind::TableRow => Some(json!({ "type": "tableRow", "content": children })),
+            NodeKind::TableCell { is_header } => {
+                // ADF requires cells to wrap content in a block (paragraph).
+                // pulldown-cmark emits Text events directly inside TableCell
+                // without a Paragraph wrapper, so we wrap here.
+                let cell_type = if is_header {
+                    "tableHeader"
+                } else {
+                    "tableCell"
+                };
+                let wrapped_content = if children.iter().all(|n| {
+                    n["type"].as_str().is_some_and(|t| {
+                        matches!(
+                            t,
+                            "paragraph"
+                                | "bulletList"
+                                | "orderedList"
+                                | "blockquote"
+                                | "codeBlock"
+                                | "heading"
+                        )
+                    })
+                }) {
+                    children
+                } else {
+                    vec![json!({ "type": "paragraph", "content": children })]
+                };
+                Some(json!({ "type": cell_type, "content": wrapped_content }))
+            }
             NodeKind::InlineMark => {
                 self.pop_mark();
                 // InlineMark is a transparent container: splice its collected text
@@ -544,6 +586,32 @@ mod tests {
         assert_eq!(text_node["text"], "*not italic*");
         // No em mark because backslash escapes the asterisks.
         assert!(text_node["marks"].is_null());
+    }
+
+    #[test]
+    fn test_markdown_table_cells_and_headers() {
+        let input = "| foo | bar |\n| --- | --- |\n| baz | qux |";
+        let adf = markdown_to_adf(input);
+        let table = &adf["content"][0];
+        assert_eq!(table["type"], "table");
+
+        let rows = table["content"].as_array().unwrap();
+        assert_eq!(rows.len(), 2, "expected 2 tableRows (header + body)");
+
+        // Header row's cells should be tableHeader.
+        let header_cells = rows[0]["content"].as_array().unwrap();
+        assert_eq!(header_cells[0]["type"], "tableHeader");
+        assert_eq!(header_cells[1]["type"], "tableHeader");
+
+        // Body row's cells should be tableCell.
+        let body_cells = rows[1]["content"].as_array().unwrap();
+        assert_eq!(body_cells[0]["type"], "tableCell");
+        assert_eq!(body_cells[1]["type"], "tableCell");
+
+        // Cells wrap their content in a paragraph, per ADF convention.
+        let first_header_text = &header_cells[0]["content"][0];
+        assert_eq!(first_header_text["type"], "paragraph");
+        assert_eq!(first_header_text["content"][0]["text"], "foo");
     }
 
     #[test]

--- a/src/snapshots/jr__adf__tests__markdown_complex_to_adf.snap
+++ b/src/snapshots/jr__adf__tests__markdown_complex_to_adf.snap
@@ -1,6 +1,6 @@
 ---
 source: src/adf.rs
-assertion_line: 443
+assertion_line: 492
 expression: adf
 ---
 {
@@ -112,8 +112,13 @@ expression: adf
         {
           "content": [
             {
-              "text": "bullet one",
-              "type": "text"
+              "content": [
+                {
+                  "text": "bullet one",
+                  "type": "text"
+                }
+              ],
+              "type": "paragraph"
             }
           ],
           "type": "listItem"
@@ -121,16 +126,26 @@ expression: adf
         {
           "content": [
             {
-              "text": "bullet two",
-              "type": "text"
+              "content": [
+                {
+                  "text": "bullet two",
+                  "type": "text"
+                }
+              ],
+              "type": "paragraph"
             },
             {
               "content": [
                 {
                   "content": [
                     {
-                      "text": "nested bullet",
-                      "type": "text"
+                      "content": [
+                        {
+                          "text": "nested bullet",
+                          "type": "text"
+                        }
+                      ],
+                      "type": "paragraph"
                     }
                   ],
                   "type": "listItem"
@@ -149,8 +164,13 @@ expression: adf
         {
           "content": [
             {
-              "text": "ordered",
-              "type": "text"
+              "content": [
+                {
+                  "text": "ordered",
+                  "type": "text"
+                }
+              ],
+              "type": "paragraph"
             }
           ],
           "type": "listItem"
@@ -158,8 +178,13 @@ expression: adf
         {
           "content": [
             {
-              "text": "items",
-              "type": "text"
+              "content": [
+                {
+                  "text": "items",
+                  "type": "text"
+                }
+              ],
+              "type": "paragraph"
             }
           ],
           "type": "listItem"

--- a/src/snapshots/jr__adf__tests__markdown_complex_to_adf.snap
+++ b/src/snapshots/jr__adf__tests__markdown_complex_to_adf.snap
@@ -1,16 +1,17 @@
 ---
 source: src/adf.rs
+assertion_line: 443
 expression: adf
 ---
 {
   "content": [
     {
       "attrs": {
-        "level": 2
+        "level": 1
       },
       "content": [
         {
-          "text": "Root cause",
+          "text": "Header 1",
           "type": "text"
         }
       ],
@@ -19,7 +20,7 @@ expression: adf
     {
       "content": [
         {
-          "text": "The auth module had a ",
+          "text": "Paragraph with ",
           "type": "text"
         },
         {
@@ -28,11 +29,37 @@ expression: adf
               "type": "strong"
             }
           ],
-          "text": "critical bug",
+          "text": "bold",
           "type": "text"
         },
         {
-          "text": " in ",
+          "text": ", ",
+          "type": "text"
+        },
+        {
+          "marks": [
+            {
+              "type": "em"
+            }
+          ],
+          "text": "italic",
+          "type": "text"
+        },
+        {
+          "text": ", ",
+          "type": "text"
+        },
+        {
+          "marks": [
+            {
+              "type": "strike"
+            }
+          ],
+          "text": "strike",
+          "type": "text"
+        },
+        {
+          "text": ", ",
           "type": "text"
         },
         {
@@ -41,7 +68,24 @@ expression: adf
               "type": "code"
             }
           ],
-          "text": "validate_token",
+          "text": "inline code",
+          "type": "text"
+        },
+        {
+          "text": ", and a ",
+          "type": "text"
+        },
+        {
+          "marks": [
+            {
+              "attrs": {
+                "href": "https://example.com",
+                "title": "title"
+              },
+              "type": "link"
+            }
+          ],
+          "text": "link",
           "type": "text"
         },
         {
@@ -52,17 +96,24 @@ expression: adf
       "type": "paragraph"
     },
     {
+      "attrs": {
+        "level": 2
+      },
+      "content": [
+        {
+          "text": "Header 2",
+          "type": "text"
+        }
+      ],
+      "type": "heading"
+    },
+    {
       "content": [
         {
           "content": [
             {
-              "content": [
-                {
-                  "text": "Missing null check",
-                  "type": "text"
-                }
-              ],
-              "type": "paragraph"
+              "text": "bullet one",
+              "type": "text"
             }
           ],
           "type": "listItem"
@@ -70,13 +121,22 @@ expression: adf
         {
           "content": [
             {
+              "text": "bullet two",
+              "type": "text"
+            },
+            {
               "content": [
                 {
-                  "text": "Wrong error type",
-                  "type": "text"
+                  "content": [
+                    {
+                      "text": "nested bullet",
+                      "type": "text"
+                    }
+                  ],
+                  "type": "listItem"
                 }
               ],
-              "type": "paragraph"
+              "type": "bulletList"
             }
           ],
           "type": "listItem"
@@ -87,7 +147,154 @@ expression: adf
     {
       "content": [
         {
-          "text": "fn validate() -> bool {\n    true\n}",
+          "content": [
+            {
+              "text": "ordered",
+              "type": "text"
+            }
+          ],
+          "type": "listItem"
+        },
+        {
+          "content": [
+            {
+              "text": "items",
+              "type": "text"
+            }
+          ],
+          "type": "listItem"
+        }
+      ],
+      "type": "orderedList"
+    },
+    {
+      "content": [
+        {
+          "content": [
+            {
+              "text": "blockquoted text",
+              "type": "text"
+            }
+          ],
+          "type": "paragraph"
+        }
+      ],
+      "type": "blockquote"
+    },
+    {
+      "content": [
+        {
+          "content": [
+            {
+              "content": [
+                {
+                  "content": [
+                    {
+                      "text": "Col A",
+                      "type": "text"
+                    }
+                  ],
+                  "type": "paragraph"
+                }
+              ],
+              "type": "tableHeader"
+            },
+            {
+              "content": [
+                {
+                  "content": [
+                    {
+                      "text": "Col B",
+                      "type": "text"
+                    }
+                  ],
+                  "type": "paragraph"
+                }
+              ],
+              "type": "tableHeader"
+            }
+          ],
+          "type": "tableRow"
+        },
+        {
+          "content": [
+            {
+              "content": [
+                {
+                  "content": [
+                    {
+                      "text": "a1",
+                      "type": "text"
+                    }
+                  ],
+                  "type": "paragraph"
+                }
+              ],
+              "type": "tableCell"
+            },
+            {
+              "content": [
+                {
+                  "content": [
+                    {
+                      "text": "b1",
+                      "type": "text"
+                    }
+                  ],
+                  "type": "paragraph"
+                }
+              ],
+              "type": "tableCell"
+            }
+          ],
+          "type": "tableRow"
+        },
+        {
+          "content": [
+            {
+              "content": [
+                {
+                  "content": [
+                    {
+                      "text": "a2",
+                      "type": "text"
+                    }
+                  ],
+                  "type": "paragraph"
+                }
+              ],
+              "type": "tableCell"
+            },
+            {
+              "content": [
+                {
+                  "content": [
+                    {
+                      "text": "b2",
+                      "type": "text"
+                    }
+                  ],
+                  "type": "paragraph"
+                }
+              ],
+              "type": "tableCell"
+            }
+          ],
+          "type": "tableRow"
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "type": "rule"
+    },
+    {
+      "attrs": {
+        "language": "rust"
+      },
+      "content": [
+        {
+          "text": "fn validate() -> bool { true }\n",
           "type": "text"
         }
       ],

--- a/src/snapshots/jr__adf__tests__markdown_complex_to_adf.snap
+++ b/src/snapshots/jr__adf__tests__markdown_complex_to_adf.snap
@@ -1,6 +1,5 @@
 ---
 source: src/adf.rs
-assertion_line: 492
 expression: adf
 ---
 {


### PR DESCRIPTION
## Summary

Replaces hand-rolled `adf::markdown_to_adf()` with a `pulldown-cmark`-based event-driven `AdfBuilder`. Fixes broken output from `jr issue comment --markdown`, `jr issue create --markdown`, and `jr issue edit --markdown` where italics, links, tables, ordered lists, strikethrough, blockquotes, hard breaks, horizontal rules, and nested lists were silently dropped or mis-rendered.

- New dep: `pulldown-cmark = { version = "0.13", default-features = false }`
- Supports: headings, paragraphs, bold/italic/strike/inline-code/link marks, bullet + ordered lists (with `order` attr), nested lists, code blocks (fenced + indented, with language attr), blockquotes, GFM tables (with `tableHeader` vs `tableCell` row distinction), horizontal rules, hard breaks, soft breaks as space
- Explicit non-mappings: images skipped (Jira requires media upload flow), HTML preserved as literal text, task list syntax `[x]` / `[ ]` passes through as text inside regular bulletList
- Public signature `markdown_to_adf(&str) -> Value` unchanged; no call-site edits

Closes #197.

## Test Plan

- [x] `cargo test --lib adf::` — 31/31 pass (existing + 16 new feature-focused tests covering every row of the spec's feature-mapping table)
- [x] `cargo test --test issue_commands` — 49/49 pass (integration at `tests/issue_commands.rs:631` auto-tracks new ADF shape via wiremock `body_partial_json` matcher)
- [x] `cargo test` — full suite green
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean, no new `#[allow]`
- [x] `insta` snapshot covers union of features (headings H1+H2, all marks, nested+ordered lists, blockquote, 2x2 table with header row, rule, fenced code block)
- [x] Local PR review: 5 specialized agents (comments, tests, errors, types, general code), iterated to clean; caught and fixed a critical ADF-schema violation (listItem content must be block-level — added `wrap_inlines_as_blocks` helper shared with tableCell)
- [ ] Manual smoke test against a live Jira issue (will run before marking ready)