### PR TITLE
feat: adf_to_text rich rendering — ordered lists, marks, tables, blockquote, rule, hardBreak (#202)

### DIFF
--- a/docs/superpowers/plans/2026-04-16-adf-to-text-rich-rendering.md
+++ b/docs/superpowers/plans/2026-04-16-adf-to-text-rich-rendering.md
@@ -1,0 +1,1180 @@
+# adf_to_text Rich Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the free `render_node`/`render_children` pair in `src/adf.rs` with a stateful `AdfRenderer` struct supporting ordered-list numbering (respecting `attrs.order`), inline marks (`strong`/`em`/`strike`/`code`/`link`), blockquote line prefixing (including nested `> > `), `rule` as `---`, `hardBreak` as `\n`, `codeBlock` with language fence, pipe-style tables with header separator, and graceful fallback for unknown nodes.
+
+**Architecture:** Stateful visitor struct `AdfRenderer { output, list_stack, blockquote_depth }` mirroring the existing write-path `AdfBuilder` pattern. Blockquote prefixing uses a split-and-prefix pass after rendering children into `output`, so all descendant content gets prefixed uniformly. Marks apply inside-out by iterating `node.marks[]` in array order (last mark outermost). Tables emit pipe-row markdown with a `| --- | --- |` separator line after any row containing a `tableHeader` cell.
+
+**Tech Stack:** Rust 2024 (edition), MSRV 1.85, `serde_json::Value` for ADF traversal, `insta` for snapshots. No new crate dependencies.
+
+---
+
+### Task 1: Scaffold `AdfRenderer` preserving current behavior
+
+**Files:**
+- Modify: `src/adf.rs` (replace `adf_to_text`, `render_node`, `render_children` at lines 345–410 with struct + impl; keep public signature `pub fn adf_to_text(&Value) -> String`)
+
+Pure refactor. No new behavior. All existing tests must still pass after this task.
+
+- [ ] **Step 1: Replace the free-function read path with a struct-based one**
+
+In `src/adf.rs`, replace the range from line 345 (start of `pub fn adf_to_text`) through line 410 (end of `fn render_children`) with:
+
+```rust
+pub fn adf_to_text(adf: &Value) -> String {
+    let mut r = AdfRenderer::new();
+    r.render_doc(adf);
+    r.finish()
+}
+
+struct AdfRenderer {
+    output: String,
+    list_stack: Vec<ListFrame>,
+    blockquote_depth: usize,
+}
+
+enum ListFrame {
+    Bullet,
+    // `Ordered { next_index: u64 }` variant added in Task 2 alongside its first use.
+}
+
+impl AdfRenderer {
+    fn new() -> Self {
+        Self {
+            output: String::new(),
+            list_stack: Vec::new(),
+            blockquote_depth: 0,
+        }
+    }
+
+    fn render_doc(&mut self, adf: &Value) {
+        if let Some(content) = adf.get("content").and_then(|c| c.as_array()) {
+            for node in content {
+                self.render_node(node);
+            }
+        }
+    }
+
+    fn render_node(&mut self, node: &Value) {
+        let node_type = node.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        match node_type {
+            "text" => {
+                if let Some(text) = node.get("text").and_then(|t| t.as_str()) {
+                    self.output.push_str(text);
+                }
+            }
+            "paragraph" => {
+                self.render_children(node);
+                self.output.push('\n');
+            }
+            "heading" => {
+                let level = node
+                    .get("attrs")
+                    .and_then(|a| a.get("level"))
+                    .and_then(|l| l.as_u64())
+                    .unwrap_or(1) as usize;
+                for _ in 0..level {
+                    self.output.push('#');
+                }
+                self.output.push(' ');
+                self.render_children(node);
+                self.output.push('\n');
+            }
+            "bulletList" | "orderedList" => {
+                self.list_stack.push(ListFrame::Bullet);
+                self.render_children(node);
+                self.list_stack.pop();
+            }
+            "listItem" => {
+                let indent = "  ".repeat(self.list_stack.len().saturating_sub(1));
+                self.output.push_str(&indent);
+                self.output.push_str("- ");
+                self.render_children(node);
+            }
+            "codeBlock" => {
+                self.output.push_str("```\n");
+                self.render_children(node);
+                self.output.push_str("\n```\n");
+            }
+            _ => {
+                if node.get("content").is_some() {
+                    self.render_children(node);
+                } else {
+                    self.output
+                        .push_str(&format!("[unsupported: {node_type}]"));
+                }
+            }
+        }
+    }
+
+    fn render_children(&mut self, node: &Value) {
+        if let Some(content) = node.get("content").and_then(|c| c.as_array()) {
+            for child in content {
+                self.render_node(child);
+            }
+        }
+    }
+
+    fn finish(self) -> String {
+        self.output.trim_end().to_string()
+    }
+}
+```
+
+Note: `ListFrame` has a single `Bullet` variant in Task 1; the `Ordered` variant gets added in Task 2 alongside its first use. This keeps Task 1 a minimal behavior-preserving refactor.
+
+- [ ] **Step 2: Run existing tests — all must pass**
+
+Run: `cargo test --lib adf::` from the repo root.
+
+Expected: all `adf::tests::*` tests pass, including `test_adf_to_text_paragraph`, `test_adf_roundtrip_heading`, `test_adf_to_text_unsupported`, `test_adf_to_text_snapshot`.
+
+- [ ] **Step 3: Run clippy to catch any warnings introduced**
+
+Run: `cargo clippy --all-targets -- -D warnings`
+
+Expected: no warnings. If the unused `Ordered` variant warns, that's fine — Task 2 uses it. If a different warning appears, fix before committing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/adf.rs
+git commit -m "refactor: port adf_to_text to AdfRenderer struct (#202)
+
+Pure refactor preserving existing behavior. Introduces the state
+carrier needed for ordered-list numbering and blockquote nesting
+in subsequent tasks. Mirrors the write-path AdfBuilder pattern."
+```
+
+---
+
+### Task 2: Ordered-list numeric prefixes with `attrs.order`
+
+**Files:**
+- Modify: `src/adf.rs` — update the `bulletList | orderedList` and `listItem` match arms; add tests
+
+- [ ] **Step 1: Write failing tests**
+
+Append to the `#[cfg(test)] mod tests` block in `src/adf.rs`:
+
+```rust
+    #[test]
+    fn test_render_ordered_list_numeric_prefix() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "orderedList",
+                "content": [
+                    {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "alpha"}]}]},
+                    {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "beta"}]}]},
+                    {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "gamma"}]}]},
+                ]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("1. alpha"), "got: {text:?}");
+        assert!(text.contains("2. beta"), "got: {text:?}");
+        assert!(text.contains("3. gamma"), "got: {text:?}");
+    }
+
+    #[test]
+    fn test_render_ordered_list_respects_attrs_order() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "orderedList",
+                "attrs": {"order": 5},
+                "content": [
+                    {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "five"}]}]},
+                    {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "six"}]}]},
+                ]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("5. five"), "got: {text:?}");
+        assert!(text.contains("6. six"), "got: {text:?}");
+    }
+
+    #[test]
+    fn test_render_ordered_list_order_zero_defaults_to_one() {
+        // Jira treats order < 1 as start-at-1 (matches HTML <ol start> behavior).
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "orderedList",
+                "attrs": {"order": 0},
+                "content": [
+                    {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "only"}]}]},
+                ]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("1. only"), "got: {text:?}");
+    }
+
+    #[test]
+    fn test_render_mixed_nested_lists() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "orderedList",
+                "content": [{
+                    "type": "listItem",
+                    "content": [
+                        {"type": "paragraph", "content": [{"type": "text", "text": "outer"}]},
+                        {"type": "bulletList", "content": [{
+                            "type": "listItem",
+                            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "inner"}]}]
+                        }]}
+                    ]
+                }]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("1. outer"), "got: {text:?}");
+        assert!(text.contains("  - inner"), "got: {text:?}");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib adf::tests::test_render_ordered -- --exact` and the mixed-list test individually.
+
+Expected: 4 failures — listItem uses `- ` for everything, ignoring the parent frame.
+
+- [ ] **Step 3: Update `bulletList | orderedList` and `listItem` arms**
+
+Replace the `"bulletList" | "orderedList"` arm with two separate arms:
+
+```rust
+            "bulletList" => {
+                self.list_stack.push(ListFrame::Bullet);
+                self.render_children(node);
+                self.list_stack.pop();
+            }
+            "orderedList" => {
+                let start = node
+                    .get("attrs")
+                    .and_then(|a| a.get("order"))
+                    .and_then(|o| o.as_u64())
+                    .filter(|&n| n >= 1)
+                    .unwrap_or(1);
+                self.list_stack.push(ListFrame::Ordered { next_index: start });
+                self.render_children(node);
+                self.list_stack.pop();
+            }
+            // NOTE: Task 2 also adds the `Ordered` variant to the `ListFrame` enum:
+            //     enum ListFrame {
+            //         Bullet,
+            //         Ordered { next_index: u64 },
+            //     }
+```
+
+Replace the `"listItem"` arm with:
+
+```rust
+            "listItem" => {
+                let indent = "  ".repeat(self.list_stack.len().saturating_sub(1));
+                self.output.push_str(&indent);
+                // Determine the prefix from the enclosing list frame, then
+                // increment the counter so the NEXT sibling item gets the next number.
+                let prefix = match self.list_stack.last_mut() {
+                    Some(ListFrame::Ordered { next_index }) => {
+                        let n = *next_index;
+                        *next_index += 1;
+                        format!("{n}. ")
+                    }
+                    _ => "- ".to_string(),
+                };
+                self.output.push_str(&prefix);
+                self.render_children(node);
+            }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib adf::` — all old + 4 new tests pass.
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo clippy --all-targets -- -D warnings` — no warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/adf.rs
+git commit -m "feat: render orderedList with numeric prefixes (#202)
+
+Respects attrs.order; treats order<1 as start-at-1 matching Jira's
+renderer. Nested bulletList inside orderedList keeps its indent."
+```
+
+---
+
+### Task 3: Inline marks (`strong`/`em`/`strike`/`code`/`link`)
+
+**Files:**
+- Modify: `src/adf.rs` — extend `"text"` arm to apply marks; add tests
+
+- [ ] **Step 1: Write failing tests**
+
+Append to the test module:
+
+```rust
+    #[test]
+    fn test_render_strong_mark() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "bold", "marks": [{"type": "strong"}]}
+            ]}]
+        });
+        assert_eq!(adf_to_text(&adf), "**bold**");
+    }
+
+    #[test]
+    fn test_render_em_mark() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "em", "marks": [{"type": "em"}]}
+            ]}]
+        });
+        assert_eq!(adf_to_text(&adf), "*em*");
+    }
+
+    #[test]
+    fn test_render_strike_mark() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "gone", "marks": [{"type": "strike"}]}
+            ]}]
+        });
+        assert_eq!(adf_to_text(&adf), "~~gone~~");
+    }
+
+    #[test]
+    fn test_render_code_mark() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "x", "marks": [{"type": "code"}]}
+            ]}]
+        });
+        assert_eq!(adf_to_text(&adf), "`x`");
+    }
+
+    #[test]
+    fn test_render_link_preserves_href() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "jr", "marks": [
+                    {"type": "link", "attrs": {"href": "https://example.com/jr"}}
+                ]}
+            ]}]
+        });
+        assert_eq!(adf_to_text(&adf), "[jr](https://example.com/jr)");
+    }
+
+    #[test]
+    fn test_render_link_missing_href_defaults_empty() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "jr", "marks": [{"type": "link"}]}
+            ]}]
+        });
+        assert_eq!(adf_to_text(&adf), "[jr]()");
+    }
+
+    #[test]
+    fn test_render_multiple_marks_deterministic_order() {
+        // marks = [strong, em] applied in order: strong wraps first (inner), em wraps second (outer).
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "foo", "marks": [{"type": "strong"}, {"type": "em"}]}
+            ]}]
+        });
+        // strong-then-em → "*" + "**foo**" + "*" = "***foo***"
+        assert_eq!(adf_to_text(&adf), "***foo***");
+    }
+
+    #[test]
+    fn test_render_unknown_mark_drops_syntax() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "plain", "marks": [{"type": "underline"}]}
+            ]}]
+        });
+        assert_eq!(adf_to_text(&adf), "plain");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib adf::tests::test_render_strong_mark adf::tests::test_render_em_mark adf::tests::test_render_strike_mark adf::tests::test_render_code_mark adf::tests::test_render_link`
+
+Expected: all fail — marks are currently ignored.
+
+- [ ] **Step 3: Add a mark-application helper and update the `"text"` arm**
+
+Add a free helper near the bottom of the non-test code in `src/adf.rs` (just above `#[cfg(test)]`):
+
+```rust
+/// Wrap `text` with markdown-style syntax for each mark, innermost-first.
+/// Unknown mark types pass through without added syntax.
+fn apply_marks(text: &str, marks: Option<&Vec<Value>>) -> String {
+    let mut result = text.to_string();
+    let Some(marks) = marks else { return result };
+    for mark in marks {
+        let mark_type = mark.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        result = match mark_type {
+            "code" => format!("`{result}`"),
+            "em" => format!("*{result}*"),
+            "strong" => format!("**{result}**"),
+            "strike" => format!("~~{result}~~"),
+            "link" => {
+                let href = mark
+                    .get("attrs")
+                    .and_then(|a| a.get("href"))
+                    .and_then(|h| h.as_str())
+                    .unwrap_or("");
+                format!("[{result}]({href})")
+            }
+            _ => result,
+        };
+    }
+    result
+}
+```
+
+Replace the `"text"` arm in `render_node` with:
+
+```rust
+            "text" => {
+                let text = node.get("text").and_then(|t| t.as_str()).unwrap_or("");
+                let marks = node.get("marks").and_then(|m| m.as_array());
+                self.output.push_str(&apply_marks(text, marks));
+            }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib adf::` — all old + 8 new mark tests pass.
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo clippy --all-targets -- -D warnings` — no warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/adf.rs
+git commit -m "feat: render inline marks on text nodes (#202)
+
+Adds strong/em/strike/code/link. Marks iterate in marks[] array
+order, wrapping inner-to-outer. Unknown mark types pass through
+as bare text."
+```
+
+---
+
+### Task 4: Blockquote line prefixing (including nested `> > `)
+
+**Files:**
+- Modify: `src/adf.rs` — add a `"blockquote"` arm with a split-and-prefix pass; add tests
+
+- [ ] **Step 1: Write failing tests**
+
+Append to the test module:
+
+```rust
+    #[test]
+    fn test_render_blockquote_prefixes_each_line() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "blockquote",
+                "content": [
+                    {"type": "paragraph", "content": [{"type": "text", "text": "line one"}]},
+                    {"type": "paragraph", "content": [{"type": "text", "text": "line two"}]}
+                ]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        // Each rendered line inside the blockquote starts with "> ".
+        for line in text.lines() {
+            assert!(line.starts_with("> "), "line should be prefixed: {line:?}");
+        }
+        assert!(text.contains("> line one"));
+        assert!(text.contains("> line two"));
+    }
+
+    #[test]
+    fn test_render_nested_blockquote() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "blockquote",
+                "content": [{
+                    "type": "blockquote",
+                    "content": [
+                        {"type": "paragraph", "content": [{"type": "text", "text": "inner"}]}
+                    ]
+                }]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("> > inner"), "got: {text:?}");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib adf::tests::test_render_blockquote adf::tests::test_render_nested_blockquote`
+
+Expected: both fail — no blockquote prefix is currently emitted (the existing code's `_` arm just recurses into the content).
+
+- [ ] **Step 3: Add the `"blockquote"` arm**
+
+Insert a new arm in `render_node` above the fallback `_`:
+
+```rust
+            "blockquote" => {
+                self.blockquote_depth += 1;
+                let start = self.output.len();
+                self.render_children(node);
+                self.blockquote_depth -= 1;
+
+                // Prefix every line in the just-rendered segment with "> ".
+                // A single "> " is added per nesting level; nested blockquotes
+                // accumulate to "> > " on each line when their own prefix pass
+                // runs during unwind.
+                let rendered = self.output.split_off(start);
+                let prefix = "> ";
+                for (i, line) in rendered.split('\n').enumerate() {
+                    if i > 0 {
+                        self.output.push('\n');
+                    }
+                    if !line.is_empty() {
+                        self.output.push_str(prefix);
+                        self.output.push_str(line);
+                    }
+                }
+            }
+```
+
+Note on the mechanics: each `blockquote` arm pops its rendered segment, splits on `\n`, prefixes each non-empty line with `"> "`, and writes it back. For `blockquote > blockquote > paragraph`, the inner blockquote runs first on its unwind → produces `"> inner\n"`. The outer then processes that text and prefixes each line again → produces `"> > inner\n"`. Exactly the CommonMark-compliant `> > ` nested form.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib adf::` — all tests pass including the two new ones.
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo clippy --all-targets -- -D warnings` — no warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/adf.rs
+git commit -m "feat: render blockquote with > line prefixes (#202)
+
+Every line inside a blockquote gets a '> ' prefix. Nested
+blockquotes accumulate to '> > ' per CommonMark convention."
+```
+
+---
+
+### Task 5: `rule`, `hardBreak`, codeBlock with language
+
+**Files:**
+- Modify: `src/adf.rs` — add `"rule"` and `"hardBreak"` arms, extend `"codeBlock"` for `attrs.language`; add tests
+
+- [ ] **Step 1: Write failing tests**
+
+Append to the test module:
+
+```rust
+    #[test]
+    fn test_render_rule() {
+        let adf = json!({
+            "type": "doc",
+            "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "above"}]},
+                {"type": "rule"},
+                {"type": "paragraph", "content": [{"type": "text", "text": "below"}]}
+            ]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("---"), "expected rule line, got: {text:?}");
+        assert!(text.contains("above"));
+        assert!(text.contains("below"));
+    }
+
+    #[test]
+    fn test_render_hard_break_inserts_newline() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "line one"},
+                {"type": "hardBreak"},
+                {"type": "text", "text": "line two"}
+            ]}]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("line one\nline two"), "got: {text:?}");
+    }
+
+    #[test]
+    fn test_render_code_block_with_language() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "codeBlock",
+                "attrs": {"language": "rust"},
+                "content": [{"type": "text", "text": "fn x() {}"}]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("```rust"), "expected rust fence, got: {text:?}");
+        assert!(text.contains("fn x() {}"));
+    }
+
+    #[test]
+    fn test_render_code_block_without_language() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "codeBlock",
+                "content": [{"type": "text", "text": "plain"}]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("```\nplain"), "expected empty fence, got: {text:?}");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib adf::tests::test_render_rule adf::tests::test_render_hard_break adf::tests::test_render_code_block`
+
+Expected: `test_render_rule`, `test_render_hard_break_inserts_newline`, and `test_render_code_block_with_language` fail. `test_render_code_block_without_language` may pass already.
+
+- [ ] **Step 3: Add arms and extend codeBlock**
+
+Add two new arms above the fallback `_`:
+
+```rust
+            "rule" => {
+                self.output.push_str("---\n");
+            }
+            "hardBreak" => {
+                self.output.push('\n');
+            }
+```
+
+Replace the existing `"codeBlock"` arm with:
+
+```rust
+            "codeBlock" => {
+                let lang = node
+                    .get("attrs")
+                    .and_then(|a| a.get("language"))
+                    .and_then(|l| l.as_str())
+                    .unwrap_or("");
+                self.output.push_str("```");
+                self.output.push_str(lang);
+                self.output.push('\n');
+                self.render_children(node);
+                self.output.push_str("\n```\n");
+            }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib adf::`
+
+All tests pass, including 4 new ones.
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo clippy --all-targets -- -D warnings` — no warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/adf.rs
+git commit -m "feat: render rule, hardBreak, and codeBlock language (#202)
+
+rule → '---' on its own line.
+hardBreak → plain '\n' (the trailing-two-spaces form is markdown
+source syntax, not rendered-text convention).
+codeBlock → fence opens with the attrs.language when present."
+```
+
+---
+
+### Task 6: Tables (pipe rows with header separator)
+
+**Files:**
+- Modify: `src/adf.rs` — add `"table"`, `"tableRow"`, `"tableCell"`, `"tableHeader"` arms; add tests
+
+- [ ] **Step 1: Write failing tests**
+
+Append to the test module:
+
+```rust
+    #[test]
+    fn test_render_table_pipe_format() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "table",
+                "content": [
+                    {"type": "tableRow", "content": [
+                        {"type": "tableHeader", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "h1"}]}]},
+                        {"type": "tableHeader", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "h2"}]}]},
+                    ]},
+                    {"type": "tableRow", "content": [
+                        {"type": "tableCell", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "a"}]}]},
+                        {"type": "tableCell", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "b"}]}]},
+                    ]},
+                ]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("| h1 | h2 |"), "header row missing: {text:?}");
+        assert!(text.contains("| --- | --- |"), "separator missing: {text:?}");
+        assert!(text.contains("| a | b |"), "body row missing: {text:?}");
+    }
+
+    #[test]
+    fn test_render_table_mixed_header_cell_row_still_emits_separator() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "table",
+                "content": [
+                    {"type": "tableRow", "content": [
+                        {"type": "tableHeader", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "h"}]}]},
+                        {"type": "tableCell", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "c"}]}]},
+                    ]},
+                ]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("| h | c |"), "row missing: {text:?}");
+        assert!(text.contains("| --- | --- |"), "separator missing: {text:?}");
+    }
+
+    #[test]
+    fn test_render_table_cell_flattens_paragraph() {
+        // Paragraph inside cell should not emit its own trailing newline
+        // (would break the | cell | cell | row structure).
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "table",
+                "content": [{
+                    "type": "tableRow",
+                    "content": [
+                        {"type": "tableCell", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "just text"}]}]}
+                    ]
+                }]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("| just text |"), "cell not flat: {text:?}");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib adf::tests::test_render_table`
+
+Expected: 3 failures — tables currently fall through to the `_` recurse-into-content arm, which emits raw text without pipe structure.
+
+- [ ] **Step 3: Add table-family arms**
+
+Add these four arms above the fallback `_`:
+
+```rust
+            "table" => {
+                self.render_children(node);
+                self.output.push('\n');
+            }
+            "tableRow" => {
+                let cells = node
+                    .get("content")
+                    .and_then(|c| c.as_array())
+                    .cloned()
+                    .unwrap_or_default();
+                let cell_count = cells.len();
+                let mut has_header = false;
+                self.output.push_str("| ");
+                for (i, cell) in cells.iter().enumerate() {
+                    if i > 0 {
+                        self.output.push_str(" | ");
+                    }
+                    if cell.get("type").and_then(|t| t.as_str()) == Some("tableHeader") {
+                        has_header = true;
+                    }
+                    self.render_cell_inline(cell);
+                }
+                self.output.push_str(" |\n");
+                if has_header {
+                    self.output.push_str("| ");
+                    for i in 0..cell_count {
+                        if i > 0 {
+                            self.output.push_str(" | ");
+                        }
+                        self.output.push_str("---");
+                    }
+                    self.output.push_str(" |\n");
+                }
+            }
+            "tableCell" | "tableHeader" => {
+                // Should not be reached directly — tableRow invokes render_cell_inline
+                // on its cells. Fall through to flat rendering defensively.
+                self.render_cell_inline(node);
+            }
+```
+
+Add this new helper method on `impl AdfRenderer`:
+
+```rust
+    /// Render a tableCell/tableHeader's children in "flat" mode: a paragraph's
+    /// inline content is emitted without its trailing newline (which would
+    /// break the "| cell | cell |" row structure). Other block types inside
+    /// a cell (rare but legal per the schema) fall back to normal rendering
+    /// with best-effort whitespace collapsing to keep the row on one line.
+    fn render_cell_inline(&mut self, cell: &Value) {
+        let Some(content) = cell.get("content").and_then(|c| c.as_array()) else {
+            return;
+        };
+        for (i, child) in content.iter().enumerate() {
+            if i > 0 {
+                self.output.push(' ');
+            }
+            let child_type = child.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            match child_type {
+                "paragraph" => {
+                    // Inline children only — no trailing newline.
+                    if let Some(cc) = child.get("content").and_then(|c| c.as_array()) {
+                        for inline in cc {
+                            self.render_node(inline);
+                        }
+                    }
+                }
+                _ => self.render_node(child),
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib adf::`
+
+All tests pass, including 3 new table tests.
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo clippy --all-targets -- -D warnings` — no warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/adf.rs
+git commit -m "feat: render ADF tables as pipe rows with header separator (#202)
+
+Separator emitted after any row that contains a tableHeader cell
+(matches ADF schema where header-ness is per-cell, not per-row).
+Paragraph inside a cell is flattened to keep the row on one line."
+```
+
+---
+
+### Task 7: Graceful fallback — drop unknown leaves silently
+
+**Files:**
+- Modify: `src/adf.rs` — change the fallback arm; rewrite the existing `test_adf_to_text_unsupported` test
+
+- [ ] **Step 1: Update the existing test and add a new companion test**
+
+Locate `test_adf_to_text_unsupported` (currently at `src/adf.rs:460`). Replace it with these two:
+
+```rust
+    #[test]
+    fn test_render_unknown_leaf_drops_silently() {
+        // Leaf (no content array) of an unknown type should produce empty text,
+        // not debug junk like "[unsupported: mediaGroup]".
+        let adf = json!({
+            "type": "doc",
+            "content": [{ "type": "mediaGroup" }]
+        });
+        assert_eq!(adf_to_text(&adf), "");
+    }
+
+    #[test]
+    fn test_render_unknown_container_recurses() {
+        // Container (has content array) of an unknown type should render its
+        // children — salvages panel, nestedExpand, etc.
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "panel",
+                "attrs": {"panelType": "info"},
+                "content": [
+                    {"type": "paragraph", "content": [{"type": "text", "text": "inside panel"}]}
+                ]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("inside panel"), "got: {text:?}");
+        assert!(!text.contains("[unsupported"), "no debug string: {text:?}");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify the new leaf-drop test fails (container test already passes)**
+
+Run: `cargo test --lib adf::tests::test_render_unknown`
+
+Expected: `test_render_unknown_leaf_drops_silently` fails — current code emits `[unsupported: mediaGroup]`. `test_render_unknown_container_recurses` passes already because the current fallback already recurses into `content`.
+
+- [ ] **Step 3: Change the fallback arm**
+
+In `render_node`, replace the `_` arm's body:
+
+```rust
+            _ => {
+                // Unknown node: recurse into content if present, otherwise
+                // drop silently. Per the #202 spec, this avoids debug strings
+                // like "[unsupported: type]" reaching user output while still
+                // salvaging the text content of container nodes like panel or
+                // nestedExpand.
+                if node.get("content").is_some() {
+                    self.render_children(node);
+                }
+            }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --lib adf::`
+
+All tests pass, including both fallback tests.
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo clippy --all-targets -- -D warnings` — no warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/adf.rs
+git commit -m "fix: drop unknown ADF leaf nodes silently (#202)
+
+Replaces the '[unsupported: <type>]' debug string with empty
+output. Unknown containers still recurse into content. Matches
+the flexydox/adf-to-md precedent and avoids leaking internal
+debug syntax into 'jr issue view' output."
+```
+
+---
+
+### Task 8: Snapshot regeneration + roundtrip test
+
+**Files:**
+- Modify: `src/adf.rs` — rewrite `test_adf_to_text_snapshot` with a rich input, add `test_markdown_to_adf_to_text_roundtrip`
+- Modify: `src/snapshots/jr__adf__tests__adf_to_text_complex.snap` (auto-regenerated by `cargo insta review`)
+
+- [ ] **Step 1: Replace the existing snapshot test**
+
+Locate `test_adf_to_text_snapshot` (currently around line 766). Replace its body with a rich input that exercises the new rendering paths:
+
+```rust
+    #[test]
+    fn test_adf_to_text_snapshot() {
+        let adf = json!({
+            "type": "doc",
+            "version": 1,
+            "content": [
+                {"type": "heading", "attrs": {"level": 2}, "content": [
+                    {"type": "text", "text": "Summary"}
+                ]},
+                {"type": "paragraph", "content": [
+                    {"type": "text", "text": "A "},
+                    {"type": "text", "text": "bold", "marks": [{"type": "strong"}]},
+                    {"type": "text", "text": " word, an "},
+                    {"type": "text", "text": "italic", "marks": [{"type": "em"}]},
+                    {"type": "text", "text": " word, a "},
+                    {"type": "text", "text": "link", "marks": [
+                        {"type": "link", "attrs": {"href": "https://example.com"}}
+                    ]},
+                    {"type": "text", "text": ", and "},
+                    {"type": "text", "text": "code", "marks": [{"type": "code"}]},
+                    {"type": "text", "text": "."}
+                ]},
+                {"type": "bulletList", "content": [
+                    {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "first bullet"}]}]},
+                    {"type": "listItem", "content": [
+                        {"type": "paragraph", "content": [{"type": "text", "text": "second bullet"}]},
+                        {"type": "orderedList", "attrs": {"order": 3}, "content": [
+                            {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "three"}]}]},
+                            {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "four"}]}]}
+                        ]}
+                    ]}
+                ]},
+                {"type": "blockquote", "content": [
+                    {"type": "paragraph", "content": [{"type": "text", "text": "quoted thought"}]}
+                ]},
+                {"type": "rule"},
+                {"type": "codeBlock", "attrs": {"language": "rust"}, "content": [
+                    {"type": "text", "text": "fn main() { println!(\"hi\"); }"}
+                ]},
+                {"type": "table", "content": [
+                    {"type": "tableRow", "content": [
+                        {"type": "tableHeader", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "k"}]}]},
+                        {"type": "tableHeader", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "v"}]}]}
+                    ]},
+                    {"type": "tableRow", "content": [
+                        {"type": "tableCell", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "a"}]}]},
+                        {"type": "tableCell", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "1"}]}]}
+                    ]}
+                ]}
+            ]
+        });
+        let text = adf_to_text(&adf);
+        insta::assert_snapshot!("adf_to_text_complex", text);
+    }
+```
+
+- [ ] **Step 2: Add the roundtrip test**
+
+Append to the test module:
+
+```rust
+    #[test]
+    fn test_markdown_to_adf_to_text_roundtrip() {
+        let input = concat!(
+            "# Heading\n",
+            "\n",
+            "Paragraph with **bold** and *italic* and `code`.\n",
+            "\n",
+            "- a\n",
+            "- b\n",
+            "\n",
+            "1. one\n",
+            "2. two\n",
+            "\n",
+            "> quote\n",
+        );
+        let adf_original = markdown_to_adf(input);
+        let text = adf_to_text(&adf_original);
+        let adf_reparsed = markdown_to_adf(&text);
+
+        // Compare node-type sequences at each depth for structural equivalence.
+        // Marks are compared as sets per text node (CommonMark renders
+        // '{strong, em}' and '{em, strong}' identically as '***text***').
+        let types_original = collect_node_types(&adf_original);
+        let types_reparsed = collect_node_types(&adf_reparsed);
+        assert_eq!(
+            types_original, types_reparsed,
+            "node-type structure should roundtrip"
+        );
+    }
+
+    /// Walk the ADF tree depth-first and collect each node's `type` field.
+    /// Used to assert structural (not textual) equivalence on roundtrip.
+    fn collect_node_types(adf: &Value) -> Vec<String> {
+        let mut types = Vec::new();
+        walk_types(adf, &mut types);
+        types
+    }
+
+    fn walk_types(node: &Value, out: &mut Vec<String>) {
+        if let Some(t) = node.get("type").and_then(|t| t.as_str()) {
+            out.push(t.to_string());
+        }
+        if let Some(content) = node.get("content").and_then(|c| c.as_array()) {
+            for child in content {
+                walk_types(child, out);
+            }
+        }
+    }
+```
+
+- [ ] **Step 3: Run tests; review and accept the new snapshot**
+
+Run: `cargo test --lib adf::`
+
+The first run will produce a snapshot mismatch (the existing `.snap` file is for the old, simpler input). Review and accept:
+
+```bash
+cargo insta review
+# In the review UI: press `a` to accept the new snapshot, `q` to quit.
+# Or non-interactively:
+cargo insta accept --unreferenced=delete
+```
+
+Then re-run: `cargo test --lib adf::` — all tests pass.
+
+- [ ] **Step 4: Run the full CI-equivalent check set**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+All three pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/adf.rs src/snapshots/jr__adf__tests__adf_to_text_complex.snap
+git commit -m "test: snapshot + roundtrip coverage for rich adf_to_text (#202)
+
+Regenerates the adf_to_text_complex snapshot with a rich input
+exercising headings, mixed inline marks, nested mixed-list,
+blockquote, rule, codeBlock-with-language, and a 2-row table.
+Adds a markdown→ADF→text→ADF roundtrip test comparing node-type
+sequences for structural equivalence."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Ordered lists with `attrs.order` → Task 2 ✅
+- Nested list indentation → Tasks 2 (mixed-list test), 8 (snapshot) ✅
+- Table pipe format → Task 6 ✅
+- Link href preservation → Task 3 ✅
+- Inline marks (strong/em/strike/code) → Task 3 ✅
+- Blockquote `> ` prefix → Task 4 ✅
+- Rule → Task 5 ✅
+- CodeBlock language → Task 5 ✅
+- HardBreak → Task 5 ✅
+- Graceful fallback (recurse/drop) → Task 7 ✅
+- Snapshot update → Task 8 ✅
+- Roundtrip test → Task 8 ✅
+- `listItem` no trailing `\n` → encoded in Task 1's scaffold (matches existing behavior) ✅
+- Unknown marks pass bare → Task 3 (`test_render_unknown_mark_drops_syntax`) ✅
+
+**No placeholders:** searched for TBD/TODO/"fill in"/"add appropriate"/"handle edge cases" — none present.
+
+**Type consistency:**
+- `AdfRenderer` fields: `output: String`, `list_stack: Vec<ListFrame>`, `blockquote_depth: usize` — consistent across tasks.
+- `ListFrame` variants: `Bullet`, `Ordered { next_index: u64 }` — consistent.
+- Method names: `new`, `render_doc`, `render_node`, `render_children`, `render_cell_inline`, `finish` — consistent.
+- `apply_marks(&str, Option<&Vec<Value>>)` helper signature used only in Task 3's `"text"` arm.
+
+No gaps found.

--- a/docs/superpowers/plans/2026-04-16-adf-to-text-rich-rendering.md
+++ b/docs/superpowers/plans/2026-04-16-adf-to-text-rich-rendering.md
@@ -4,7 +4,7 @@
 
 **Goal:** Replace the free `render_node`/`render_children` pair in `src/adf.rs` with a stateful `AdfRenderer` struct supporting ordered-list numbering (respecting `attrs.order`), inline marks (`strong`/`em`/`strike`/`code`/`link`), blockquote line prefixing (including nested `> > `), `rule` as `---`, `hardBreak` as `\n`, `codeBlock` with language fence, pipe-style tables with header separator, and graceful fallback for unknown nodes.
 
-**Architecture:** Stateful visitor struct `AdfRenderer { output, list_stack, blockquote_depth }` mirroring the existing write-path `AdfBuilder` pattern. Blockquote prefixing uses a split-and-prefix pass after rendering children into `output`, so all descendant content gets prefixed uniformly. Marks apply inside-out by iterating `node.marks[]` in array order (last mark outermost). Tables emit pipe-row markdown with a `| --- | --- |` separator line after any row containing a `tableHeader` cell.
+**Architecture:** Stateful visitor struct `AdfRenderer { output, list_stack }` mirroring the existing write-path `AdfBuilder` pattern. Blockquote prefixing uses a split-and-prefix pass after rendering children into `output`, so all descendant content gets prefixed uniformly. Marks apply inside-out by iterating `node.marks[]` in array order (last mark outermost). Tables emit pipe-row markdown with a `| --- | --- |` separator line after any row containing a `tableHeader` cell.
 
 **Tech Stack:** Rust 2024 (edition), MSRV 1.85, `serde_json::Value` for ADF traversal, `insta` for snapshots. No new crate dependencies.
 
@@ -31,7 +31,6 @@ pub fn adf_to_text(adf: &Value) -> String {
 struct AdfRenderer {
     output: String,
     list_stack: Vec<ListFrame>,
-    blockquote_depth: usize,
 }
 
 enum ListFrame {
@@ -44,7 +43,6 @@ impl AdfRenderer {
         Self {
             output: String::new(),
             list_stack: Vec::new(),
-            blockquote_depth: 0,
         }
     }
 
@@ -546,25 +544,34 @@ Insert a new arm in `render_node` above the fallback `_`:
 
 ```rust
             "blockquote" => {
-                self.blockquote_depth += 1;
                 let start = self.output.len();
                 self.render_children(node);
-                self.blockquote_depth -= 1;
 
                 // Prefix every line in the just-rendered segment with "> ".
-                // A single "> " is added per nesting level; nested blockquotes
-                // accumulate to "> > " on each line when their own prefix pass
-                // runs during unwind.
+                // Internal blank lines get bare ">" (no trailing space),
+                // trailing empties are trimmed. Nested blockquotes accumulate
+                // to "> > " automatically because each outer level re-prefixes
+                // its inner level's already-prefixed output on unwind — no
+                // depth counter is needed.
                 let rendered = self.output.split_off(start);
+                let mut lines: Vec<&str> = rendered.split('\n').collect();
+                while lines.last() == Some(&"") {
+                    lines.pop();
+                }
                 let prefix = "> ";
-                for (i, line) in rendered.split('\n').enumerate() {
+                for (i, line) in lines.iter().enumerate() {
                     if i > 0 {
                         self.output.push('\n');
                     }
-                    if !line.is_empty() {
+                    if line.is_empty() {
+                        self.output.push('>');
+                    } else {
                         self.output.push_str(prefix);
                         self.output.push_str(line);
                     }
+                }
+                if !lines.is_empty() {
+                    self.output.push('\n');
                 }
             }
 ```
@@ -1172,7 +1179,7 @@ sequences for structural equivalence."
 **No placeholders:** searched for TBD/TODO/"fill in"/"add appropriate"/"handle edge cases" — none present.
 
 **Type consistency:**
-- `AdfRenderer` fields: `output: String`, `list_stack: Vec<ListFrame>`, `blockquote_depth: usize` — consistent across tasks.
+- `AdfRenderer` fields: `output: String`, `list_stack: Vec<ListFrame>` — consistent across tasks. `blockquote_depth` was scoped out during implementation (stack-unwind re-prefix needs no depth counter).
 - `ListFrame` variants: `Bullet`, `Ordered { next_index: u64 }` — consistent.
 - Method names: `new`, `render_doc`, `render_node`, `render_children`, `render_cell_inline`, `finish` — consistent.
 - `apply_marks(&str, Option<&Vec<Value>>)` helper signature used only in Task 3's `"text"` arm.

--- a/docs/superpowers/specs/2026-04-16-adf-to-text-rich-rendering-design.md
+++ b/docs/superpowers/specs/2026-04-16-adf-to-text-rich-rendering-design.md
@@ -63,8 +63,8 @@ enum ListFrame {
 | `paragraph` | children, then `\n` |
 | `heading` (`attrs.level`) | `#` repeated `level` times, then space, then children, then `\n`. Required per schema; defaults to `level=1` defensively against corrupted input only. |
 | `bulletList` | push `ListFrame::Bullet`, render children, pop |
-| `orderedList` (`attrs.order`) | push `ListFrame::Ordered { next_index: order.unwrap_or(1) }`, render children, pop |
-| `listItem` | `"  "` × `(list_stack.len() - 1)` + prefix (`- ` or `{n}. `) + children + `\n`. Increment counter if the enclosing frame is `Ordered`. |
+| `orderedList` (`attrs.order`) | push `ListFrame::Ordered { next_index: order.filter(|&n| n >= 1).unwrap_or(1) }`, render children, pop. Jira treats `order=0`, negative, or missing as "start at 1"; the filter matches that contract. |
+| `listItem` | `"  "` × `(list_stack.len() - 1)` + prefix (`- ` or `{n}. `) + children. **No trailing `\n`** — the enclosed `paragraph` (schema-guaranteed: `listItem` content is block-only per ADF spec, and the write path already wraps inline in paragraphs) contributes its own trailing `\n`. Nested list children use their own indentation chain. Increment the counter after rendering if the enclosing frame is `Ordered`. |
 | `blockquote` | increment `blockquote_depth`, render children, decrement. Every rendered line contributed while `blockquote_depth > 0` gets prefixed with `"> "` × depth. |
 | `codeBlock` (`attrs.language`) | ` ```{lang}` fence line (empty lang = plain ` ``` `), code content, ` ``` ` close fence, `\n`. |
 | `rule` | `---\n` |
@@ -179,7 +179,7 @@ Two small tests replace the old one.
 One UX: best-effort render; never panic, never return an error, never emit debug syntax.
 
 - Use `serde_json::Value::get` + typed accessors (`.as_str`, `.as_array`, `.as_u64`) returning `Option`; chain with `.and_then` and default with `.unwrap_or` / `.unwrap_or_default`. No `.unwrap()` or `.expect()` anywhere in the renderer.
-- Missing optional fields (`codeBlock.attrs.language`, link `attrs.title`) → sensible empty default.
+- Missing optional fields (`codeBlock.attrs.language`, link `attrs.title`, `orderedList.attrs.order`) → sensible empty default. For `orderedList.attrs.order`, additionally filter out values `< 1` (Jira renders these as "start at 1", matching HTML's behavior with invalid `<ol start>`).
 - Missing required fields (`heading.attrs.level`, `link.attrs.href`) → defensive fallback (`level=1`, empty href). The ADF schema requires these; the fallback exists as defense-in-depth against corrupted input, not a normal path.
 - Malformed value types (e.g., `text` field on text node is an object not string) → treat as empty text. Matches the write-path's tolerance for unexpected event shapes.
 

--- a/docs/superpowers/specs/2026-04-16-adf-to-text-rich-rendering-design.md
+++ b/docs/superpowers/specs/2026-04-16-adf-to-text-rich-rendering-design.md
@@ -42,7 +42,6 @@ The struct carries the mutable state the new behavior needs — ordered-list cou
 struct AdfRenderer {
     output: String,
     list_stack: Vec<ListFrame>,
-    blockquote_depth: usize,
 }
 
 enum ListFrame {
@@ -53,7 +52,7 @@ enum ListFrame {
 
 - `list_stack.len()` replaces the old `depth: usize` parameter. Indent level for `listItem` is `list_stack.len() - 1`.
 - Each `listItem` under `ListFrame::Ordered` increments `next_index` after rendering.
-- `blockquote_depth` tracks nested `blockquote` nesting; prefix rendered into each line as `"> " * blockquote_depth`.
+- Nested `blockquote` nesting is handled by an unwind-time re-prefix pass (see the "Blockquote line-prefixing" section below) — no depth counter is needed; each enclosing blockquote re-prefixes its children's already-prefixed output on the way out.
 
 ### Feature mapping
 
@@ -65,7 +64,7 @@ enum ListFrame {
 | `bulletList` | push `ListFrame::Bullet`, render children, pop |
 | `orderedList` (`attrs.order`) | push `ListFrame::Ordered { next_index: order.filter(|&n| n >= 1).unwrap_or(1) }`, render children, pop. Jira treats `order=0`, negative, or missing as "start at 1"; the filter matches that contract. |
 | `listItem` | `"  "` × `(list_stack.len() - 1)` + prefix (`- ` or `{n}. `) + children. **No trailing `\n`** — the enclosed `paragraph` (schema-guaranteed: `listItem` content is block-only per ADF spec, and the write path already wraps inline in paragraphs) contributes its own trailing `\n`. Nested list children use their own indentation chain. Increment the counter after rendering if the enclosing frame is `Ordered`. |
-| `blockquote` | increment `blockquote_depth`, render children, decrement. Every rendered line contributed while `blockquote_depth > 0` gets prefixed with `"> "` × depth. |
+| `blockquote` | record the current `output.len()`, render children, then on unwind prefix every line of the just-rendered segment with `"> "` (empty lines get `">"`, trailing empties are trimmed). Nested blockquotes accumulate to `"> > "` automatically because each outer level re-prefixes its inner level's already-prefixed output. |
 | `codeBlock` (`attrs.language`) | ` ```{lang}` fence line (empty lang = plain ` ``` `), code content, ` ``` ` close fence, `\n`. |
 | `rule` | `---\n` |
 | `hardBreak` | `\n`. Trailing-two-spaces (`  \n`) form is a markdown-source convention; plain text doesn't need it. |
@@ -122,7 +121,7 @@ adf_to_text(&Value)
 
 ### Blockquote line-prefixing
 
-Implementation: before rendering a blockquote's children, record `output.len()`. After rendering, split the appended segment on `\n` and prefix each line with `"> "` × `blockquote_depth`. This means the prefix applies uniformly to paragraph text, nested list items, code blocks, and anything else rendered within. Nesting compounds (`> > `) because each enclosing blockquote applies its own prefix on unwind.
+Implementation: before rendering a blockquote's children, record `output.len()`. After rendering, split the appended segment on `\n`, trim trailing empty lines, then prefix each remaining line with `"> "` (or bare `">"` for internal blank lines). This means the prefix applies uniformly to paragraph text, nested list items, code blocks, and anything else rendered within. Nesting compounds (`> > `) because each enclosing blockquote re-applies its own prefix on unwind — no depth counter is needed.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-04-16-adf-to-text-rich-rendering-design.md
+++ b/docs/superpowers/specs/2026-04-16-adf-to-text-rich-rendering-design.md
@@ -1,0 +1,209 @@
+# ADF → Text Rich Rendering
+
+**Status:** Proposed
+**Issue:** [#202](https://github.com/Zious11/jira-cli/issues/202)
+**Related:** [#197](https://github.com/Zious11/jira-cli/issues/197), [PR #201](https://github.com/Zious11/jira-cli/pull/201)
+
+## Problem
+
+`src/adf.rs::adf_to_text` is the read-path renderer used by `jr issue view` (description) and `jr issue comments` (body). After PR #201 replaced the write-path `markdown_to_adf` with a real `pulldown-cmark`-driven builder, the write path emits proper ADF for ordered lists, tables, inline marks, blockquotes, hard breaks, horizontal rules, and code blocks with language — but the read path is behind. Concretely:
+
+- `orderedList` items render with `- ` bullet prefixes (same as `bulletList`) — numeric order is lost.
+- `table` / `tableRow` / `tableCell` / `tableHeader` fall through a generic "render children" path, collapsing cells into a flat text stream with no visible structure.
+- `link` marks render as their text only — the `href` attr is dropped.
+- `strong` / `em` / `strike` / `code` marks are dropped — bold and italic are indistinguishable from plain.
+- `blockquote` has no line marker — reads as a plain paragraph.
+- `rule` is silently dropped.
+- `hardBreak` is silently dropped.
+- `codeBlock` ignores `attrs.language`.
+- Unknown node types emit a debug string `[unsupported: <type>]` into user-facing output.
+
+The renderer's consumers embed its output inside `comfy-table` cells with `ContentArrangement::Dynamic` (see `src/cli/issue/list.rs:651`, `666`, `756`). That context rules out ANSI escape codes (the cell wraps the string as-is) and rules out Unicode box-drawing (would compete with the outer table). The only signal available for distinguishing inline formatting is literal characters in the output.
+
+## Design
+
+### Core change
+
+Replace the current free `render_node` / `render_children` pair with a stateful `AdfRenderer` struct living in `src/adf.rs` alongside `AdfBuilder`. The public API is unchanged:
+
+```rust
+pub fn adf_to_text(adf: &Value) -> String {
+    let mut r = AdfRenderer::new();
+    r.render_doc(adf);
+    r.finish()
+}
+```
+
+The struct carries the mutable state the new behavior needs — ordered-list counters, blockquote nesting depth — without having to thread those through function parameters on every recursive call. This mirrors the write-path `AdfBuilder` in the same file and matches the idiomatic Rust pattern used by `serde_json::PrettyFormatter`, `pulldown-cmark-to-cmark`, and `rustdoc` for tree-to-string rendering with nested state.
+
+### Renderer shape
+
+```rust
+struct AdfRenderer {
+    output: String,
+    list_stack: Vec<ListFrame>,
+    blockquote_depth: usize,
+}
+
+enum ListFrame {
+    Bullet,
+    Ordered { next_index: u64 },
+}
+```
+
+- `list_stack.len()` replaces the old `depth: usize` parameter. Indent level for `listItem` is `list_stack.len() - 1`.
+- Each `listItem` under `ListFrame::Ordered` increments `next_index` after rendering.
+- `blockquote_depth` tracks nested `blockquote` nesting; prefix rendered into each line as `"> " * blockquote_depth`.
+
+### Feature mapping
+
+| ADF node | Text output |
+|---|---|
+| `text` | apply `marks` (see Marks below) |
+| `paragraph` | children, then `\n` |
+| `heading` (`attrs.level`) | `#` repeated `level` times, then space, then children, then `\n`. Required per schema; defaults to `level=1` defensively against corrupted input only. |
+| `bulletList` | push `ListFrame::Bullet`, render children, pop |
+| `orderedList` (`attrs.order`) | push `ListFrame::Ordered { next_index: order.unwrap_or(1) }`, render children, pop |
+| `listItem` | `"  "` × `(list_stack.len() - 1)` + prefix (`- ` or `{n}. `) + children + `\n`. Increment counter if the enclosing frame is `Ordered`. |
+| `blockquote` | increment `blockquote_depth`, render children, decrement. Every rendered line contributed while `blockquote_depth > 0` gets prefixed with `"> "` × depth. |
+| `codeBlock` (`attrs.language`) | ` ```{lang}` fence line (empty lang = plain ` ``` `), code content, ` ``` ` close fence, `\n`. |
+| `rule` | `---\n` |
+| `hardBreak` | `\n`. Trailing-two-spaces (`  \n`) form is a markdown-source convention; plain text doesn't need it. |
+| `table` | render each `tableRow`; between header row(s) and body rows, emit `\| --- \| --- \|\n` separator. `\n` after the whole table. |
+| `tableRow` | `\| ` + cells joined by ` \| ` + ` \|\n`. After rendering, if any cell in this row was a `tableHeader`, emit the separator line with one dashed segment per cell in that row. |
+| `tableHeader` / `tableCell` | render children flat — paragraphs inside cells collapse (no inner `\n`). |
+| unknown **with** `content` array | recurse into `content`. Salvages `panel`, `nestedExpand`, and future additions without per-type code. |
+| unknown **leaf** (no `content`) | emit nothing. Silently drops `mediaSingle`, `mention`, `status`, `emoji`, `date`, `inlineCard`, `taskList`. Explicit renderers for the user-visible ones are tracked as follow-up work. |
+
+### Marks
+
+| Mark | Wrap (innermost text → outermost) |
+|---|---|
+| `code` | `` `text` `` |
+| `em` | `*text*` |
+| `strong` | `**text**` |
+| `strike` | `~~text~~` |
+| `link` (`attrs.href`) | `[text](href)`. Required per schema; defaults to empty string defensively against corrupted input only. |
+| unknown (`underline`, `textColor`, `subsup`, `backgroundColor`, …) | bare text, no syntax. |
+
+Iteration order: walk `node.marks[]` in array order, applying each mark to wrap the accumulated text. Result: the last mark in the array ends up outermost in the output. This is deterministic for snapshot tests even when multiple marks coexist on one text node. CommonMark parses back such strings to an equivalent AST regardless of which mark is outermost on a single run, so the fixed order is semantically roundtrip-safe.
+
+CLI convention context: tools like `gh`, `glow`, `mdcat`, and `bat` strip delimiters in plain-text mode because they also emit ANSI styling in colored mode. Our renderer never has ANSI available (cell context), so bare text would erase all distinction between bold, italic, strike, inline code, and plain. Markdown-syntax wrapping is the best signal available.
+
+### Header-row detection (tables)
+
+Per the ADF schema, header-ness lives on the cell (`tableHeader` vs `tableCell`), not the row — a `tableRow` may legally mix both. Jira Cloud's editor always emits the first row as all `tableHeader` in practice, but the renderer doesn't assume that. Rule:
+
+> After rendering each `tableRow`, if any of its cells was a `tableHeader`, emit the `| --- | --- | ... |` separator with one dashed segment per cell.
+
+The first all-header row produces the right markdown; the pathological "mixed header+body in one row" case produces valid output where the separator still appears after the row with any header.
+
+### Data flow
+
+```
+adf_to_text(&Value)
+    └─ AdfRenderer::new()
+       └─ render_doc(&Value)           // iterates top-level content[]
+          └─ render_block(&Value)       // dispatches on node.type
+             ├─ paragraph → render_inline(&Value) + newline
+             ├─ heading → # prefix + render_inline
+             ├─ bulletList / orderedList → push frame, render_block on each listItem, pop
+             ├─ listItem → indent + prefix + render_inline (+ nested block children)
+             ├─ blockquote → ++depth, render children, --depth
+             ├─ codeBlock → fence + raw text children + fence
+             ├─ rule → ---
+             ├─ table → render each tableRow; emit separator after any header row
+             └─ unknown → recurse into content if present, else skip
+          └─ render_inline(&Value)
+             ├─ text → apply_marks(text, marks)
+             ├─ hardBreak → newline
+             └─ unknown → recurse into content if present, else skip
+```
+
+### Blockquote line-prefixing
+
+Implementation: before rendering a blockquote's children, record `output.len()`. After rendering, split the appended segment on `\n` and prefix each line with `"> "` × `blockquote_depth`. This means the prefix applies uniformly to paragraph text, nested list items, code blocks, and anything else rendered within. Nesting compounds (`> > `) because each enclosing blockquote applies its own prefix on unwind.
+
+## Testing
+
+### Unit tests (one per AC item + edge cases)
+
+| Test | Scenario |
+|---|---|
+| `test_render_ordered_list_numeric_prefix` | 3 items, no `attrs.order`, asserts `1.` / `2.` / `3.` |
+| `test_render_ordered_list_respects_attrs_order` | `attrs.order: 5`, asserts `5.` / `6.` |
+| `test_render_nested_bullet_lists_indent` | outer/inner bulletList, asserts `-\n  -` |
+| `test_render_mixed_nested_lists` | orderedList containing bulletList, asserts `1.\n  -` |
+| `test_render_link_preserves_href` | link mark, asserts `[text](url)` |
+| `test_render_link_with_no_href` | malformed link, asserts `[text]()` |
+| `test_render_strong_mark` | asserts `**text**` |
+| `test_render_em_mark` | asserts `*text*` |
+| `test_render_strike_mark` | asserts `~~text~~` |
+| `test_render_code_mark` | asserts `` `text` `` |
+| `test_render_unknown_mark_drops_syntax` | `underline` mark, asserts bare text |
+| `test_render_multiple_marks_deterministic_order` | `[strong, em]`, asserts fixed output |
+| `test_render_blockquote_prefixes_each_line` | multi-line paragraph, asserts every line starts `>` |
+| `test_render_nested_blockquote` | doubly-nested, asserts `> >` |
+| `test_render_rule` | asserts `---` on its own line |
+| `test_render_hard_break_inserts_newline` | paragraph with hardBreak |
+| `test_render_code_block_with_language` | asserts `` ```rust\n...\n``` `` |
+| `test_render_code_block_without_language` | asserts empty fence |
+| `test_render_table_pipe_format` | 2×2 table with header, asserts header row + `\| --- \|` separator + body rows |
+| `test_render_table_mixed_header_cell_row` | row with both types, asserts separator still emitted |
+| `test_render_unknown_container_recurses` | `{type:"panel", content:[...]}`, asserts inner text visible |
+| `test_render_unknown_leaf_drops_silently` | `{type:"mediaSingle"}`, asserts empty |
+| `test_render_malformed_heading_defaults_level_1` | no `attrs.level`, asserts `# text` |
+
+### Snapshot test
+
+Rewrite `test_adf_to_text_snapshot` (currently adf.rs:766) with a rich doc exercising: heading at level 2, paragraph with mixed marks, nested lists mixing bullet and ordered, blockquote, `rule`, `hardBreak`, `codeBlock` with `attrs.language`, and a 2-row table with headers. Stored as insta snapshot `adf_to_text_complex`.
+
+### Roundtrip test
+
+`test_markdown_to_adf_to_text_roundtrip` — feed a moderately rich markdown string through `markdown_to_adf`, then through `adf_to_text`, and assert that re-parsing the output via `markdown_to_adf` produces structurally-equivalent ADF. Structural equivalence compares node types in traversal order and depth, and treats `marks` as a set per text node (ignores array order — CommonMark renders both orderings of e.g. `{em, strong}` as `***text***`). Whitespace-only text differences are ignored. Catches regressions in mark emission and list-numbering, and tightens the contract between the two sides.
+
+### Updated test
+
+`test_adf_to_text_unsupported` (currently adf.rs:460) asserts `[unsupported: mediaGroup]`. Updated contract:
+- unknown leaf → empty string
+- unknown container (has `content` array) → recurse into children, text of recognized descendants appears
+
+Two small tests replace the old one.
+
+### No integration tests
+
+`adf_to_text` is a pure function with no I/O, no config, no async. Existing `jr issue view` and `jr issue comments` integration tests that pass through it cover the wiring. No new integration tests needed.
+
+## Error Handling
+
+One UX: best-effort render; never panic, never return an error, never emit debug syntax.
+
+- Use `serde_json::Value::get` + typed accessors (`.as_str`, `.as_array`, `.as_u64`) returning `Option`; chain with `.and_then` and default with `.unwrap_or` / `.unwrap_or_default`. No `.unwrap()` or `.expect()` anywhere in the renderer.
+- Missing optional fields (`codeBlock.attrs.language`, link `attrs.title`) → sensible empty default.
+- Missing required fields (`heading.attrs.level`, `link.attrs.href`) → defensive fallback (`level=1`, empty href). The ADF schema requires these; the fallback exists as defense-in-depth against corrupted input, not a normal path.
+- Malformed value types (e.g., `text` field on text node is an object not string) → treat as empty text. Matches the write-path's tolerance for unexpected event shapes.
+
+## Validation Summary
+
+Decisions confirmed through Perplexity and Context7 during brainstorming:
+
+- **Stateful `&mut self` visitor struct** is the idiomatic Rust pattern for tree-to-string renderers tracking nested state (`serde_json::PrettyFormatter`, `pulldown-cmark-to-cmark`, `rustdoc`).
+- **Markdown-syntax wrapping for inline marks** diverges from the `gh`/`glow`/`bat` convention of "strip delimiters in plain-text mode" — defensible here because their plain-text mode is an ANSI-colored mode's fallback, while our output is consumed in a context (inside `comfy-table` cells) where ANSI is never available. Bare text would erase all inline distinctions.
+- **ADF `link.attrs.href`** required and non-empty per schema; `heading.attrs.level` required per schema; `codeBlock.attrs.language` optional.
+- **ADF `tableRow` can mix `tableHeader` and `tableCell`** per schema — header-ness is per-cell. Rule checks for any header in the row, not "first row is header."
+- **CommonMark nested blockquote:** `> >` with spaces, per line, not `>>`. Our design matches.
+- **Plain `\n` for hardBreak** in plain-text output — trailing-two-spaces is source-level syntax, not rendered-text convention.
+- **Graceful fallback** (recurse into unknown containers, silently drop unknown leaves) precedented in the `flexydox/issue-pr-commenter-action` ADF→markdown converter and related npm tooling.
+
+## Out of Scope (Follow-Ups)
+
+These are realistic ADF content types a Jira ticket might contain, deferred to separate issues:
+
+- **`mention`** → render as `@display_name`. Very common in real Jira content; worth doing but needs its own resolution plan (attrs contain `id` + `text`; prefer `text` if present).
+- **`status` / `emoji` / `date` / `inlineCard`** → one-line text renderers per type.
+- **`mediaSingle` / `mediaGroup` / `media`** → `[image: filename]` or similar. Jira native attachments; rendering them inline is ambiguous.
+- **`taskList` / `taskItem`** → `- [x]` / `- [ ]` style. Requires a new list frame variant.
+- **`panel`** (with type info/note/warning/error) → prefix with `> Note:` etc. Currently covered partially by the unknown-container fallback (content renders, panel type lost).
+- **Nested mark types beyond the AC** — `underline`, `textColor`, `subsup`, `backgroundColor` — bare-text fallback is already correct; dedicated formatting could come later if needed.
+
+Each of the above is a small, independent follow-up. Handling them here would inflate scope without serving the immediate fix of #202's acceptance criteria.

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -461,15 +461,32 @@ impl AdfRenderer {
                 // inner passes already produced — so a fixed "> " is correct at
                 // every level; no depth counter is needed.
                 let rendered = self.output.split_off(start);
+                // Collect lines, trim trailing empties (they'd produce a dangling
+                // "> " at the very end). Middle empty lines are preserved and
+                // prefixed with "> " so the blockquote context isn't broken by
+                // the blank-line-between-paragraphs pattern (e.g., a multi-line
+                // code block inside a blockquote).
+                let mut lines: Vec<&str> = rendered.split('\n').collect();
+                while lines.last() == Some(&"") {
+                    lines.pop();
+                }
                 let prefix = "> ";
-                for (i, line) in rendered.split('\n').enumerate() {
+                for (i, line) in lines.iter().enumerate() {
                     if i > 0 {
                         self.output.push('\n');
                     }
-                    if !line.is_empty() {
+                    if line.is_empty() {
+                        // Blank line inside the quote: emit just ">" (no trailing
+                        // space) — matches the conventional `>\n` markdown form
+                        // and preserves block-quote continuity.
+                        self.output.push('>');
+                    } else {
                         self.output.push_str(prefix);
                         self.output.push_str(line);
                     }
+                }
+                if !lines.is_empty() {
+                    self.output.push('\n');
                 }
             }
             "table" => {
@@ -547,19 +564,59 @@ impl AdfRenderer {
             let child_type = child.get("type").and_then(|t| t.as_str()).unwrap_or("");
             match child_type {
                 "paragraph" => {
+                    // Paragraph inside a cell: render its inline children
+                    // directly, substituting any hardBreak with a space so the
+                    // pipe-row structure stays on one line.
                     if let Some(cc) = child.get("content").and_then(|c| c.as_array()) {
                         for inline in cc {
-                            self.render_node(inline);
+                            self.render_inline_in_cell(inline);
                         }
                     }
                 }
+                "hardBreak" => self.output.push(' '),
                 _ => self.render_node(child),
             }
         }
     }
 
+    /// Like `render_node`, but when the node is a `hardBreak` emit a space
+    /// instead of a newline. Used inside table cells to keep rows single-line.
+    fn render_inline_in_cell(&mut self, node: &Value) {
+        let t = node.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        if t == "hardBreak" {
+            self.output.push(' ');
+        } else {
+            self.render_node(node);
+        }
+    }
+
     fn finish(self) -> String {
         self.output.trim_end().to_string()
+    }
+}
+
+/// Wrap an inline-code span using a delimiter long enough to contain any
+/// backtick runs in `text` (CommonMark rule: delimiter must have more
+/// backticks than the longest run inside). If the content begins or ends
+/// with a backtick, a single space is padded on each side so the delimiter
+/// can't "glue" to the content.
+fn wrap_code_span(text: &str) -> String {
+    let mut longest_run = 0usize;
+    let mut current = 0usize;
+    for ch in text.chars() {
+        if ch == '`' {
+            current += 1;
+            longest_run = longest_run.max(current);
+        } else {
+            current = 0;
+        }
+    }
+    let delim = "`".repeat(longest_run + 1);
+    let needs_pad = text.starts_with('`') || text.ends_with('`');
+    if needs_pad {
+        format!("{delim} {text} {delim}")
+    } else {
+        format!("{delim}{text}{delim}")
     }
 }
 
@@ -571,7 +628,7 @@ fn apply_marks(text: &str, marks: Option<&Vec<Value>>) -> String {
     for mark in marks {
         let mark_type = mark.get("type").and_then(|t| t.as_str()).unwrap_or("");
         result = match mark_type {
-            "code" => format!("`{result}`"),
+            "code" => wrap_code_span(&result),
             "em" => format!("*{result}*"),
             "strong" => format!("**{result}**"),
             "strike" => format!("~~{result}~~"),
@@ -1477,5 +1534,80 @@ mod tests {
                 walk_types(child, out);
             }
         }
+    }
+
+    #[test]
+    fn test_render_code_mark_with_backtick_in_content() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "foo`bar", "marks": [{"type": "code"}]}
+            ]}]
+        });
+        let text = adf_to_text(&adf);
+        assert_eq!(text, "``foo`bar``");
+    }
+
+    #[test]
+    fn test_render_code_mark_with_leading_trailing_backtick_pads() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "`x`", "marks": [{"type": "code"}]}
+            ]}]
+        });
+        let text = adf_to_text(&adf);
+        assert_eq!(text, "`` `x` ``");
+    }
+
+    #[test]
+    fn test_render_blockquote_with_internal_blank_line_keeps_prefix() {
+        // Blockquote containing a codeBlock whose content has a blank line.
+        // The blank line inside the quote must get a ">" prefix so the
+        // blockquote context isn't broken.
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "blockquote",
+                "content": [{
+                    "type": "codeBlock",
+                    "content": [{"type": "text", "text": "line 1\n\nline 3"}]
+                }]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        for line in text.lines() {
+            assert!(
+                line.starts_with('>'),
+                "every rendered line inside the blockquote should begin with '>': {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_render_hard_break_in_table_cell_becomes_space() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "table",
+                "content": [{
+                    "type": "tableRow",
+                    "content": [{
+                        "type": "tableCell",
+                        "content": [{
+                            "type": "paragraph",
+                            "content": [
+                                {"type": "text", "text": "line one"},
+                                {"type": "hardBreak"},
+                                {"type": "text", "text": "line two"}
+                            ]
+                        }]
+                    }]
+                }]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        // The cell content must stay on a single pipe row — no embedded newline.
+        assert!(text.contains("| line one line two |"), "got: {text:?}");
     }
 }

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -413,7 +413,8 @@ impl AdfRenderer {
                     .and_then(|o| o.as_u64())
                     .filter(|&n| n >= 1)
                     .unwrap_or(1);
-                self.list_stack.push(ListFrame::Ordered { next_index: start });
+                self.list_stack
+                    .push(ListFrame::Ordered { next_index: start });
                 self.render_children(node);
                 self.list_stack.pop();
             }
@@ -964,11 +965,48 @@ mod tests {
             "type": "doc",
             "version": 1,
             "content": [
-                {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Summary"}]},
-                {"type": "paragraph", "content": [{"type": "text", "text": "This is a description."}]},
+                {"type": "heading", "attrs": {"level": 2}, "content": [
+                    {"type": "text", "text": "Summary"}
+                ]},
+                {"type": "paragraph", "content": [
+                    {"type": "text", "text": "A "},
+                    {"type": "text", "text": "bold", "marks": [{"type": "strong"}]},
+                    {"type": "text", "text": " word, an "},
+                    {"type": "text", "text": "italic", "marks": [{"type": "em"}]},
+                    {"type": "text", "text": " word, a "},
+                    {"type": "text", "text": "link", "marks": [
+                        {"type": "link", "attrs": {"href": "https://example.com"}}
+                    ]},
+                    {"type": "text", "text": ", and "},
+                    {"type": "text", "text": "code", "marks": [{"type": "code"}]},
+                    {"type": "text", "text": "."}
+                ]},
                 {"type": "bulletList", "content": [
-                    {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Item one"}]}]},
-                    {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Item two"}]}]}
+                    {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "first bullet"}]}]},
+                    {"type": "listItem", "content": [
+                        {"type": "paragraph", "content": [{"type": "text", "text": "second bullet"}]},
+                        {"type": "orderedList", "attrs": {"order": 3}, "content": [
+                            {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "three"}]}]},
+                            {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "four"}]}]}
+                        ]}
+                    ]}
+                ]},
+                {"type": "blockquote", "content": [
+                    {"type": "paragraph", "content": [{"type": "text", "text": "quoted thought"}]}
+                ]},
+                {"type": "rule"},
+                {"type": "codeBlock", "attrs": {"language": "rust"}, "content": [
+                    {"type": "text", "text": "fn main() { println!(\"hi\"); }"}
+                ]},
+                {"type": "table", "content": [
+                    {"type": "tableRow", "content": [
+                        {"type": "tableHeader", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "k"}]}]},
+                        {"type": "tableHeader", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "v"}]}]}
+                    ]},
+                    {"type": "tableRow", "content": [
+                        {"type": "tableCell", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "a"}]}]},
+                        {"type": "tableCell", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "1"}]}]}
+                    ]}
                 ]}
             ]
         });
@@ -1053,7 +1091,10 @@ mod tests {
         });
         let text = adf_to_text(&adf);
         assert!(text.contains("| h1 | h2 |"), "header row missing: {text:?}");
-        assert!(text.contains("| --- | --- |"), "separator missing: {text:?}");
+        assert!(
+            text.contains("| --- | --- |"),
+            "separator missing: {text:?}"
+        );
         assert!(text.contains("| a | b |"), "body row missing: {text:?}");
     }
 
@@ -1073,7 +1114,10 @@ mod tests {
         });
         let text = adf_to_text(&adf);
         assert!(text.contains("| h | c |"), "row missing: {text:?}");
-        assert!(text.contains("| --- | --- |"), "separator missing: {text:?}");
+        assert!(
+            text.contains("| --- | --- |"),
+            "separator missing: {text:?}"
+        );
     }
 
     #[test]
@@ -1366,7 +1410,10 @@ mod tests {
             }]
         });
         let text = adf_to_text(&adf);
-        assert!(text.contains("```rust"), "expected rust fence, got: {text:?}");
+        assert!(
+            text.contains("```rust"),
+            "expected rust fence, got: {text:?}"
+        );
         assert!(text.contains("fn x() {}"));
     }
 
@@ -1380,6 +1427,55 @@ mod tests {
             }]
         });
         let text = adf_to_text(&adf);
-        assert!(text.contains("```\nplain"), "expected empty fence, got: {text:?}");
+        assert!(
+            text.contains("```\nplain"),
+            "expected empty fence, got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn test_markdown_to_adf_to_text_roundtrip() {
+        let input = concat!(
+            "# Heading\n",
+            "\n",
+            "Paragraph with **bold** and *italic* and `code`.\n",
+            "\n",
+            "- a\n",
+            "- b\n",
+            "\n",
+            "1. one\n",
+            "2. two\n",
+            "\n",
+            "> quote\n",
+        );
+        let adf_original = markdown_to_adf(input);
+        let text = adf_to_text(&adf_original);
+        let adf_reparsed = markdown_to_adf(&text);
+
+        let types_original = collect_node_types(&adf_original);
+        let types_reparsed = collect_node_types(&adf_reparsed);
+        assert_eq!(
+            types_original, types_reparsed,
+            "node-type structure should roundtrip"
+        );
+    }
+
+    /// Walk the ADF tree depth-first and collect each node's `type` field.
+    /// Used to assert structural (not textual) equivalence on roundtrip.
+    fn collect_node_types(adf: &Value) -> Vec<String> {
+        let mut types = Vec::new();
+        walk_types(adf, &mut types);
+        types
+    }
+
+    fn walk_types(node: &Value, out: &mut Vec<String>) {
+        if let Some(t) = node.get("type").and_then(|t| t.as_str()) {
+            out.push(t.to_string());
+        }
+        if let Some(content) = node.get("content").and_then(|c| c.as_array()) {
+            for child in content {
+                walk_types(child, out);
+            }
+        }
     }
 }

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -565,8 +565,8 @@ impl AdfRenderer {
             match child_type {
                 "paragraph" => {
                     // Paragraph inside a cell: render its inline children
-                    // directly, substituting any hardBreak with a space so the
-                    // pipe-row structure stays on one line.
+                    // directly. `hardBreak` becomes a space; text nodes are
+                    // sanitized for cell-unsafe characters (pipes, newlines).
                     if let Some(cc) = child.get("content").and_then(|c| c.as_array()) {
                         for inline in cc {
                             self.render_inline_in_cell(inline);
@@ -574,25 +574,40 @@ impl AdfRenderer {
                     }
                 }
                 "hardBreak" => self.output.push(' '),
-                _ => self.render_node(child),
+                _ => self.render_inline_in_cell(child),
             }
         }
     }
 
-    /// Like `render_node`, but when the node is a `hardBreak` emit a space
-    /// instead of a newline. Used inside table cells to keep rows single-line.
+    /// Render an inline node in cell mode: `hardBreak` becomes a space, and
+    /// text nodes are sanitized so pipes don't introduce false column
+    /// separators and embedded newlines don't break the row structure. Marks
+    /// are applied to the sanitized text so the escape survives mark wrapping.
     fn render_inline_in_cell(&mut self, node: &Value) {
         let t = node.get("type").and_then(|t| t.as_str()).unwrap_or("");
-        if t == "hardBreak" {
-            self.output.push(' ');
-        } else {
-            self.render_node(node);
+        match t {
+            "hardBreak" => self.output.push(' '),
+            "text" => {
+                let text = node.get("text").and_then(|v| v.as_str()).unwrap_or("");
+                let sanitized = sanitize_table_cell_text(text);
+                let marks = node.get("marks").and_then(|m| m.as_array());
+                self.output.push_str(&apply_marks(&sanitized, marks));
+            }
+            _ => self.render_node(node),
         }
     }
 
     fn finish(self) -> String {
         self.output.trim_end().to_string()
     }
+}
+
+/// Escape pipe characters and collapse embedded newlines in text that will
+/// be rendered inside a markdown table cell. Without this, a literal `|` in a
+/// cell's text would be read as an extra column separator, and an embedded
+/// `\n` would break the pipe row into multiple lines.
+fn sanitize_table_cell_text(text: &str) -> String {
+    text.replace(['\r', '\n'], " ").replace('|', r"\|")
 }
 
 /// Wrap an inline-code span using a delimiter long enough to contain any
@@ -620,15 +635,35 @@ fn wrap_code_span(text: &str) -> String {
     }
 }
 
-/// Wrap `text` with markdown-style syntax for each mark, innermost-first.
+/// Wrap `text` with markdown-style syntax for each mark. `code` is always
+/// applied innermost regardless of its position in the `marks` array, because
+/// the content of an inline-code span is literal and cannot itself carry
+/// other markdown syntax. The remaining marks then wrap the code span in
+/// array order.
+///
+/// This matters because the write-path `AdfBuilder::push_code` appends
+/// `{type: "code"}` to the active marks *after* any other marks, so on
+/// roundtrip we see `marks: [strong, code]` for `**`\x`**`; applying marks
+/// strictly in order would produce `` `**x**` `` (code outermost),
+/// losing the bold semantics.
+///
 /// Unknown mark types pass through without added syntax.
 fn apply_marks(text: &str, marks: Option<&Vec<Value>>) -> String {
-    let mut result = text.to_string();
-    let Some(marks) = marks else { return result };
+    let Some(marks) = marks else {
+        return text.to_string();
+    };
+    let has_code = marks
+        .iter()
+        .any(|m| m.get("type").and_then(|t| t.as_str()) == Some("code"));
+    let mut result = if has_code {
+        wrap_code_span(text)
+    } else {
+        text.to_string()
+    };
     for mark in marks {
         let mark_type = mark.get("type").and_then(|t| t.as_str()).unwrap_or("");
         result = match mark_type {
-            "code" => wrap_code_span(&result),
+            "code" => result, // handled above as innermost
             "em" => format!("*{result}*"),
             "strong" => format!("**{result}**"),
             "strike" => format!("~~{result}~~"),
@@ -1609,5 +1644,63 @@ mod tests {
         let text = adf_to_text(&adf);
         // The cell content must stay on a single pipe row — no embedded newline.
         assert!(text.contains("| line one line two |"), "got: {text:?}");
+    }
+
+    #[test]
+    fn test_render_strong_with_code_applies_code_innermost() {
+        // Matches the write-path's marks ordering: strong + code produces
+        // marks = [strong, code]. Output must be **`code`** not `**code**`.
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "x", "marks": [{"type": "strong"}, {"type": "code"}]}
+            ]}]
+        });
+        let text = adf_to_text(&adf);
+        assert_eq!(text, "**`x`**");
+    }
+
+    #[test]
+    fn test_render_table_cell_escapes_pipe_in_text() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "table",
+                "content": [{
+                    "type": "tableRow",
+                    "content": [{
+                        "type": "tableCell",
+                        "content": [{"type": "paragraph", "content": [
+                            {"type": "text", "text": "a|b"}
+                        ]}]
+                    }]
+                }]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        // Pipe inside the cell must be escaped so it doesn't introduce a
+        // false column break.
+        assert!(text.contains(r"| a\|b |"), "got: {text:?}");
+    }
+
+    #[test]
+    fn test_render_table_cell_collapses_newlines_in_text() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "table",
+                "content": [{
+                    "type": "tableRow",
+                    "content": [{
+                        "type": "tableCell",
+                        "content": [{"type": "paragraph", "content": [
+                            {"type": "text", "text": "line\nwrap"}
+                        ]}]
+                    }]
+                }]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("| line wrap |"), "got: {text:?}");
     }
 }

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -351,7 +351,6 @@ pub fn adf_to_text(adf: &Value) -> String {
 struct AdfRenderer {
     output: String,
     list_stack: Vec<ListFrame>,
-    blockquote_depth: usize,
 }
 
 enum ListFrame {
@@ -364,7 +363,6 @@ impl AdfRenderer {
         Self {
             output: String::new(),
             list_stack: Vec::new(),
-            blockquote_depth: 0,
         }
     }
 
@@ -454,17 +452,14 @@ impl AdfRenderer {
                 self.output.push_str("\n```\n");
             }
             "blockquote" => {
-                self.blockquote_depth += 1;
                 let start = self.output.len();
                 self.render_children(node);
-                self.blockquote_depth -= 1;
 
                 // Prefix every line in the just-rendered segment with "> ".
                 // Nesting accumulates ("> > inner") because each level's prefix
                 // pass runs on unwind, re-prefixing the output its children's
-                // inner passes already produced — `blockquote_depth` is tracked
-                // for state but not consulted here; the prefix is always a
-                // single "> " regardless of depth.
+                // inner passes already produced — so a fixed "> " is correct at
+                // every level; no depth counter is needed.
                 let rendered = self.output.split_off(start);
                 let prefix = "> ";
                 for (i, line) in rendered.split('\n').enumerate() {
@@ -482,11 +477,11 @@ impl AdfRenderer {
                 self.output.push('\n');
             }
             "tableRow" => {
-                let cells = node
+                let cells: &[Value] = node
                     .get("content")
                     .and_then(|c| c.as_array())
-                    .cloned()
-                    .unwrap_or_default();
+                    .map(|v| v.as_slice())
+                    .unwrap_or(&[]);
                 let cell_count = cells.len();
                 let mut has_header = false;
                 self.output.push_str("| ");

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -378,9 +378,9 @@ impl AdfRenderer {
         let node_type = node.get("type").and_then(|t| t.as_str()).unwrap_or("");
         match node_type {
             "text" => {
-                if let Some(text) = node.get("text").and_then(|t| t.as_str()) {
-                    self.output.push_str(text);
-                }
+                let text = node.get("text").and_then(|t| t.as_str()).unwrap_or("");
+                let marks = node.get("marks").and_then(|m| m.as_array());
+                self.output.push_str(&apply_marks(text, marks));
             }
             "paragraph" => {
                 self.render_children(node);
@@ -456,6 +456,32 @@ impl AdfRenderer {
     fn finish(self) -> String {
         self.output.trim_end().to_string()
     }
+}
+
+/// Wrap `text` with markdown-style syntax for each mark, innermost-first.
+/// Unknown mark types pass through without added syntax.
+fn apply_marks(text: &str, marks: Option<&Vec<Value>>) -> String {
+    let mut result = text.to_string();
+    let Some(marks) = marks else { return result };
+    for mark in marks {
+        let mark_type = mark.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        result = match mark_type {
+            "code" => format!("`{result}`"),
+            "em" => format!("*{result}*"),
+            "strong" => format!("**{result}**"),
+            "strike" => format!("~~{result}~~"),
+            "link" => {
+                let href = mark
+                    .get("attrs")
+                    .and_then(|a| a.get("href"))
+                    .and_then(|h| h.as_str())
+                    .unwrap_or("");
+                format!("[{result}]({href})")
+            }
+            _ => result,
+        };
+    }
+    result
 }
 
 #[cfg(test)]
@@ -911,6 +937,96 @@ mod tests {
         assert_eq!(link_text["text"], "link");
         assert_eq!(link_text["marks"][0]["type"], "link");
         assert_eq!(link_text["marks"][0]["attrs"]["href"], "https://x");
+    }
+
+    #[test]
+    fn test_render_strong_mark() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "bold", "marks": [{"type": "strong"}]}
+            ]}]
+        });
+        assert_eq!(adf_to_text(&adf), "**bold**");
+    }
+
+    #[test]
+    fn test_render_em_mark() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "em", "marks": [{"type": "em"}]}
+            ]}]
+        });
+        assert_eq!(adf_to_text(&adf), "*em*");
+    }
+
+    #[test]
+    fn test_render_strike_mark() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "gone", "marks": [{"type": "strike"}]}
+            ]}]
+        });
+        assert_eq!(adf_to_text(&adf), "~~gone~~");
+    }
+
+    #[test]
+    fn test_render_code_mark() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "x", "marks": [{"type": "code"}]}
+            ]}]
+        });
+        assert_eq!(adf_to_text(&adf), "`x`");
+    }
+
+    #[test]
+    fn test_render_link_preserves_href() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "jr", "marks": [
+                    {"type": "link", "attrs": {"href": "https://example.com/jr"}}
+                ]}
+            ]}]
+        });
+        assert_eq!(adf_to_text(&adf), "[jr](https://example.com/jr)");
+    }
+
+    #[test]
+    fn test_render_link_missing_href_defaults_empty() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "jr", "marks": [{"type": "link"}]}
+            ]}]
+        });
+        assert_eq!(adf_to_text(&adf), "[jr]()");
+    }
+
+    #[test]
+    fn test_render_multiple_marks_deterministic_order() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "foo", "marks": [{"type": "strong"}, {"type": "em"}]}
+            ]}]
+        });
+        assert_eq!(adf_to_text(&adf), "***foo***");
+    }
+
+    #[test]
+    fn test_render_unknown_mark_drops_syntax() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "plain", "marks": [{"type": "underline"}]}
+            ]}]
+        });
+        assert_eq!(adf_to_text(&adf), "plain");
     }
 
     #[test]

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -355,7 +355,7 @@ struct AdfRenderer {
 
 enum ListFrame {
     Bullet,
-    // `Ordered { next_index: u64 }` variant added in Task 2 alongside its first use.
+    Ordered { next_index: u64 },
 }
 
 impl AdfRenderer {
@@ -399,15 +399,34 @@ impl AdfRenderer {
                 self.render_children(node);
                 self.output.push('\n');
             }
-            "bulletList" | "orderedList" => {
+            "bulletList" => {
                 self.list_stack.push(ListFrame::Bullet);
+                self.render_children(node);
+                self.list_stack.pop();
+            }
+            "orderedList" => {
+                let start = node
+                    .get("attrs")
+                    .and_then(|a| a.get("order"))
+                    .and_then(|o| o.as_u64())
+                    .filter(|&n| n >= 1)
+                    .unwrap_or(1);
+                self.list_stack.push(ListFrame::Ordered { next_index: start });
                 self.render_children(node);
                 self.list_stack.pop();
             }
             "listItem" => {
                 let indent = "  ".repeat(self.list_stack.len().saturating_sub(1));
                 self.output.push_str(&indent);
-                self.output.push_str("- ");
+                let prefix = match self.list_stack.last_mut() {
+                    Some(ListFrame::Ordered { next_index }) => {
+                        let n = *next_index;
+                        *next_index += 1;
+                        format!("{n}. ")
+                    }
+                    _ => "- ".to_string(),
+                };
+                self.output.push_str(&prefix);
                 self.render_children(node);
             }
             "codeBlock" => {
@@ -892,5 +911,81 @@ mod tests {
         assert_eq!(link_text["text"], "link");
         assert_eq!(link_text["marks"][0]["type"], "link");
         assert_eq!(link_text["marks"][0]["attrs"]["href"], "https://x");
+    }
+
+    #[test]
+    fn test_render_ordered_list_numeric_prefix() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "orderedList",
+                "content": [
+                    {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "alpha"}]}]},
+                    {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "beta"}]}]},
+                    {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "gamma"}]}]},
+                ]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("1. alpha"), "got: {text:?}");
+        assert!(text.contains("2. beta"), "got: {text:?}");
+        assert!(text.contains("3. gamma"), "got: {text:?}");
+    }
+
+    #[test]
+    fn test_render_ordered_list_respects_attrs_order() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "orderedList",
+                "attrs": {"order": 5},
+                "content": [
+                    {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "five"}]}]},
+                    {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "six"}]}]},
+                ]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("5. five"), "got: {text:?}");
+        assert!(text.contains("6. six"), "got: {text:?}");
+    }
+
+    #[test]
+    fn test_render_ordered_list_order_zero_defaults_to_one() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "orderedList",
+                "attrs": {"order": 0},
+                "content": [
+                    {"type": "listItem", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "only"}]}]},
+                ]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("1. only"), "got: {text:?}");
+    }
+
+    #[test]
+    fn test_render_mixed_nested_lists() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "orderedList",
+                "content": [{
+                    "type": "listItem",
+                    "content": [
+                        {"type": "paragraph", "content": [{"type": "text", "text": "outer"}]},
+                        {"type": "bulletList", "content": [{
+                            "type": "listItem",
+                            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "inner"}]}]
+                        }]}
+                    ]
+                }]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("1. outer"), "got: {text:?}");
+        assert!(text.contains("  - inner"), "got: {text:?}");
     }
 }

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -511,11 +511,13 @@ impl AdfRenderer {
                 self.render_cell_inline(node);
             }
             _ => {
+                // Unknown node: recurse into content if present, otherwise
+                // drop silently. Per the #202 spec, this avoids debug strings
+                // like "[unsupported: type]" reaching user output while still
+                // salvaging the text content of container nodes like panel or
+                // nestedExpand.
                 if node.get("content").is_some() {
                     self.render_children(node);
-                } else {
-                    self.output
-                        .push_str(&format!("[unsupported: {node_type}]"));
                 }
             }
         }
@@ -634,12 +636,29 @@ mod tests {
     }
 
     #[test]
-    fn test_adf_to_text_unsupported() {
+    fn test_render_unknown_leaf_drops_silently() {
         let adf = json!({
             "type": "doc",
             "content": [{ "type": "mediaGroup" }]
         });
-        assert!(adf_to_text(&adf).contains("[unsupported: mediaGroup]"));
+        assert_eq!(adf_to_text(&adf), "");
+    }
+
+    #[test]
+    fn test_render_unknown_container_recurses() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "panel",
+                "attrs": {"panelType": "info"},
+                "content": [
+                    {"type": "paragraph", "content": [{"type": "text", "text": "inside panel"}]}
+                ]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("inside panel"), "got: {text:?}");
+        assert!(!text.contains("[unsupported"), "no debug string: {text:?}");
     }
 
     #[test]

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -407,6 +407,9 @@ impl AdfRenderer {
                 self.list_stack.pop();
             }
             "orderedList" => {
+                // Treat missing, 0, or negative `attrs.order` as "start at 1" —
+                // matches Jira's own renderer, which ignores invalid HTML
+                // `<ol start>` values the same way.
                 let start = node
                     .get("attrs")
                     .and_then(|a| a.get("order"))
@@ -457,9 +460,11 @@ impl AdfRenderer {
                 self.blockquote_depth -= 1;
 
                 // Prefix every line in the just-rendered segment with "> ".
-                // A single "> " is added per nesting level; nested blockquotes
-                // accumulate to "> > " on each line when their own prefix pass
-                // runs during unwind.
+                // Nesting accumulates ("> > inner") because each level's prefix
+                // pass runs on unwind, re-prefixing the output its children's
+                // inner passes already produced — `blockquote_depth` is tracked
+                // for state but not consulted here; the prefix is always a
+                // single "> " regardless of depth.
                 let rendered = self.output.split_off(start);
                 let prefix = "> ";
                 for (i, line) in rendered.split('\n').enumerate() {

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -351,6 +351,7 @@ pub fn adf_to_text(adf: &Value) -> String {
 struct AdfRenderer {
     output: String,
     list_stack: Vec<ListFrame>,
+    blockquote_depth: usize,
 }
 
 enum ListFrame {
@@ -363,6 +364,7 @@ impl AdfRenderer {
         Self {
             output: String::new(),
             list_stack: Vec::new(),
+            blockquote_depth: 0,
         }
     }
 
@@ -433,6 +435,28 @@ impl AdfRenderer {
                 self.output.push_str("```\n");
                 self.render_children(node);
                 self.output.push_str("\n```\n");
+            }
+            "blockquote" => {
+                self.blockquote_depth += 1;
+                let start = self.output.len();
+                self.render_children(node);
+                self.blockquote_depth -= 1;
+
+                // Prefix every line in the just-rendered segment with "> ".
+                // A single "> " is added per nesting level; nested blockquotes
+                // accumulate to "> > " on each line when their own prefix pass
+                // runs during unwind.
+                let rendered = self.output.split_off(start);
+                let prefix = "> ";
+                for (i, line) in rendered.split('\n').enumerate() {
+                    if i > 0 {
+                        self.output.push('\n');
+                    }
+                    if !line.is_empty() {
+                        self.output.push_str(prefix);
+                        self.output.push_str(line);
+                    }
+                }
             }
             _ => {
                 if node.get("content").is_some() {
@@ -937,6 +961,44 @@ mod tests {
         assert_eq!(link_text["text"], "link");
         assert_eq!(link_text["marks"][0]["type"], "link");
         assert_eq!(link_text["marks"][0]["attrs"]["href"], "https://x");
+    }
+
+    #[test]
+    fn test_render_blockquote_prefixes_each_line() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "blockquote",
+                "content": [
+                    {"type": "paragraph", "content": [{"type": "text", "text": "line one"}]},
+                    {"type": "paragraph", "content": [{"type": "text", "text": "line two"}]}
+                ]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        for line in text.lines() {
+            assert!(line.starts_with("> "), "line should be prefixed: {line:?}");
+        }
+        assert!(text.contains("> line one"));
+        assert!(text.contains("> line two"));
+    }
+
+    #[test]
+    fn test_render_nested_blockquote() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "blockquote",
+                "content": [{
+                    "type": "blockquote",
+                    "content": [
+                        {"type": "paragraph", "content": [{"type": "text", "text": "inner"}]}
+                    ]
+                }]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("> > inner"), "got: {text:?}");
     }
 
     #[test]

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -471,6 +471,45 @@ impl AdfRenderer {
                     }
                 }
             }
+            "table" => {
+                self.render_children(node);
+                self.output.push('\n');
+            }
+            "tableRow" => {
+                let cells = node
+                    .get("content")
+                    .and_then(|c| c.as_array())
+                    .cloned()
+                    .unwrap_or_default();
+                let cell_count = cells.len();
+                let mut has_header = false;
+                self.output.push_str("| ");
+                for (i, cell) in cells.iter().enumerate() {
+                    if i > 0 {
+                        self.output.push_str(" | ");
+                    }
+                    if cell.get("type").and_then(|t| t.as_str()) == Some("tableHeader") {
+                        has_header = true;
+                    }
+                    self.render_cell_inline(cell);
+                }
+                self.output.push_str(" |\n");
+                if has_header {
+                    self.output.push_str("| ");
+                    for i in 0..cell_count {
+                        if i > 0 {
+                            self.output.push_str(" | ");
+                        }
+                        self.output.push_str("---");
+                    }
+                    self.output.push_str(" |\n");
+                }
+            }
+            "tableCell" | "tableHeader" => {
+                // Should not be reached directly — tableRow invokes render_cell_inline
+                // on its cells. Fall through to flat rendering defensively.
+                self.render_cell_inline(node);
+            }
             _ => {
                 if node.get("content").is_some() {
                     self.render_children(node);
@@ -486,6 +525,32 @@ impl AdfRenderer {
         if let Some(content) = node.get("content").and_then(|c| c.as_array()) {
             for child in content {
                 self.render_node(child);
+            }
+        }
+    }
+
+    /// Render a tableCell/tableHeader's children in "flat" mode: a paragraph's
+    /// inline content is emitted without its trailing newline (which would
+    /// break the "| cell | cell |" row structure). Other block types inside
+    /// a cell (rare but legal per the schema) fall back to normal rendering.
+    fn render_cell_inline(&mut self, cell: &Value) {
+        let Some(content) = cell.get("content").and_then(|c| c.as_array()) else {
+            return;
+        };
+        for (i, child) in content.iter().enumerate() {
+            if i > 0 {
+                self.output.push(' ');
+            }
+            let child_type = child.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            match child_type {
+                "paragraph" => {
+                    if let Some(cc) = child.get("content").and_then(|c| c.as_array()) {
+                        for inline in cc {
+                            self.render_node(inline);
+                        }
+                    }
+                }
+                _ => self.render_node(child),
             }
         }
     }
@@ -947,6 +1012,67 @@ mod tests {
         assert!(text(&items[0]).contains("done task"));
         assert!(text(&items[1]).contains("[ ]"));
         assert!(text(&items[1]).contains("pending task"));
+    }
+
+    #[test]
+    fn test_render_table_pipe_format() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "table",
+                "content": [
+                    {"type": "tableRow", "content": [
+                        {"type": "tableHeader", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "h1"}]}]},
+                        {"type": "tableHeader", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "h2"}]}]},
+                    ]},
+                    {"type": "tableRow", "content": [
+                        {"type": "tableCell", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "a"}]}]},
+                        {"type": "tableCell", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "b"}]}]},
+                    ]},
+                ]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("| h1 | h2 |"), "header row missing: {text:?}");
+        assert!(text.contains("| --- | --- |"), "separator missing: {text:?}");
+        assert!(text.contains("| a | b |"), "body row missing: {text:?}");
+    }
+
+    #[test]
+    fn test_render_table_mixed_header_cell_row_still_emits_separator() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "table",
+                "content": [
+                    {"type": "tableRow", "content": [
+                        {"type": "tableHeader", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "h"}]}]},
+                        {"type": "tableCell", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "c"}]}]},
+                    ]},
+                ]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("| h | c |"), "row missing: {text:?}");
+        assert!(text.contains("| --- | --- |"), "separator missing: {text:?}");
+    }
+
+    #[test]
+    fn test_render_table_cell_flattens_paragraph() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "table",
+                "content": [{
+                    "type": "tableRow",
+                    "content": [
+                        {"type": "tableCell", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "just text"}]}]}
+                    ]
+                }]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("| just text |"), "cell not flat: {text:?}");
     }
 
     #[test]

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -343,69 +343,99 @@ fn heading_level_to_u8(level: HeadingLevel) -> u8 {
 }
 
 pub fn adf_to_text(adf: &Value) -> String {
-    let mut output = String::new();
-    if let Some(content) = adf.get("content").and_then(|c| c.as_array()) {
-        for node in content {
-            render_node(node, &mut output, 0);
-        }
-    }
-    output.trim_end().to_string()
+    let mut r = AdfRenderer::new();
+    r.render_doc(adf);
+    r.finish()
 }
 
-fn render_node(node: &Value, output: &mut String, depth: usize) {
-    let node_type = node.get("type").and_then(|t| t.as_str()).unwrap_or("");
-    match node_type {
-        "text" => {
-            if let Some(text) = node.get("text").and_then(|t| t.as_str()) {
-                output.push_str(text);
-            }
+struct AdfRenderer {
+    output: String,
+    list_stack: Vec<ListFrame>,
+}
+
+enum ListFrame {
+    Bullet,
+    // `Ordered { next_index: u64 }` variant added in Task 2 alongside its first use.
+}
+
+impl AdfRenderer {
+    fn new() -> Self {
+        Self {
+            output: String::new(),
+            list_stack: Vec::new(),
         }
-        "paragraph" => {
-            render_children(node, output, depth);
-            output.push('\n');
-        }
-        "heading" => {
-            let level = node
-                .get("attrs")
-                .and_then(|a| a.get("level"))
-                .and_then(|l| l.as_u64())
-                .unwrap_or(1) as usize;
-            for _ in 0..level {
-                output.push('#');
-            }
-            output.push(' ');
-            render_children(node, output, depth);
-            output.push('\n');
-        }
-        "bulletList" | "orderedList" => {
-            render_children(node, output, depth);
-        }
-        "listItem" => {
-            let indent = "  ".repeat(depth);
-            output.push_str(&indent);
-            output.push_str("- ");
-            render_children(node, output, depth + 1);
-        }
-        "codeBlock" => {
-            output.push_str("```\n");
-            render_children(node, output, depth);
-            output.push_str("\n```\n");
-        }
-        _ => {
-            if node.get("content").is_some() {
-                render_children(node, output, depth);
-            } else {
-                output.push_str(&format!("[unsupported: {node_type}]"));
+    }
+
+    fn render_doc(&mut self, adf: &Value) {
+        if let Some(content) = adf.get("content").and_then(|c| c.as_array()) {
+            for node in content {
+                self.render_node(node);
             }
         }
     }
-}
 
-fn render_children(node: &Value, output: &mut String, depth: usize) {
-    if let Some(content) = node.get("content").and_then(|c| c.as_array()) {
-        for child in content {
-            render_node(child, output, depth);
+    fn render_node(&mut self, node: &Value) {
+        let node_type = node.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        match node_type {
+            "text" => {
+                if let Some(text) = node.get("text").and_then(|t| t.as_str()) {
+                    self.output.push_str(text);
+                }
+            }
+            "paragraph" => {
+                self.render_children(node);
+                self.output.push('\n');
+            }
+            "heading" => {
+                let level = node
+                    .get("attrs")
+                    .and_then(|a| a.get("level"))
+                    .and_then(|l| l.as_u64())
+                    .unwrap_or(1) as usize;
+                for _ in 0..level {
+                    self.output.push('#');
+                }
+                self.output.push(' ');
+                self.render_children(node);
+                self.output.push('\n');
+            }
+            "bulletList" | "orderedList" => {
+                self.list_stack.push(ListFrame::Bullet);
+                self.render_children(node);
+                self.list_stack.pop();
+            }
+            "listItem" => {
+                let indent = "  ".repeat(self.list_stack.len().saturating_sub(1));
+                self.output.push_str(&indent);
+                self.output.push_str("- ");
+                self.render_children(node);
+            }
+            "codeBlock" => {
+                self.output.push_str("```\n");
+                self.render_children(node);
+                self.output.push_str("\n```\n");
+            }
+            _ => {
+                if node.get("content").is_some() {
+                    self.render_children(node);
+                } else {
+                    self.output
+                        .push_str(&format!("[unsupported: {node_type}]"));
+                }
+            }
         }
+    }
+
+    fn render_children(&mut self, node: &Value) {
+        if let Some(content) = node.get("content").and_then(|c| c.as_array()) {
+            for child in content {
+                self.render_node(child);
+            }
+        }
+    }
+
+    fn finish(self) -> String {
+        self.output.trim_end().to_string()
     }
 }
 

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -431,8 +431,21 @@ impl AdfRenderer {
                 self.output.push_str(&prefix);
                 self.render_children(node);
             }
+            "rule" => {
+                self.output.push_str("---\n");
+            }
+            "hardBreak" => {
+                self.output.push('\n');
+            }
             "codeBlock" => {
-                self.output.push_str("```\n");
+                let lang = node
+                    .get("attrs")
+                    .and_then(|a| a.get("language"))
+                    .and_then(|l| l.as_str())
+                    .unwrap_or("");
+                self.output.push_str("```");
+                self.output.push_str(lang);
+                self.output.push('\n');
                 self.render_children(node);
                 self.output.push_str("\n```\n");
             }
@@ -1165,5 +1178,63 @@ mod tests {
         let text = adf_to_text(&adf);
         assert!(text.contains("1. outer"), "got: {text:?}");
         assert!(text.contains("  - inner"), "got: {text:?}");
+    }
+
+    #[test]
+    fn test_render_rule() {
+        let adf = json!({
+            "type": "doc",
+            "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "above"}]},
+                {"type": "rule"},
+                {"type": "paragraph", "content": [{"type": "text", "text": "below"}]}
+            ]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("---"), "expected rule line, got: {text:?}");
+        assert!(text.contains("above"));
+        assert!(text.contains("below"));
+    }
+
+    #[test]
+    fn test_render_hard_break_inserts_newline() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [
+                {"type": "text", "text": "line one"},
+                {"type": "hardBreak"},
+                {"type": "text", "text": "line two"}
+            ]}]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("line one\nline two"), "got: {text:?}");
+    }
+
+    #[test]
+    fn test_render_code_block_with_language() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "codeBlock",
+                "attrs": {"language": "rust"},
+                "content": [{"type": "text", "text": "fn x() {}"}]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("```rust"), "expected rust fence, got: {text:?}");
+        assert!(text.contains("fn x() {}"));
+    }
+
+    #[test]
+    fn test_render_code_block_without_language() {
+        let adf = json!({
+            "type": "doc",
+            "content": [{
+                "type": "codeBlock",
+                "content": [{"type": "text", "text": "plain"}]
+            }]
+        });
+        let text = adf_to_text(&adf);
+        assert!(text.contains("```\nplain"), "expected empty fence, got: {text:?}");
     }
 }

--- a/src/snapshots/jr__adf__tests__adf_to_text_complex.snap
+++ b/src/snapshots/jr__adf__tests__adf_to_text_complex.snap
@@ -3,6 +3,16 @@ source: src/adf.rs
 expression: text
 ---
 ## Summary
-This is a description.
-- Item one
-- Item two
+A **bold** word, an *italic* word, a [link](https://example.com), and `code`.
+- first bullet
+- second bullet
+  3. three
+  4. four
+> quoted thought
+---
+```rust
+fn main() { println!("hi"); }
+```
+| k | v |
+| --- | --- |
+| a | 1 |


### PR DESCRIPTION
## Summary

Replaces the read-path `adf_to_text` in `src/adf.rs` with a stateful `AdfRenderer` struct that fully covers the ADF node types the write-path (`markdown_to_adf` from #197) now emits. The renderer is symmetric to the existing `AdfBuilder` in the same file.

**New behavior:**
- Ordered lists render with numeric prefixes respecting `attrs.order` (values `< 1` fall back to `1` matching Jira's renderer)
- Inline marks render with markdown syntax: `**strong**`, `*em*`, `~~strike~~`, `` `code` ``, `[text](href)`; unknown mark types pass bare
- Blockquotes prefix each line with `> `; nested blockquotes accumulate to `> >` via stack-unwinding re-prefix
- `rule` → `---`, `hardBreak` → `\n`, `codeBlock` opens with `` ```{attrs.language} `` when present
- Tables render as pipe rows (`| cell | cell |`) with a `| --- | --- |` separator after any row containing a `tableHeader` cell
- Unknown container nodes recurse into `content`; unknown leaves drop silently (replaces the old `[unsupported: <type>]` debug string that leaked into `jr issue view`)

## Fixes

Closes #202

## Design & Plan

- Spec: `docs/superpowers/specs/2026-04-16-adf-to-text-rich-rendering-design.md`
- Plan: `docs/superpowers/plans/2026-04-16-adf-to-text-rich-rendering.md`
- 8 self-contained TDD commits (RED → GREEN → clippy-clean → commit per task)

## Test Plan

- [x] Unit tests: 55 adf tests passing (previously 32) — one per AC item plus edge cases (`order=0` defaults, mixed nested lists, unknown mark drop, link missing href, mixed header/cell table row, unknown leaf drops silently, etc.)
- [x] Snapshot test `adf_to_text_complex` regenerated with a rich ADF document exercising every new rendering path
- [x] Structural roundtrip test `test_markdown_to_adf_to_text_roundtrip` — markdown → ADF → text → ADF preserves node-type traversal order
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean (zero lint suppressions)
- [x] Full `cargo test` passes (415 lib tests + integration tests)
- [x] Local multi-agent PR review: code-reviewer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, comment-analyzer — all clean after one round of comment-accuracy fixes
- [ ] Manual smoke: `jr issue view <KEY>` against live Jira on a description with rich formatting

## Follow-up

- #203 — expand edge-case test coverage (empty docs, whitespace-only blockquote, multi-hardBreak, more mark permutations). Non-critical; all deferred findings from the local review.
- Out-of-scope per the spec's Out of Scope section: `mention`, `status`, `emoji`, `mediaSingle`, `panel` type badge, `taskList/taskItem` — each a small follow-up when surfaced.