### PR TITLE
feat: surface 401 scope-mismatch as InsufficientScope

### DIFF
--- a/docs/superpowers/plans/2026-04-17-insufficient-scope-error.md
+++ b/docs/superpowers/plans/2026-04-17-insufficient-scope-error.md
@@ -1,0 +1,455 @@
+# Insufficient-Scope 401 Error Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a distinct `JrError::InsufficientScope` variant and restructure `parse_error` so 401 responses carrying `"scope does not match"` surface actionable workaround guidance instead of the generic "Not authenticated" message.
+
+**Architecture:** One new `thiserror` variant in `src/error.rs` (exit code `2`). `parse_error` in `src/api/client.rs` restructured to read the body first, then branch on 401 + case-insensitive substring `"scope does not match"`. Graceful fallback to existing `NotAuthenticated` on any mismatch — no regression surface.
+
+**Tech Stack:** Rust 2024, thiserror 2, reqwest 0.13, wiremock 0.6, tokio.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-insufficient-scope-error-design.md`
+
+**Local CI gate (run after every task before commit):**
+```bash
+cargo fmt --all -- --check && cargo clippy --all-targets -- -D warnings && cargo test
+```
+
+---
+
+## File Structure
+
+| File | Change | Purpose |
+|---|---|---|
+| `src/error.rs` | Modify (+~15 lines, +1 unit test) | New `JrError::InsufficientScope` variant + exit-code arm + test |
+| `src/api/client.rs` | Modify `parse_error` (lines 295-309, replace 14 lines with ~18) | Read body first, branch on 401 + substring match |
+| `tests/api_client.rs` | Modify (+2 integration tests, no imports needed) | Positive scope-mismatch test + explicit negative fall-through test |
+
+No new files. No new dependencies. No changes to `Cargo.toml`.
+
+---
+
+## Task 1: Add `JrError::InsufficientScope` variant
+
+**Files:**
+- Modify: `src/error.rs:1-43`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Edit `src/error.rs`, add inside the `#[cfg(test)] mod tests` block (after the existing `user_error_display_passthrough` test at line 73):
+
+```rust
+    #[test]
+    fn insufficient_scope_exit_code() {
+        assert_eq!(
+            JrError::InsufficientScope {
+                message: "Unauthorized; scope does not match".into()
+            }
+            .exit_code(),
+            2
+        );
+    }
+
+    #[test]
+    fn insufficient_scope_display_includes_workarounds() {
+        let err = JrError::InsufficientScope {
+            message: "Unauthorized; scope does not match".into(),
+        };
+        let s = err.to_string();
+        assert!(s.contains("Insufficient token scope"), "got: {s}");
+        assert!(
+            s.contains("Unauthorized; scope does not match"),
+            "raw message should be included: {s}"
+        );
+        assert!(s.contains("write:jira-work"), "workaround missing: {s}");
+        assert!(s.contains("OAuth 2.0"), "workaround missing: {s}");
+        assert!(
+            s.contains("github.com/Zious11/jira-cli/issues/185"),
+            "issue link missing: {s}"
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib error::`
+
+Expected: FAIL with `error[E0599]: no variant or associated item named "InsufficientScope" found for enum "JrError"` (the type doesn't exist yet).
+
+- [ ] **Step 3: Add the variant**
+
+Edit `src/error.rs` — add the new variant between `NotAuthenticated` (line 5-6) and `NetworkError` (line 8-9) so it stays grouped with the other auth/network errors:
+
+```rust
+    #[error("Not authenticated. Run \"jr auth login\" to connect.")]
+    NotAuthenticated,
+
+    #[error(
+        "Insufficient token scope: {message}\n\n\
+         The Atlassian API gateway rejects granular-scoped personal tokens on POST \
+         requests (while PUT/GET succeed). Workarounds:\n  \
+         • Use a classic token with \"write:jira-work\" scope instead of granular scopes, or\n  \
+         • Try OAuth 2.0 (run \"jr auth login --oauth\") — may avoid this bug, not verified\n\
+         See https://github.com/Zious11/jira-cli/issues/185 for details."
+    )]
+    InsufficientScope { message: String },
+
+    #[error("Could not reach {0} — check your connection")]
+    NetworkError(String),
+```
+
+- [ ] **Step 4: Add the exit-code arm**
+
+Edit `src/error.rs`, inside the `impl JrError { pub fn exit_code ... }` match block (around line 34-42). Add the `InsufficientScope` arm grouped with `NotAuthenticated`:
+
+```rust
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            JrError::NotAuthenticated => 2,
+            JrError::InsufficientScope { .. } => 2,
+            JrError::ConfigError(_) => 78,
+            JrError::UserError(_) => 64,
+            JrError::Interrupted => 130,
+            _ => 1,
+        }
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test --lib error::`
+
+Expected: PASS (all existing tests + 2 new ones).
+
+- [ ] **Step 6: Run full CI gate**
+
+Run: `cargo fmt --all -- --check && cargo clippy --all-targets -- -D warnings && cargo test`
+
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/error.rs
+git commit -m "feat(error): add JrError::InsufficientScope variant (#185)"
+```
+
+---
+
+## Task 2: Restructure `parse_error` to dispatch on body content
+
+**Files:**
+- Modify: `src/api/client.rs:295-309`
+
+- [ ] **Step 1: Read the existing `parse_error` to confirm line range**
+
+Run: `sed -n '295,309p' src/api/client.rs`
+
+Expected output:
+```rust
+    /// Parse an error response into a `JrError`.
+    async fn parse_error(response: Response) -> anyhow::Error {
+        let status = response.status().as_u16();
+
+        if status == 401 {
+            return JrError::NotAuthenticated.into();
+        }
+
+        let message = match response.bytes().await {
+            Ok(body) => extract_error_message(&body),
+            Err(e) => format!("Could not read error response: {e}"),
+        };
+
+        JrError::ApiError { status, message }.into()
+    }
+```
+
+If the line range differs, adjust the edit below accordingly. Do not proceed if the function body has diverged from the spec's expected shape — flag it as a NEEDS_CONTEXT escalation.
+
+- [ ] **Step 2: Replace the function body**
+
+Edit `src/api/client.rs` — replace the entire `parse_error` function (lines 295-309) with:
+
+```rust
+    /// Parse an error response into a `JrError`.
+    ///
+    /// Always reads the response body first, then branches on status. On 401, if
+    /// the body's message contains `"scope does not match"` (case-insensitive,
+    /// ASCII), returns `JrError::InsufficientScope` with the raw gateway message
+    /// — matches the Atlassian API gateway's rejection shape for granular-scoped
+    /// personal tokens on POST requests (see issue #185). Any other 401 falls
+    /// through to `NotAuthenticated`; non-401 4xx/5xx returns `ApiError`.
+    async fn parse_error(response: Response) -> anyhow::Error {
+        let status = response.status().as_u16();
+        let message = match response.bytes().await {
+            Ok(body) => extract_error_message(&body),
+            Err(e) => format!("Could not read error response: {e}"),
+        };
+
+        if status == 401 {
+            if message.to_ascii_lowercase().contains("scope does not match") {
+                return JrError::InsufficientScope { message }.into();
+            }
+            return JrError::NotAuthenticated.into();
+        }
+
+        JrError::ApiError { status, message }.into()
+    }
+```
+
+- [ ] **Step 3: Run existing 401 test to verify non-scope fall-through still works**
+
+Run: `cargo test --test api_client test_401_returns_not_authenticated`
+
+Expected: PASS. The existing test uses body message `"Client must be authenticated to access this resource."` — no "scope" substring, so it still falls through to `NotAuthenticated`.
+
+- [ ] **Step 4: Run full CI gate**
+
+Run: `cargo fmt --all -- --check && cargo clippy --all-targets -- -D warnings && cargo test`
+
+Expected: all green (667 existing tests pass + 2 from Task 1).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/api/client.rs
+git commit -m "feat(client): dispatch 401 scope-mismatch to InsufficientScope (#185)"
+```
+
+---
+
+## Task 3: Add integration test for scope-mismatch 401 path
+
+**Files:**
+- Modify: `tests/api_client.rs` (add test after the existing `test_401_returns_not_authenticated` at line 72)
+
+- [ ] **Step 1: Verify existing test structure**
+
+Run: `sed -n '1,30p' tests/api_client.rs`
+
+Confirm the imports include `wiremock::{MockServer, Mock, ResponseTemplate}`, `wiremock::matchers::{method, path}`, `serde_json::json`, and `jr::api::client::JiraClient`. Existing 401 test at line 72 is the template to mirror.
+
+- [ ] **Step 2: Write the failing test**
+
+Edit `tests/api_client.rs` — add this test immediately after the existing `test_401_returns_not_authenticated` function (ends around line 97):
+
+```rust
+#[tokio::test]
+async fn test_401_scope_mismatch_returns_insufficient_scope() {
+    // Atlassian API gateway rejects granular-scoped personal tokens on POST
+    // requests with this exact body shape. The error must surface actionable
+    // workaround guidance instead of the generic "Not authenticated" message.
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "code": 401,
+            "message": "Unauthorized; scope does not match"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client =
+        JiraClient::new_for_test(server.uri(), "Basic granular-token".to_string());
+
+    let err = client
+        .post::<serde_json::Value, _>(
+            "/rest/api/3/issue",
+            &serde_json::json!({"fields": {"summary": "test"}}),
+        )
+        .await
+        .unwrap_err();
+
+    let s = err.to_string();
+    assert!(
+        s.contains("Insufficient token scope"),
+        "expected distinct scope error, got: {s}"
+    );
+    assert!(
+        s.contains("Unauthorized; scope does not match"),
+        "raw gateway message should be preserved: {s}"
+    );
+    assert!(
+        s.contains("write:jira-work"),
+        "classic-scope workaround missing: {s}"
+    );
+    assert!(s.contains("OAuth 2.0"), "OAuth workaround missing: {s}");
+    assert!(
+        s.contains("github.com/Zious11/jira-cli/issues/185"),
+        "issue link missing: {s}"
+    );
+}
+```
+
+- [ ] **Step 3: Run the new test to verify it fails**
+
+Run: `cargo test --test api_client test_401_scope_mismatch_returns_insufficient_scope`
+
+Expected: **Actually passes** if Tasks 1 and 2 are complete — this integration test exercises the already-implemented logic. The "failing test" convention is inverted here because the test is written after the implementation rather than before. If Task 2 was skipped or is incomplete, the test FAILS because the error will still be generic `"Not authenticated"`.
+
+If it fails: return to Task 2 and verify the dispatch logic landed correctly.
+
+- [ ] **Step 4: Verify `JiraClient::post` signature**
+
+Run: `grep -n "pub async fn post" src/api/client.rs`
+
+Expected: a method signature matching `pub async fn post<T: DeserializeOwned, B: Serialize>(...)`. If the signature differs, adjust the turbofish in the test to match. If `post` doesn't exist at all, flag as NEEDS_CONTEXT.
+
+- [ ] **Step 5: Run full CI gate**
+
+Run: `cargo fmt --all -- --check && cargo clippy --all-targets -- -D warnings && cargo test`
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/api_client.rs
+git commit -m "test(client): cover 401 scope-mismatch → InsufficientScope (#185)"
+```
+
+---
+
+## Task 4: Add integration test for 401 fall-through boundary
+
+**Files:**
+- Modify: `tests/api_client.rs` (add test after the Task 3 test)
+
+- [ ] **Step 1: Write the failing test**
+
+Edit `tests/api_client.rs` — add this test immediately after `test_401_scope_mismatch_returns_insufficient_scope`:
+
+```rust
+#[tokio::test]
+async fn test_401_without_scope_mismatch_falls_through_to_not_authenticated() {
+    // 401 responses whose body does NOT contain "scope does not match" (e.g.,
+    // expired session, bad credentials) must continue to return the generic
+    // NotAuthenticated error. Pins the dispatch boundary intentionally so a
+    // future tightening of the substring match surfaces as a test failure
+    // instead of a silent behavior change.
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "code": 401,
+            "message": "Session expired"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client =
+        JiraClient::new_for_test(server.uri(), "Basic expired-session".to_string());
+
+    let err = client
+        .get::<serde_json::Value>("/rest/api/3/myself")
+        .await
+        .unwrap_err();
+
+    let s = err.to_string();
+    assert!(
+        s.contains("Not authenticated"),
+        "expected generic 401 fall-through, got: {s}"
+    );
+    assert!(
+        !s.contains("Insufficient token scope"),
+        "must NOT dispatch to InsufficientScope without the substring: {s}"
+    );
+}
+```
+
+- [ ] **Step 2: Run the new test**
+
+Run: `cargo test --test api_client test_401_without_scope_mismatch_falls_through_to_not_authenticated`
+
+Expected: PASS — Task 2's fall-through branch returns `NotAuthenticated` for any 401 body without the substring.
+
+- [ ] **Step 3: Run full CI gate**
+
+Run: `cargo fmt --all -- --check && cargo clippy --all-targets -- -D warnings && cargo test`
+
+Expected: all green. Total new tests from this PR: 4 (2 unit in `src/error.rs` from Task 1, 2 integration in `tests/api_client.rs` from Tasks 3+4).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/api_client.rs
+git commit -m "test(client): pin 401-without-scope fall-through boundary (#185)"
+```
+
+---
+
+## Task 5: Cross-verify the complete behavior
+
+**Files:** None modified — verification only.
+
+- [ ] **Step 1: Run the full test suite one more time**
+
+Run: `cargo test`
+
+Expected: all tests pass (prior baseline + 4 new tests from Tasks 1/3/4).
+
+- [ ] **Step 2: Confirm clippy and format are clean**
+
+Run: `cargo fmt --all -- --check && cargo clippy --all-targets -- -D warnings`
+
+Expected: zero output from fmt, zero warnings from clippy.
+
+- [ ] **Step 3: Skim the diff for anything surprising**
+
+Run: `git log --oneline develop..HEAD` then `git diff develop..HEAD --stat`
+
+Expected: 4 commits, ~3 files changed, roughly +110/-5 lines. If the diff touches any other file, investigate before proceeding.
+
+- [ ] **Step 4: Smoke-test the Display output manually (optional but recommended)**
+
+Run:
+```bash
+cat > /tmp/jr_display_test.rs <<'EOF'
+use jr::error::JrError;
+fn main() {
+    let err = JrError::InsufficientScope {
+        message: "Unauthorized; scope does not match".into(),
+    };
+    println!("{err}");
+}
+EOF
+```
+
+This won't compile standalone since `JrError` is non-public in some crate setups — skip if it fails. The unit test `insufficient_scope_display_includes_workarounds` already covers the Display output content, so this manual check is redundant but can be useful for visual inspection of the multi-line formatting.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| Error variant shape (display text, exit code 2) | Task 1 |
+| `parse_error` body-first restructure | Task 2 |
+| 401 + substring dispatch to `InsufficientScope` | Task 2 |
+| Graceful fallback to `NotAuthenticated` | Task 2 (fall-through), Task 4 (test) |
+| Positive wiremock test | Task 3 |
+| Negative wiremock test | Task 4 |
+| Exit-code unit test | Task 1 |
+| Display-text unit test (workaround strings present) | Task 1 |
+
+Spec-required files all covered: `src/error.rs` (Task 1), `src/api/client.rs` (Task 2), `tests/api_client.rs` (Tasks 3+4).
+
+**2. Placeholder scan:** None — every step has exact code, exact commands, exact expected output.
+
+**3. Type consistency:**
+- `JrError::InsufficientScope { message: String }` — struct variant with named field `message`. Used consistently across Tasks 1 (definition, tests) and 2 (construction).
+- `parse_error` return type unchanged (`anyhow::Error`) — caller-compatible.
+- `post::<serde_json::Value, _>` turbofish in Task 3 matches the existing `post` signature pattern (confirmed by the `get::<serde_json::Value>` usage in the existing test at line 87).
+- Substring match string `"scope does not match"` (lowercase, no punctuation) used identically in Task 2 and Task 3's test fixture.
+
+---
+
+## Execution Handoff
+
+Plan complete. Size: 4 code tasks + 1 verification. Bite-sized: each task has 4-7 steps, each step is 2-5 minutes.

--- a/docs/superpowers/plans/2026-04-17-insufficient-scope-error.md
+++ b/docs/superpowers/plans/2026-04-17-insufficient-scope-error.md
@@ -21,11 +21,13 @@ cargo fmt --all -- --check && cargo clippy --all-targets -- -D warnings && cargo
 
 | File | Change | Purpose |
 |---|---|---|
-| `src/error.rs` | Modify (+~15 lines, +1 unit test) | New `JrError::InsufficientScope` variant + exit-code arm + test |
+| `src/error.rs` | Modify (+~15 lines, +2 unit tests) | New `JrError::InsufficientScope` variant + exit-code arm + exit-code and Display unit tests |
 | `src/api/client.rs` | Modify `parse_error` (lines 295-309, replace 14 lines with ~18) | Read body first, branch on 401 + substring match |
-| `tests/api_client.rs` | Modify (+2 integration tests, no imports needed) | Positive scope-mismatch test + explicit negative fall-through test |
+| `tests/api_client.rs` | Modify (+4 integration tests, no imports needed) | Positive scope-mismatch, fall-through boundary, case-insensitive match, non-401 status-gate |
+| `docs/superpowers/specs/2026-04-17-insufficient-scope-error-design.md` | New | Design spec referenced by this plan |
+| `docs/superpowers/plans/2026-04-17-insufficient-scope-error.md` | New | This implementation plan |
 
-No new files. No new dependencies. No changes to `Cargo.toml`.
+No new Rust/source files. Documentation files added: this plan and the linked design spec. No new dependencies. No changes to `Cargo.toml`.
 
 ---
 

--- a/docs/superpowers/specs/2026-04-17-insufficient-scope-error-design.md
+++ b/docs/superpowers/specs/2026-04-17-insufficient-scope-error-design.md
@@ -22,7 +22,7 @@ Today, jr maps any 401 to a generic `JrError::NotAuthenticated` ("Not authentica
 
 1. New error variant `JrError::InsufficientScope { message: String }` in `src/error.rs`, exit code `2` (same class as `NotAuthenticated`).
 2. `parse_error` in `src/api/client.rs` restructured to read the body first, then branch: on 401 + body message containing `"scope does not match"` (case-insensitive substring, ASCII), return `InsufficientScope`; otherwise unchanged behavior.
-3. Three new tests (one integration for the positive path, one integration for the fall-through, one unit test for exit code).
+3. Six new tests: four integration (positive-path detection, case-insensitive match, 401 fall-through, and non-401 status-gate behavior) and two unit (`InsufficientScope` exit code and `Display` rendering).
 
 No API/CLI surface changes. No new dependencies. No caller updates needed — all callers already handle `anyhow::Error` returned from `parse_error`.
 
@@ -73,18 +73,23 @@ Graceful degradation: if Atlassian fixes the bug, changes wording, or localizes 
 
 ## Testing
 
-All three tests mirror existing patterns (`tests/api_client.rs:72` for wiremock, `src/error.rs:45` for exit-code unit tests).
+All tests mirror existing patterns (`tests/api_client.rs:72` for wiremock, `src/error.rs:45` for exit-code unit tests).
 
-**1. `test_401_scope_mismatch_returns_insufficient_scope`** (integration, `tests/api_client.rs`):
-- Mount a wiremock `POST /rest/api/3/issue` responder returning `401` with body `{"code": 401, "message": "Unauthorized; scope does not match"}`.
-- Assert error display contains `"Insufficient token scope"`, `"write:jira-work"`, and `"OAuth"` (both workaround hints surface).
+**Integration tests** (`tests/api_client.rs`):
 
-**2. `test_401_without_scope_mismatch_falls_through_to_not_authenticated`** (integration, `tests/api_client.rs`):
-- Mount a wiremock `GET /rest/api/3/myself` responder returning `401` with body `{"code": 401, "message": "Session expired"}` (no "scope" substring).
-- Assert error display contains `"Not authenticated"`. Pins the fall-through boundary intentionally, independent of any other existing 401 test's body-string choice.
+1. `test_401_scope_mismatch_returns_insufficient_scope` — positive path. Wiremock `POST /rest/api/3/issue` returns `401 {"code": 401, "message": "Unauthorized; scope does not match"}`. Asserts error display contains `"Insufficient token scope"`, the raw gateway message, `"write:jira-work"`, `"OAuth 2.0"`, and the `#185` issue link.
 
-**3. `test_insufficient_scope_exit_code`** (unit, `src/error.rs`):
-- `assert_eq!(JrError::InsufficientScope { message: "x".into() }.exit_code(), 2)`.
+2. `test_401_without_scope_mismatch_falls_through_to_not_authenticated` — negative boundary. Wiremock `GET /rest/api/3/myself` returns `401 {"code": 401, "message": "Session expired"}` (no "scope" substring). Asserts `"Not authenticated"` and explicitly `NOT "Insufficient token scope"`. Pins the fall-through independent of any other existing 401 test's body-string choice.
+
+3. `test_401_scope_mismatch_matches_case_insensitively` — Wiremock 401 body uses title case (`"Scope Does Not Match"`). Asserts the error still dispatches to `InsufficientScope`. Pins `to_ascii_lowercase()` usage so a future drop trips CI.
+
+4. `test_non_401_with_scope_substring_does_not_dispatch_to_insufficient_scope` — Wiremock returns `403` with body containing `"scope does not match"`. Asserts the error is `ApiError (403)`, not `InsufficientScope`. Pins the `status == 401` gate.
+
+**Unit tests** (`src/error.rs`):
+
+5. `insufficient_scope_exit_code` — `assert_eq!(JrError::InsufficientScope { message: "x".into() }.exit_code(), 2)`.
+
+6. `insufficient_scope_display_includes_workarounds` — builds the variant and asserts Display contains `"Insufficient token scope"`, the raw message, `"write:jira-work"`, `"OAuth 2.0"`, and the `#185` issue link.
 
 Existing `test_401_returns_not_authenticated` remains unchanged — it continues to cover the canonical bad-auth case.
 
@@ -109,8 +114,8 @@ Existing `test_401_returns_not_authenticated` remains unchanged — it continues
 
 ## Files touched
 
-- `src/error.rs` — new variant, `exit_code()` arm, one unit test.
+- `src/error.rs` — new variant, `exit_code()` arm, two unit tests (exit code + Display content).
 - `src/api/client.rs` — restructure `parse_error` body-read ordering, add 401-body-substring branch (~15 lines).
-- `tests/api_client.rs` — two new integration tests mirroring the existing 401 test.
+- `tests/api_client.rs` — four new integration tests (positive dispatch, fall-through boundary, case-insensitivity, non-401 status gate).
 
 No changes to `Cargo.toml`, CLI definitions, or any caller of `parse_error`.

--- a/docs/superpowers/specs/2026-04-17-insufficient-scope-error-design.md
+++ b/docs/superpowers/specs/2026-04-17-insufficient-scope-error-design.md
@@ -1,0 +1,114 @@
+# Insufficient-Scope 401 Error — Design Spec
+
+**Issue:** #185 — granular-scoped personal API tokens return 401 on POST but succeed on PUT.
+
+**Scope:** Detect the Atlassian API gateway's `"scope does not match"` 401 response and surface a distinct, actionable `JrError::InsufficientScope` with workaround guidance. This is a jr-side UX improvement for an external Atlassian gateway bug; jr cannot fix the underlying server behavior.
+
+**Non-goals:**
+- Changing authentication flow, OAuth handling, or token storage.
+- Modifying verbose/debug logging (already shipped in #183).
+- Adding configurable OAuth scopes (tracked separately in #184).
+- Retry, fallback, or automatic scope upgrade — the user must change credentials themselves.
+
+---
+
+## Motivation
+
+Validated via Perplexity (community.developer.atlassian.com, atlassian-python-api#1618, multiple community posts): granular-scoped personal API tokens (`write:issue:jira`, `write:comment:jira`, etc.) authenticate correctly for GET and PUT, but return `401 {"code": 401, "message": "Unauthorized; scope does not match"}` on all POST requests. Atlassian has not publicly acknowledged the bug; no JRACLOUD/JSWCLOUD ticket exists as of April 2026. Confirmed workarounds are: use a classic token with `write:jira-work` scope, or switch to OAuth 2.0 (3LO).
+
+Today, jr maps any 401 to a generic `JrError::NotAuthenticated` ("Not authenticated. Run \"jr auth login\" to connect.") — misleading for this case, because the token *is* authenticated; only this one class of requests is refused. Without `--verbose` (which exposes the raw body per #183), users have no indication of the true cause.
+
+## Change summary
+
+1. New error variant `JrError::InsufficientScope { message: String }` in `src/error.rs`, exit code `2` (same class as `NotAuthenticated`).
+2. `parse_error` in `src/api/client.rs` restructured to read the body first, then branch: on 401 + body message containing `"scope does not match"` (case-insensitive substring, ASCII), return `InsufficientScope`; otherwise unchanged behavior.
+3. Three new tests (one integration for the positive path, one integration for the fall-through, one unit test for exit code).
+
+No API/CLI surface changes. No new dependencies. No caller updates needed — all callers already handle `anyhow::Error` returned from `parse_error`.
+
+## Error variant
+
+```rust
+#[error(
+    "Insufficient token scope: {message}\n\n\
+     The Atlassian API gateway rejects granular-scoped tokens on POST requests \
+     (while PUT/GET succeed). Workarounds:\n  \
+     • Use a classic token with \"write:jira-work\" scope instead of granular scopes, or\n  \
+     • Use OAuth 2.0 (run \"jr auth login --oauth\")\n\
+     See https://github.com/Zious11/jira-cli/issues/185 for details."
+)]
+InsufficientScope { message: String },
+```
+
+The raw gateway `message` is stored verbatim so it surfaces in logs, `--verbose` output, and any future structured-JSON error path. Exit code `2` parallels `NotAuthenticated` — both represent "credentials need user attention."
+
+## Dispatch logic
+
+```rust
+async fn parse_error(response: Response) -> anyhow::Error {
+    let status = response.status().as_u16();
+    let message = match response.bytes().await {
+        Ok(body) => extract_error_message(&body),
+        Err(e) => format!("Could not read error response: {e}"),
+    };
+
+    if status == 401 {
+        // Match the Atlassian gateway's exact 401 shape for granular-token
+        // POST rejections. Case-insensitive guards against future capitalization
+        // drift; substring (not exact equality) guards against prefix/suffix
+        // wording shifts like ";" punctuation changes.
+        if message.to_ascii_lowercase().contains("scope does not match") {
+            return JrError::InsufficientScope { message }.into();
+        }
+        return JrError::NotAuthenticated.into();
+    }
+
+    JrError::ApiError { status, message }.into()
+}
+```
+
+Graceful degradation: if Atlassian fixes the bug, changes wording, or localizes the message, the match fails and users get the same generic `NotAuthenticated` they'd get today — no regression surface.
+
+## Testing
+
+All three tests mirror existing patterns (`tests/api_client.rs:72` for wiremock, `src/error.rs:45` for exit-code unit tests).
+
+**1. `test_401_scope_mismatch_returns_insufficient_scope`** (integration, `tests/api_client.rs`):
+- Mount a wiremock `POST /rest/api/3/issue` responder returning `401` with body `{"code": 401, "message": "Unauthorized; scope does not match"}`.
+- Assert error display contains `"Insufficient token scope"`, `"write:jira-work"`, and `"OAuth"` (both workaround hints surface).
+
+**2. `test_401_without_scope_mismatch_falls_through_to_not_authenticated`** (integration, `tests/api_client.rs`):
+- Mount a wiremock `GET /rest/api/3/myself` responder returning `401` with body `{"code": 401, "message": "Session expired"}` (no "scope" substring).
+- Assert error display contains `"Not authenticated"`. Pins the fall-through boundary intentionally, independent of any other existing 401 test's body-string choice.
+
+**3. `test_insufficient_scope_exit_code`** (unit, `src/error.rs`):
+- `assert_eq!(JrError::InsufficientScope { message: "x".into() }.exit_code(), 2)`.
+
+Existing `test_401_returns_not_authenticated` remains unchanged — it continues to cover the canonical bad-auth case.
+
+## Architecture decisions
+
+**Substring match, not regex.** The gateway string is stable across all reported cases (community.developer.atlassian.com posts span ≥2 years, same wording). Regex adds no value and enlarges the change surface.
+
+**Case-insensitive (ASCII).** Server-generated error strings from the auth layer are always ASCII. `to_ascii_lowercase` avoids locale-dependent Unicode case folding and is cheaper than `to_lowercase`.
+
+**Body-first read in `parse_error`.** `parse_error` is the error-only path (only called from `client.rs:213-214` and `222` on 4xx/5xx). Always reading the body there costs nothing extra vs. the current design, which already reads the body for non-401 errors. The small overhead on auth failures is dominated by the RTT.
+
+**No `--verbose` coupling.** Even without `--verbose`, the user now gets the actionable error. `--verbose` (from #183) continues to expose the full raw body for power users.
+
+**Store the raw `message` field.** Lets the user search for "scope does not match" online and find community posts. Also keeps the structured-JSON error surface (future `--output json` for errors) forward-compatible: the raw server message will be carryable as a distinct field.
+
+## Rejected alternatives
+
+- **Close as external bug, add README entry only (issue-author's literal framing):** Loses the agent-friendly actionable-error property of the CLI. #183's verbose-body log helps power users but doesn't surface the workaround in the default output path.
+- **Detect via Basic-auth-only + POST combination (no body inspection):** Brittle — false positives for any classic-token user who hits a real 401 on a POST (e.g., expired session).
+- **Auto-retry the POST with different auth:** jr has no way to upgrade a token's scope at runtime and would silently hide the problem.
+- **Map to `JrError::ApiError` with custom message:** Loses the distinct exit code and makes the `exit_code()` match arm leaky (would need string-matching on the message).
+
+## Files touched
+
+- `src/error.rs` — new variant, `exit_code()` arm, one unit test.
+- `src/api/client.rs` — restructure `parse_error` body-read ordering, add 401-body-substring branch (~15 lines).
+- `tests/api_client.rs` — two new integration tests mirroring the existing 401 test.
+
+No changes to `Cargo.toml`, CLI definitions, or any caller of `parse_error`.

--- a/docs/superpowers/specs/2026-04-17-insufficient-scope-error-design.md
+++ b/docs/superpowers/specs/2026-04-17-insufficient-scope-error-design.md
@@ -31,16 +31,18 @@ No API/CLI surface changes. No new dependencies. No caller updates needed — al
 ```rust
 #[error(
     "Insufficient token scope: {message}\n\n\
-     The Atlassian API gateway rejects granular-scoped tokens on POST requests \
-     (while PUT/GET succeed). Workarounds:\n  \
+     The Atlassian API gateway rejects granular-scoped personal tokens on POST \
+     requests (while PUT/GET succeed). Workarounds:\n  \
      • Use a classic token with \"write:jira-work\" scope instead of granular scopes, or\n  \
-     • Use OAuth 2.0 (run \"jr auth login --oauth\")\n\
+     • Try OAuth 2.0 (run \"jr auth login --oauth\") — may avoid this bug, not verified\n\
      See https://github.com/Zious11/jira-cli/issues/185 for details."
 )]
 InsufficientScope { message: String },
 ```
 
 The raw gateway `message` is stored verbatim so it surfaces in logs, `--verbose` output, and any future structured-JSON error path. Exit code `2` parallels `NotAuthenticated` — both represent "credentials need user attention."
+
+**OAuth hedge language:** the issue body admits OAuth-as-workaround is untested. The error text reflects that honestly with "may avoid this bug, not verified" — discoverable without over-promising. If OAuth turns out to share the bug, affected users hit the same error with OAuth selected, and `#185` becomes the place to update either the text or the recommendation.
 
 ## Dispatch logic
 

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -293,17 +293,29 @@ impl JiraClient {
     }
 
     /// Parse an error response into a `JrError`.
+    ///
+    /// Always reads the response body first, then branches on status. On 401, if
+    /// the body's message contains `"scope does not match"` (case-insensitive,
+    /// ASCII), returns `JrError::InsufficientScope` with the raw gateway message
+    /// — matches the Atlassian API gateway's rejection shape for granular-scoped
+    /// personal tokens on POST requests (see issue #185). Any other 401 falls
+    /// through to `NotAuthenticated`; non-401 4xx/5xx returns `ApiError`.
     async fn parse_error(response: Response) -> anyhow::Error {
         let status = response.status().as_u16();
-
-        if status == 401 {
-            return JrError::NotAuthenticated.into();
-        }
-
         let message = match response.bytes().await {
             Ok(body) => extract_error_message(&body),
             Err(e) => format!("Could not read error response: {e}"),
         };
+
+        if status == 401 {
+            if message
+                .to_ascii_lowercase()
+                .contains("scope does not match")
+            {
+                return JrError::InsufficientScope { message }.into();
+            }
+            return JrError::NotAuthenticated.into();
+        }
 
         JrError::ApiError { status, message }.into()
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,16 @@ pub enum JrError {
     #[error("Not authenticated. Run \"jr auth login\" to connect.")]
     NotAuthenticated,
 
+    #[error(
+        "Insufficient token scope: {message}\n\n\
+         The Atlassian API gateway rejects granular-scoped personal tokens on POST \
+         requests (while PUT/GET succeed). Workarounds:\n  \
+         • Use a classic token with \"write:jira-work\" scope instead of granular scopes, or\n  \
+         • Try OAuth 2.0 (run \"jr auth login --oauth\") — may avoid this bug, not verified\n\n\
+         See https://github.com/Zious11/jira-cli/issues/185 for details."
+    )]
+    InsufficientScope { message: String },
+
     #[error("Could not reach {0} — check your connection")]
     NetworkError(String),
 
@@ -34,6 +44,7 @@ impl JrError {
     pub fn exit_code(&self) -> i32 {
         match self {
             JrError::NotAuthenticated => 2,
+            JrError::InsufficientScope { .. } => 2,
             JrError::ConfigError(_) => 78,
             JrError::UserError(_) => 64,
             JrError::Interrupted => 130,
@@ -69,6 +80,36 @@ mod tests {
         assert_eq!(
             JrError::UserError("Invalid selection".into()).to_string(),
             "Invalid selection"
+        );
+    }
+
+    #[test]
+    fn insufficient_scope_exit_code() {
+        assert_eq!(
+            JrError::InsufficientScope {
+                message: "Unauthorized; scope does not match".into()
+            }
+            .exit_code(),
+            2
+        );
+    }
+
+    #[test]
+    fn insufficient_scope_display_includes_workarounds() {
+        let err = JrError::InsufficientScope {
+            message: "Unauthorized; scope does not match".into(),
+        };
+        let s = err.to_string();
+        assert!(s.contains("Insufficient token scope"), "got: {s}");
+        assert!(
+            s.contains("Unauthorized; scope does not match"),
+            "raw message should be included: {s}"
+        );
+        assert!(s.contains("write:jira-work"), "workaround missing: {s}");
+        assert!(s.contains("OAuth 2.0"), "workaround missing: {s}");
+        assert!(
+            s.contains("github.com/Zious11/jira-cli/issues/185"),
+            "issue link missing: {s}"
         );
     }
 }

--- a/tests/api_client.rs
+++ b/tests/api_client.rs
@@ -180,6 +180,80 @@ async fn test_401_without_scope_mismatch_falls_through_to_not_authenticated() {
     );
 }
 
+#[tokio::test]
+async fn test_401_scope_mismatch_matches_case_insensitively() {
+    // Gateway message is stable lowercase today, but `parse_error` matches
+    // case-insensitively via `to_ascii_lowercase()`. Pin that behavior so a
+    // future drop of the lowercase call trips a test instead of silently
+    // narrowing the match.
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "code": 401,
+            "message": "Unauthorized; Scope Does Not Match"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(server.uri(), "Basic granular-token".to_string());
+
+    let err = client
+        .post::<serde_json::Value, _>(
+            "/rest/api/3/issue",
+            &serde_json::json!({"fields": {"summary": "test"}}),
+        )
+        .await
+        .unwrap_err();
+
+    let s = err.to_string();
+    assert!(
+        s.contains("Insufficient token scope"),
+        "case-insensitive substring match should still dispatch to InsufficientScope: {s}"
+    );
+}
+
+#[tokio::test]
+async fn test_non_401_with_scope_substring_does_not_dispatch_to_insufficient_scope() {
+    // The scope-mismatch dispatch is gated on status == 401. A 403 (or any
+    // other 4xx/5xx) whose body happens to contain "scope does not match"
+    // must fall through to the generic ApiError path — pins the status gate
+    // so a future broadening of the match to all statuses trips a test.
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "code": 403,
+            "message": "Forbidden: scope does not match policy"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(server.uri(), "Basic granular-token".to_string());
+
+    let err = client
+        .post::<serde_json::Value, _>(
+            "/rest/api/3/issue",
+            &serde_json::json!({"fields": {"summary": "test"}}),
+        )
+        .await
+        .unwrap_err();
+
+    let s = err.to_string();
+    assert!(
+        !s.contains("Insufficient token scope"),
+        "non-401 status must NOT dispatch to InsufficientScope: {s}"
+    );
+    assert!(
+        s.contains("API error (403)"),
+        "expected generic ApiError for non-401 status: {s}"
+    );
+}
+
 #[test]
 fn test_extract_error_message_from_error_messages_array() {
     let body =

--- a/tests/api_client.rs
+++ b/tests/api_client.rs
@@ -143,6 +143,43 @@ async fn test_401_scope_mismatch_returns_insufficient_scope() {
     );
 }
 
+#[tokio::test]
+async fn test_401_without_scope_mismatch_falls_through_to_not_authenticated() {
+    // 401 responses whose body does NOT contain "scope does not match" (e.g.,
+    // expired session, bad credentials) must continue to return the generic
+    // NotAuthenticated error. Pins the dispatch boundary intentionally so a
+    // future tightening of the substring match surfaces as a test failure
+    // instead of a silent behavior change.
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/myself"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "code": 401,
+            "message": "Session expired"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(server.uri(), "Basic expired-session".to_string());
+
+    let err = client
+        .get::<serde_json::Value>("/rest/api/3/myself")
+        .await
+        .unwrap_err();
+
+    let s = err.to_string();
+    assert!(
+        s.contains("Not authenticated"),
+        "expected generic 401 fall-through, got: {s}"
+    );
+    assert!(
+        !s.contains("Insufficient token scope"),
+        "must NOT dispatch to InsufficientScope without the substring: {s}"
+    );
+}
+
 #[test]
 fn test_extract_error_message_from_error_messages_array() {
     let body =

--- a/tests/api_client.rs
+++ b/tests/api_client.rs
@@ -96,6 +96,53 @@ async fn test_401_returns_not_authenticated() {
     );
 }
 
+#[tokio::test]
+async fn test_401_scope_mismatch_returns_insufficient_scope() {
+    // Atlassian API gateway rejects granular-scoped personal tokens on POST
+    // requests with this exact body shape. The error must surface actionable
+    // workaround guidance instead of the generic "Not authenticated" message.
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "code": 401,
+            "message": "Unauthorized; scope does not match"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(server.uri(), "Basic granular-token".to_string());
+
+    let err = client
+        .post::<serde_json::Value, _>(
+            "/rest/api/3/issue",
+            &serde_json::json!({"fields": {"summary": "test"}}),
+        )
+        .await
+        .unwrap_err();
+
+    let s = err.to_string();
+    assert!(
+        s.contains("Insufficient token scope"),
+        "expected distinct scope error, got: {s}"
+    );
+    assert!(
+        s.contains("Unauthorized; scope does not match"),
+        "raw gateway message should be preserved: {s}"
+    );
+    assert!(
+        s.contains("write:jira-work"),
+        "classic-scope workaround missing: {s}"
+    );
+    assert!(s.contains("OAuth 2.0"), "OAuth workaround missing: {s}");
+    assert!(
+        s.contains("github.com/Zious11/jira-cli/issues/185"),
+        "issue link missing: {s}"
+    );
+}
+
 #[test]
 fn test_extract_error_message_from_error_messages_array() {
     let body =


### PR DESCRIPTION
## Summary

Closes #185.

The Atlassian API gateway rejects granular-scoped personal API tokens (e.g., `write:issue:jira`, `write:comment:jira`) on POST requests with `401 {"code": 401, "message": "Unauthorized; scope does not match"}`, while the same tokens succeed on GET and PUT. Today, `jr` maps any 401 to the generic `JrError::NotAuthenticated` ("Run `jr auth login`"), which is misleading — the token *is* authenticated; only this one class of requests is refused.

This PR detects the specific gateway response and surfaces a distinct, actionable error:

- **New `JrError::InsufficientScope { message: String }`** variant in `src/error.rs`, exit code `2`. Display text preserves the raw gateway message verbatim and includes both known workarounds (classic `write:jira-work` scope, or OAuth 2.0).
- **`parse_error` restructured** in `src/api/client.rs` to read the body first, then branch on `status == 401 && body.to_ascii_lowercase().contains("scope does not match")`. Any other 401 falls through to the existing `NotAuthenticated` — graceful degradation if the gateway wording ever shifts.
- **6 new tests** (2 unit, 4 integration): positive dispatch, fall-through boundary, case-insensitivity, status gate, exit code, Display contents.

Validated with Perplexity: substring `"scope does not match"` is stable across all reported cases (community.developer.atlassian.com, atlassian-python-api#1618). Atlassian has not publicly acknowledged the bug via JRACLOUD/JSWCLOUD ticket; this is a jr-side UX improvement for an external gateway issue.

## Design

- Spec: `docs/superpowers/specs/2026-04-17-insufficient-scope-error-design.md`
- Plan: `docs/superpowers/plans/2026-04-17-insufficient-scope-error.md`
- Both committed on this branch alongside the implementation (not on `develop` directly).

## Test Plan

- [x] `cargo test` — 668 → 674 suite total (+6 new)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (zero warnings)
- [x] Local PR review (code-reviewer + silent-failure-hunter + pr-test-analyzer) — 2 rounds; final round clean
- [x] No behavior changes on existing 401 paths — existing `test_401_returns_not_authenticated` unchanged

## Non-goals (deferred)

- OAuth scopes configurability (#184) — the OAuth workaround's effectiveness is untested
- verbose-mode body logging (#183) — already shipped