### PR TITLE
docs(cli): document --author "me" reservation in issue changelog (#212)

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -409,7 +409,12 @@ pub enum IssueCommand {
         /// Filter by field name; repeatable (case-insensitive substring)
         #[arg(long = "field")]
         field: Vec<String>,
-        /// Filter by author ("me", display name substring, or accountId)
+        /// Filter by author ("me" for current user, or a name/accountId)
+        ///
+        /// "me" is reserved and resolves to the current user. AccountIds
+        /// (values containing ':' or ≥12 characters of letters, digits,
+        /// '-', or '_') are matched exactly; other values match as a
+        /// case-insensitive substring of displayName or accountId.
         #[arg(long)]
         author: Option<String>,
         /// Render oldest-first instead of default newest-first


### PR DESCRIPTION
## Summary

- Split the `jr issue changelog --author` help text into a compact short-help line + a long-help paragraph
- Short help now matches sibling `--assignee`/`--reporter` style: `("me" for current user, or a name/accountId)`
- Long help explicitly flags that `"me"` is reserved, that accountId-shaped values (contain `:` or ≥12 chars of letters/digits/`-`/`_`) are matched exactly, and that other values match as a case-insensitive substring of `displayName` or `accountId`

Closes #212.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (766 pass / 0 fail)
- [x] `jr issue changelog -h` renders the compact one-liner
- [x] `jr issue changelog --help` renders the full long-help paragraph
- [x] Help text cross-checked against `classify_author` + `author_matches` in `src/cli/issue/changelog.rs`