### PR TITLE
fix(changelog): require a digit for author accountId classification (#213)

### DIFF
--- a/docs/specs/changelog-author-classify-digit-requirement.md
+++ b/docs/specs/changelog-author-classify-digit-requirement.md
@@ -1,0 +1,136 @@
+# `jr issue changelog --author` classification fix
+
+**Issue:** [#213](https://github.com/Zious11/jira-cli/issues/213)
+
+## Problem
+
+`classify_author()` in `src/cli/issue/changelog.rs` misclassifies long
+single-word display names as accountIds. The current heuristic treats any
+≥12-char string composed of `[A-Za-z0-9_-]` as an accountId candidate,
+which then requires an exact-equality match in `author_matches()`.
+
+Concrete regressions:
+
+| Input | Current classification | Expected |
+|---|---|---|
+| `AlexanderGreene` (15 chars, no digits) | AccountId → exact match → 0 hits | NameSubstring |
+| `JoseMariaRodriguez` (18 chars, no digits) | AccountId → 0 hits | NameSubstring |
+| `jean-pierre-dupont` (18 chars, no digits) | AccountId → 0 hits | NameSubstring |
+
+A user passing their own (or a teammate's) long-but-digit-free name gets
+an empty result with no hint that the classifier misrouted them.
+
+## Approach
+
+**Tighten the heuristic: require a colon OR at least one digit** (in
+addition to the existing ≥12-char and alphanumeric/`-`/`_` gates).
+
+Both documented Jira Cloud accountId formats guarantee digits:
+
+- Old 24-char hex: `5b10ac8d82e05b22cc7d4ef5` (contains `0-9` alongside
+  `a-f`).
+- New prefixed: `557058:f58131cb-b67d-43c7-b30d-6b58d40bd077` (colon
+  plus 6-digit numeric prefix).
+- Service accounts, bot accounts, Forge apps, Connect addons, and
+  Marketplace apps all use the same two formats.
+- Deleted/migrated users surface as the literal `"unknown"` (7 chars,
+  below the length gate — already handled by NameSubstring).
+
+Validated twice with Perplexity (accountId formats + edge-case account
+types). Context7 on clap was unavailable (quota) but the change is
+pure-logic and does not touch clap surface.
+
+### Rejected alternatives
+
+- **Option B (explicit `--author-name` / `--author-id` flags)** — breaks
+  the single-flag `gh`-style UX; no dominant CLI convention to align
+  with (Perplexity inconclusive); adds deprecation-path surface.
+- **Option C (stderr hint on zero-match + AccountId)** — cheap but
+  script-invisible, and its value shrinks once A closes the common
+  miss. Can be revisited if a real user hits the residual edge.
+
+## Algorithm change
+
+In `src/cli/issue/changelog.rs::classify_author`:
+
+```rust
+// Before
+let looks_like_account_id = trimmed.contains(':')
+    || (trimmed.len() >= 12
+        && trimmed.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+
+// After
+let looks_like_account_id = trimmed.contains(':')
+    || (trimmed.len() >= 12
+        && trimmed.chars().any(|c| c.is_ascii_digit())
+        && trimmed.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+```
+
+One new predicate: `.any(|c| c.is_ascii_digit())`.
+
+## Residual edge
+
+A 12+ char single-word name that incidentally contains a digit
+(e.g. `User12345Name`) still misclassifies as AccountId. Documented in
+tests. Rationale: further tightening (e.g. checking digit ratio) adds
+complexity without a measured need. If users hit this in practice,
+Option C (stderr hint) is the cheapest follow-up.
+
+## Help text
+
+Update `src/cli/mod.rs` Changelog `--author` long-help to reflect the
+new rule. Replace:
+
+> AccountIds (values containing ':' or ≥12 characters of letters,
+> digits, '-', or '_') are matched exactly; other values match as a
+> case-insensitive substring of displayName or accountId.
+
+With:
+
+> AccountIds (values containing ':' or ≥12 characters with at least one
+> digit plus letters, digits, '-', or '_') are matched exactly; other
+> values match as a case-insensitive substring of displayName or
+> accountId.
+
+Short help (`-h` one-liner) unchanged.
+
+Also update the `///` docstring on `classify_author` to match.
+
+## Tests
+
+Add unit tests in `src/cli/issue/changelog.rs` `#[cfg(test)] mod tests`:
+
+| Input | Expected | Purpose |
+|---|---|---|
+| `AlexanderGreene` | NameSubstring | regression guard: 15 chars no digit |
+| `JoseMariaRodriguez` | NameSubstring | regression guard: 18 chars no digit |
+| `jean-pierre-dupont` | NameSubstring | regression guard: dashed 18 chars no digit |
+| `5b10ac8d82e05b22cc7d4ef5` | AccountId | old hex format (has digits) |
+| `557058:f58131cb-b67d-43c7` | AccountId | colon-prefixed format (colon branch) |
+| `User12345Name` | AccountId | documented residual edge (digit + 13 chars) |
+| `jean-pierre` | NameSubstring | short (11 < 12) unchanged |
+| `unknown` | NameSubstring | deleted-user accountId stub; 7 < 12 ⇒ substring |
+
+If `classify_author` is currently `fn` (private, no `pub`), no visibility
+change needed — tests live in the same module.
+
+## Out of scope
+
+- Option C stderr hint.
+- Any change to `author_matches` semantics.
+- Any change to `helpers::is_me_keyword` or the `"me"` resolution path.
+- Behavior for `ChangelogEntry.author == None` (still filtered out as
+  before via `let Some(a) = author else { return false }`).
+
+## Files touched
+
+- `src/cli/issue/changelog.rs` — 1-line predicate addition, docstring
+  update, 8 new unit tests.
+- `src/cli/mod.rs` — 1 line of `--author` long-help text.
+
+## Exit criteria
+
+- All existing tests pass.
+- 8 new unit tests pass (TDD: write failing, tighten heuristic, pass).
+- `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test` green.
+- Help text renders new wording in `jr issue changelog --help`.

--- a/docs/specs/changelog-author-classify-digit-requirement.md
+++ b/docs/specs/changelog-author-classify-digit-requirement.md
@@ -87,10 +87,10 @@ new rule. Replace:
 
 With:
 
-> AccountIds (values containing ':' or ≥12 characters with at least one
-> digit plus letters, digits, '-', or '_') are matched exactly; other
-> values match as a case-insensitive substring of displayName or
-> accountId.
+> AccountIds (values containing ':' or ≥12 characters of
+> `[A-Za-z0-9_-]` that include at least one digit) are matched
+> exactly; other values match as a case-insensitive substring of
+> displayName or accountId.
 
 Short help (`-h` one-liner) unchanged.
 

--- a/src/cli/issue/changelog.rs
+++ b/src/cli/issue/changelog.rs
@@ -120,15 +120,18 @@ enum AuthorNeedle {
 }
 
 /// Classify a user-supplied `--author` value. We treat a value as an
-/// accountId if it looks like one (no whitespace, has a colon or is
-/// entirely alphanumeric, dash, or underscore, and ≥12 chars). Otherwise it's a name
-/// substring.
+/// accountId if it either contains a colon, or is ≥12 chars of
+/// `[A-Za-z0-9_-]` containing at least one digit. Otherwise it's a
+/// name substring.
 ///
 /// The API's accountId format varies (`public cloud` uses
 /// `557058:...`-style strings; older formats are opaque 24+ char
-/// hex-like blobs). The heuristic below is conservative: a plain English
-/// name like "alice" is always a substring; anything with a colon or
-/// a long alphanumeric blob is treated as literal.
+/// hex-like blobs). Both documented formats guarantee digits, so the
+/// digit requirement distinguishes them from long digit-free display
+/// names like `AlexanderGreene` or `jean-pierre-dupont`. Residual
+/// edge: a 12+ char single-word name that incidentally contains a
+/// digit (e.g. `User12345Name`) still classifies as accountId; see
+/// issue #213 for the rationale.
 fn classify_author(raw: &str) -> AuthorNeedle {
     let trimmed = raw.trim();
     let looks_like_account_id = trimmed.contains(':')

--- a/src/cli/issue/changelog.rs
+++ b/src/cli/issue/changelog.rs
@@ -133,6 +133,7 @@ fn classify_author(raw: &str) -> AuthorNeedle {
     let trimmed = raw.trim();
     let looks_like_account_id = trimmed.contains(':')
         || (trimmed.len() >= 12
+            && trimmed.chars().any(|c| c.is_ascii_digit())
             && trimmed
                 .chars()
                 .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));

--- a/src/cli/issue/changelog.rs
+++ b/src/cli/issue/changelog.rs
@@ -309,7 +309,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_author_colon_prefixed_short_is_accountid() {
+    fn classify_author_colon_forces_accountid_regardless_of_heuristics() {
         // Colon wins the branch regardless of length/digits.
         match classify_author("557058:f58131cb-b67d-43c7") {
             AuthorNeedle::AccountId(s) => assert_eq!(s, "557058:f58131cb-b67d-43c7"),

--- a/src/cli/issue/changelog.rs
+++ b/src/cli/issue/changelog.rs
@@ -269,6 +269,80 @@ mod tests {
     }
 
     #[test]
+    fn classify_author_long_alpha_only_name_is_substring() {
+        // 15 chars, no digits — regression guard for #213.
+        match classify_author("AlexanderGreene") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s, "alexandergreene"),
+            other => panic!("expected NameSubstring, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_author_long_compound_name_is_substring() {
+        // 18 chars, no digits — regression guard for #213.
+        match classify_author("JoseMariaRodriguez") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s, "josemariarodriguez"),
+            other => panic!("expected NameSubstring, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_author_long_hyphenated_name_is_substring() {
+        // 18 chars with dashes, no digits — regression guard for #213.
+        match classify_author("jean-pierre-dupont") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s, "jean-pierre-dupont"),
+            other => panic!("expected NameSubstring, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_author_old_hex_accountid_is_accountid() {
+        // 24-char hex — contains digits, no colon.
+        match classify_author("5b10ac8d82e05b22cc7d4ef5") {
+            AuthorNeedle::AccountId(s) => assert_eq!(s, "5b10ac8d82e05b22cc7d4ef5"),
+            other => panic!("expected AccountId, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_author_colon_prefixed_short_is_accountid() {
+        // Colon wins the branch regardless of length/digits.
+        match classify_author("557058:f58131cb-b67d-43c7") {
+            AuthorNeedle::AccountId(s) => assert_eq!(s, "557058:f58131cb-b67d-43c7"),
+            other => panic!("expected AccountId, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_author_long_name_with_digit_is_accountid() {
+        // 13 chars with a digit — documented residual edge. Stays AccountId.
+        match classify_author("User12345Name") {
+            AuthorNeedle::AccountId(s) => assert_eq!(s, "User12345Name"),
+            other => panic!("expected AccountId, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_author_short_hyphenated_name_is_substring() {
+        // 11 chars — below the length gate, unaffected by the digit rule.
+        match classify_author("jean-pierre") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s, "jean-pierre"),
+            other => panic!("expected NameSubstring, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_author_unknown_placeholder_is_substring() {
+        // 7-char "unknown" — the Jira stub for deleted/migrated users.
+        // Below the length gate; NameSubstring path already matches it
+        // via case-insensitive account_id containment.
+        match classify_author("unknown") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s, "unknown"),
+            other => panic!("expected NameSubstring, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn author_matches_respects_account_id_exact() {
         let user = User {
             account_id: "557058:abc".into(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -413,8 +413,9 @@ pub enum IssueCommand {
         ///
         /// "me" is reserved and resolves to the current user. AccountIds
         /// (values containing ':' or ≥12 characters of letters, digits,
-        /// '-', or '_') are matched exactly; other values match as a
-        /// case-insensitive substring of displayName or accountId.
+        /// '-', '_' with at least one digit) are matched exactly; other
+        /// values match as a case-insensitive substring of displayName
+        /// or accountId.
         #[arg(long)]
         author: Option<String>,
         /// Render oldest-first instead of default newest-first

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -412,10 +412,10 @@ pub enum IssueCommand {
         /// Filter by author ("me" for current user, or a name/accountId)
         ///
         /// "me" is reserved and resolves to the current user. AccountIds
-        /// (values containing ':' or ≥12 characters of letters, digits,
-        /// '-', '_' with at least one digit) are matched exactly; other
-        /// values match as a case-insensitive substring of displayName
-        /// or accountId.
+        /// (values containing ':' or ≥12 characters from letters, digits,
+        /// '-', '_' including at least one digit) are matched exactly;
+        /// other values match as a case-insensitive substring of
+        /// displayName or accountId.
         #[arg(long)]
         author: Option<String>,
         /// Render oldest-first instead of default newest-first

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -412,10 +412,10 @@ pub enum IssueCommand {
         /// Filter by author ("me" for current user, or a name/accountId)
         ///
         /// "me" is reserved and resolves to the current user. AccountIds
-        /// (values containing ':' or ≥12 characters of letters, digits,
-        /// '-', or '_', and at least one digit) are matched exactly;
-        /// other values match as a case-insensitive substring of
-        /// displayName or accountId.
+        /// (values containing ':' or ≥12 characters of `[A-Za-z0-9_-]`
+        /// that include at least one digit) are matched exactly; other
+        /// values match as a case-insensitive substring of displayName
+        /// or accountId.
         #[arg(long)]
         author: Option<String>,
         /// Render oldest-first instead of default newest-first

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -412,8 +412,8 @@ pub enum IssueCommand {
         /// Filter by author ("me" for current user, or a name/accountId)
         ///
         /// "me" is reserved and resolves to the current user. AccountIds
-        /// (values containing ':' or ≥12 characters from letters, digits,
-        /// '-', '_' including at least one digit) are matched exactly;
+        /// (values containing ':' or ≥12 characters of letters, digits,
+        /// '-', or '_', and at least one digit) are matched exactly;
         /// other values match as a case-insensitive substring of
         /// displayName or accountId.
         #[arg(long)]


### PR DESCRIPTION
## Summary

- Tightens `classify_author` in `src/cli/issue/changelog.rs`: a value is only classified as an `accountId` if it contains a colon **or** is ≥12 chars of `[A-Za-z0-9_-]` **and** contains at least one digit.
- Fixes the #213 regression where long single-word display names like `AlexanderGreene`, `JoseMariaRodriguez`, `jean-pierre-dupont` classified as accountId (exact match) and returned zero rows.
- Perplexity-validated twice: every documented Atlassian accountId format (old 24-char hex, new `NNNNNN:uuid`, service/bot/Forge/Connect/Marketplace apps) guarantees digits — the digit requirement is safe. Deleted-user stub `"unknown"` is below the length gate and unaffected.
- Docstring on `classify_author` and `--author` long-help updated; short-help `-h` unchanged.
- 8 new unit tests added following TDD RED → GREEN order (3 failing tests introduced, then the predicate change makes them pass).

Residual edge documented: a 12+ char single-word name that incidentally contains a digit (e.g. `User12345Name`) still classifies as accountId. Pinned by test + docstring. Further tightening (digit ratio, etc.) deferred.

Follow-up test-coverage improvements filed: #218 (Unicode names), #219 (direct `author_matches` NameSubstring tests), #220 (12-char boundary), #221 (integration test for long-alpha name), #222 (test consolidation).

Closes #213.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 774 pass / 0 fail
- [x] 8 new unit tests cover: digit-free long names (regression), long hex accountIds, colon-prefixed accountIds, 12+ char name-with-digit (residual edge), short hyphenated names, `unknown` stub
- [x] `jr issue changelog -h` — short help unchanged
- [x] `jr issue changelog --help` — long help renders the new rule
- [x] Local multi-agent review clean (code-reviewer, pr-test-analyzer, comment-analyzer)