### PR TITLE
feat(observability): log format_date / format_comment_date parse failures once when --verbose (#214)

### DIFF
--- a/docs/specs/format-date-verbose-parse-failure-logging.md
+++ b/docs/specs/format-date-verbose-parse-failure-logging.md
@@ -127,33 +127,40 @@ Parallel pair: `comments_verbose_logs_parse_failure_once` +
 `comments_parse_failure_silent_without_verbose` using the comments
 endpoint and a malformed `"created"`.
 
-### No unit tests
+### Test strategy
 
-The dedup logic is 3 lines; integration coverage through the full
-CLI pipeline is the idiomatic vehicle in this project (see existing
-assert_cmd usage across tests/comments.rs, tests/issue_changelog.rs).
+End-to-end assertions live as integration tests, since the user-visible
+requirement is CLI stderr/stdout behavior through the full pipeline
+(see existing `assert_cmd` usage across `tests/comments.rs` and
+`tests/issue_changelog.rs`). In addition, one small unit test in
+`src/observability.rs` (`verbose_false_leaves_flag_untouched`) pins the
+short-circuit ordering: `verbose == false` must return before touching
+the dedup flag at all.
 
 **Maintainer caveat:** the per-call-site `static AtomicBool` is shared
-across parallel tests *within the same test binary*. The integration
-tests in this spec use `assert_cmd::Command::cargo_bin(...)` which
-spawns a fresh subprocess per invocation, so statics are re-initialized
-each run — safe. A future direct unit test that calls
-`format_date(..., true)` from multiple tests would see cross-test
-pollution; either refactor the helper to take the flag by reference
-(so each test provides its own), or run that test suite with
-`--test-threads=1`.
+across parallel tests *within the same test binary* when those tests
+exercise a path that can mutate the static. The integration tests in
+this spec use `assert_cmd::Command::cargo_bin(...)`, which spawns a
+fresh subprocess per invocation, so statics are re-initialized each
+run — safe. The existing unit test is also safe because it only
+exercises the `verbose == false` short-circuit path and therefore
+leaves the shared flag untouched. Any additional unit test that calls
+a `...(..., true)` path against the same call-site static from
+multiple tests would see cross-test pollution; either refactor the
+helper to take the flag by reference (so each test provides its own),
+or run that affected test suite with `--test-threads=1`.
 
 ## Files touched
 
 | File | Change |
 |---|---|
 | `src/lib.rs` | `mod observability;` |
-| `src/observability.rs` | **new**, ~15 lines with one pub(crate) fn |
+| `src/observability.rs` | **new**, one pub(crate) fn + one inline unit test |
 | `src/api/client.rs` | `pub fn verbose(&self) -> bool` getter |
 | `src/cli/issue/changelog.rs` | `format_date` + `build_rows` gain `verbose: bool`; `handle` passes `client.verbose()` |
 | `src/cli/issue/list.rs` | `format_comment_date` + `format_comment_row` gain `verbose: bool`; comments callers pass `client.verbose()` |
-| `tests/issue_changelog.rs` | 2 new tests |
-| `tests/comments.rs` | 2 new tests |
+| `tests/issue_changelog.rs` | 3 new tests (verbose logs once, silent without verbose, mixed good/bad rows) |
+| `tests/comments.rs` | 2 new tests (verbose logs once, silent without verbose) |
 
 ## Out of scope
 

--- a/docs/specs/format-date-verbose-parse-failure-logging.md
+++ b/docs/specs/format-date-verbose-parse-failure-logging.md
@@ -74,10 +74,11 @@ pub(crate) fn log_parse_failure_once(
 ```
 
 `swap(true, Relaxed)` is the idiomatic "set the flag and return the
-previous value" primitive. `Ordering::Relaxed` is correct here because
-the flag guards no shared-state initialization — worst case a narrow
-race window emits two log lines, which is acceptable for an
-observability signal.
+previous value" primitive. Because the read-modify-write is atomic,
+exactly one caller per flag can observe `false` and emit the log line.
+`Ordering::Relaxed` is correct here because we only need that atomic
+one-shot state transition; the flag does not guard shared-state
+initialization or any other cross-thread memory ordering requirement.
 
 ## Plumbing
 
@@ -105,8 +106,9 @@ No change to public surface (`--verbose` flag unchanged).
 
 ## Tests
 
-Two integration tests added, one per call-site, using the existing
-`wiremock` + `assert_cmd` pattern.
+Five integration tests added across the two call-sites (three in
+`tests/issue_changelog.rs` and two in `tests/comments.rs`), using the
+existing `wiremock` + `assert_cmd` pattern.
 
 ### `tests/issue_changelog.rs`
 

--- a/docs/specs/format-date-verbose-parse-failure-logging.md
+++ b/docs/specs/format-date-verbose-parse-failure-logging.md
@@ -133,6 +133,16 @@ The dedup logic is 3 lines; integration coverage through the full
 CLI pipeline is the idiomatic vehicle in this project (see existing
 assert_cmd usage across tests/comments.rs, tests/issue_changelog.rs).
 
+**Maintainer caveat:** the per-call-site `static AtomicBool` is shared
+across parallel tests *within the same test binary*. The integration
+tests in this spec use `assert_cmd::Command::cargo_bin(...)` which
+spawns a fresh subprocess per invocation, so statics are re-initialized
+each run — safe. A future direct unit test that calls
+`format_date(..., true)` from multiple tests would see cross-test
+pollution; either refactor the helper to take the flag by reference
+(so each test provides its own), or run that test suite with
+`--test-threads=1`.
+
 ## Files touched
 
 | File | Change |

--- a/docs/specs/format-date-verbose-parse-failure-logging.md
+++ b/docs/specs/format-date-verbose-parse-failure-logging.md
@@ -1,0 +1,165 @@
+# `format_date` / `format_comment_date` verbose parse-failure logging
+
+**Issue:** [#214](https://github.com/Zious11/jira-cli/issues/214)
+
+## Problem
+
+Two timestamp formatters silently absorb parse failures:
+
+- `format_date` in `src/cli/issue/changelog.rs` — used by `jr issue
+  changelog` table rendering.
+- `format_comment_date` in `src/cli/issue/list.rs` — used by `jr issue
+  comments` table rendering.
+
+Both render the raw ISO-8601 string when both `DateTime::parse_from_rfc3339`
+and the Jira compact-offset fallback (`%Y-%m-%dT%H:%M:%S%.3f%z`) fail. The
+user sees a broken column but no signal that a format regression has
+occurred, so a future Atlassian change (e.g., dropped milliseconds,
+nanosecond precision, `Z` suffix) silently breaks output alignment.
+
+## Approach
+
+When `--verbose` is set, emit a one-shot `eprintln!("[verbose] ...")`
+per call-site per run the first time a parse fails. Subsequent failures
+in the same run are suppressed by a function-local
+`static AtomicBool`. No change to normal runs (without `--verbose`).
+
+Matches the existing observability pattern at `src/api/client.rs:170-177`
+where `--verbose` gates plain `eprintln!("[verbose] ...")` with no
+external crates. A dedicated tracing layer is explicitly deferred per
+the issue (“out of scope for #200 — file for the next observability
+pass”).
+
+### Rejected alternatives
+
+- **Per-unique-string dedup via `OnceLock<Mutex<HashSet<String>>>`** —
+  more informative for runs with multiple distinct failures but adds
+  a dependency, heap allocations, and more code. YAGNI until a real
+  user reports multi-format flooding.
+- **Log every failure without dedup** — risk of flooding stderr when
+  an entire page of 100 entries shares a broken format.
+- **Adopt the `tracing` crate** — sizable infrastructure change; the
+  issue explicitly keeps it out of scope.
+
+## Algorithm
+
+Per call-site, inside the formatter function:
+
+```rust
+static LOGGED: AtomicBool = AtomicBool::new(false);
+// ... parse ...
+if parse_failed {
+    crate::observability::log_parse_failure_once(
+        &LOGGED, "changelog", iso, verbose,
+    );
+    return iso.to_string();
+}
+```
+
+`log_parse_failure_once` lives in a new `src/observability.rs`:
+
+```rust
+use std::sync::atomic::{AtomicBool, Ordering};
+
+pub(crate) fn log_parse_failure_once(
+    flag: &AtomicBool,
+    site: &str,
+    iso: &str,
+    verbose: bool,
+) {
+    if verbose && !flag.swap(true, Ordering::Relaxed) {
+        eprintln!("[verbose] {site} timestamp failed to parse: {iso}");
+    }
+}
+```
+
+`swap(true, Relaxed)` is the idiomatic "set the flag and return the
+previous value" primitive. `Ordering::Relaxed` is correct here because
+the flag guards no shared-state initialization — worst case a narrow
+race window emits two log lines, which is acceptable for an
+observability signal.
+
+## Plumbing
+
+`JiraClient` gains a public `verbose()` accessor (field already
+exists; currently private):
+
+```rust
+// src/api/client.rs
+pub fn verbose(&self) -> bool { self.verbose }
+```
+
+Each formatter takes an explicit `verbose: bool` parameter:
+
+- `format_date(iso: &str, verbose: bool) -> String`
+- `format_comment_date(iso: &str, verbose: bool) -> String`
+
+Callers thread `client.verbose()` from `handle()` down:
+
+- `changelog::handle`: pass to `build_rows(&entries, verbose)`, which
+  passes to each `format_date(&entry.created, verbose)` call.
+- Comments listing (in `list.rs`): pass into `format_comment_row(..., verbose)`,
+  which passes to `format_comment_date`.
+
+No change to public surface (`--verbose` flag unchanged).
+
+## Tests
+
+Two integration tests added, one per call-site, using the existing
+`wiremock` + `assert_cmd` pattern.
+
+### `tests/issue_changelog.rs`
+
+New test: `changelog_verbose_logs_parse_failure_once`. Stubs
+`/rest/api/3/issue/BAD-1/changelog` to return two entries with a
+malformed `"created"` value (e.g., `"not-a-date"`). Runs
+`jr issue changelog BAD-1 --verbose`; asserts stderr contains exactly
+one line matching `"changelog timestamp failed to parse"` even though
+the response had two broken entries.
+
+Second new test: `changelog_parse_failure_silent_without_verbose`.
+Same fixture, runs without `--verbose`; asserts stderr does **not**
+contain `"failed to parse"`.
+
+### `tests/comments.rs`
+
+Parallel pair: `comments_verbose_logs_parse_failure_once` +
+`comments_parse_failure_silent_without_verbose` using the comments
+endpoint and a malformed `"created"`.
+
+### No unit tests
+
+The dedup logic is 3 lines; integration coverage through the full
+CLI pipeline is the idiomatic vehicle in this project (see existing
+assert_cmd usage across tests/comments.rs, tests/issue_changelog.rs).
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `src/lib.rs` | `mod observability;` |
+| `src/observability.rs` | **new**, ~15 lines with one pub(crate) fn |
+| `src/api/client.rs` | `pub fn verbose(&self) -> bool` getter |
+| `src/cli/issue/changelog.rs` | `format_date` + `build_rows` gain `verbose: bool`; `handle` passes `client.verbose()` |
+| `src/cli/issue/list.rs` | `format_comment_date` + `format_comment_row` gain `verbose: bool`; comments callers pass `client.verbose()` |
+| `tests/issue_changelog.rs` | 2 new tests |
+| `tests/comments.rs` | 2 new tests |
+
+## Out of scope
+
+- Tracing/log crate adoption (deferred to future observability pass).
+- Per-unique-string dedup.
+- Logging format errors at `parse_created` call sites outside these
+  two formatters (e.g., the sort comparator in `changelog::handle`
+  — that fallback is deterministic and not user-visible).
+- Help-text edits (`--verbose` already documents “Enable verbose
+  output”).
+
+## Exit criteria
+
+- `cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test` green.
+- The 4 new integration tests pass.
+- `jr issue changelog <key> --verbose` against a response with a
+  malformed timestamp emits exactly one `[verbose]` line regardless of
+  how many entries share the bad format.
+- No change in stderr for runs without `--verbose`.

--- a/docs/superpowers/plans/2026-04-18-format-date-verbose-logging.md
+++ b/docs/superpowers/plans/2026-04-18-format-date-verbose-logging.md
@@ -556,7 +556,7 @@ created
 Find every call site in `src/cli/issue/list.rs`:
 
 ```bash
-grep -n "format_comment_row(" /Users/zious/Documents/GITHUB/jira-cli/.worktrees/format-date-verbose-logging/src/cli/issue/list.rs
+grep -n "format_comment_row(" src/cli/issue/list.rs
 ```
 
 Each caller should have `&client` in scope (comment-rendering happens inside handler functions that receive the client). Pass `client.verbose()` as the new last arg to every call.

--- a/docs/superpowers/plans/2026-04-18-format-date-verbose-logging.md
+++ b/docs/superpowers/plans/2026-04-18-format-date-verbose-logging.md
@@ -1,0 +1,626 @@
+# Verbose Parse-Failure Logging for Date Formatters — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When `--verbose` is set, emit a one-shot `eprintln!("[verbose] ...")` per call-site the first time `format_date` or `format_comment_date` fails to parse a timestamp, so a future Jira format regression surfaces instead of silently corrupting the rendered column.
+
+**Architecture:** Add a tiny `src/observability.rs` module with a `log_parse_failure_once(&AtomicBool, site, iso, verbose)` helper. Expose `JiraClient::verbose()` so handlers can thread the flag down to the two formatters. Each formatter declares a function-local `static LOGGED: AtomicBool` and calls the helper on parse failure. Four new integration tests (two per formatter) cover the "logs exactly once" and "silent without `--verbose`" contract via `assert_cmd` + `wiremock`.
+
+**Tech Stack:** Rust 2024 edition, `std::sync::atomic` only (no new dep), `assert_cmd` + `wiremock` for integration tests, clap derive (already wired, `--verbose` is `global = true`).
+
+**Spec:** `docs/specs/format-date-verbose-parse-failure-logging.md`
+
+**Task ordering rationale:** RED tests precede their GREEN implementation, and each GREEN task lands *all* foundation pieces referenced by its caller within the same commit. This avoids any window where `cargo clippy --all-targets -- -D warnings` would flag the helper or accessor as dead code, and keeps CLAUDE.md's "no lint suppression" rule unviolated.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/observability.rs` | **new** — one helper `log_parse_failure_once` |
+| `src/lib.rs` | register `mod observability;` |
+| `src/api/client.rs` | add `pub fn verbose(&self) -> bool` accessor |
+| `src/cli/issue/changelog.rs` | thread `verbose: bool` through `handle → build_rows → format_date`; call helper on parse fail |
+| `src/cli/issue/list.rs` | thread `verbose: bool` through comments callers → `format_comment_row → format_comment_date`; call helper on parse fail |
+| `tests/issue_changelog.rs` | 2 new integration tests (verbose logs once + silent without verbose) |
+| `tests/comments.rs` | 2 new integration tests (mirror for comments path) |
+
+No other modules touched. No schema/serde changes.
+
+---
+
+## Task 1: RED — two failing changelog integration tests
+
+Add the two integration tests that pin the `format_date` contract. Against the current unchanged implementation:
+
+- `changelog_verbose_logs_parse_failure_once` will **FAIL** (stderr empty, expected `"timestamp failed to parse"` × 1).
+- `changelog_parse_failure_silent_without_verbose` will **PASS vacuously** (asserts the *absence* of a message, which is trivially true pre-implementation). That's fine — we still write it now so Task 2's implementation can't regress the "silent without verbose" half.
+
+**Files:**
+- Modify: `tests/issue_changelog.rs` (append two new `#[tokio::test]` functions at the end of the file)
+
+- [ ] **Step 1.1: Append the two tests**
+
+Open `tests/issue_changelog.rs`. Add these tests at the end of the file. Match the style of neighboring tests (`#[tokio::test] async fn`, use of `wiremock` + `assert_cmd`, same imports at the top of the file — no new imports needed).
+
+```rust
+#[tokio::test]
+async fn changelog_verbose_logs_parse_failure_once() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/BAD-1/changelog"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "values": [
+                {
+                    "id": "1",
+                    "author": {
+                        "accountId": "u1",
+                        "displayName": "Alice",
+                        "emailAddress": null,
+                        "active": true
+                    },
+                    "created": "not-a-date",
+                    "items": [{
+                        "field": "status",
+                        "fieldtype": "jira",
+                        "from": null, "fromString": "To Do",
+                        "to": null, "toString": "In Progress"
+                    }]
+                },
+                {
+                    "id": "2",
+                    "author": {
+                        "accountId": "u1",
+                        "displayName": "Alice",
+                        "emailAddress": null,
+                        "active": true
+                    },
+                    "created": "still-not-a-date",
+                    "items": [{
+                        "field": "status",
+                        "fieldtype": "jira",
+                        "from": null, "fromString": "In Progress",
+                        "to": null, "toString": "Done"
+                    }]
+                }
+            ],
+            "startAt": 0,
+            "maxResults": 100,
+            "total": 2,
+            "isLast": true
+        })))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "changelog", "BAD-1", "--verbose"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let count = stderr.matches("timestamp failed to parse").count();
+    assert_eq!(
+        count, 1,
+        "expected exactly one parse-failure log across 2 bad entries, got {count}. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("[verbose] changelog"),
+        "expected [verbose] changelog prefix in stderr, got:\n{stderr}"
+    );
+}
+
+#[tokio::test]
+async fn changelog_parse_failure_silent_without_verbose() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/BAD-2/changelog"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "values": [{
+                "id": "1",
+                "author": {
+                    "accountId": "u1",
+                    "displayName": "Alice",
+                    "emailAddress": null,
+                    "active": true
+                },
+                "created": "not-a-date",
+                "items": [{
+                    "field": "status",
+                    "fieldtype": "jira",
+                    "from": null, "fromString": "A",
+                    "to": null, "toString": "B"
+                }]
+            }],
+            "startAt": 0,
+            "maxResults": 100,
+            "total": 1,
+            "isLast": true
+        })))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "changelog", "BAD-2"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("failed to parse"),
+        "expected no verbose parse-failure output without --verbose, got:\n{stderr}"
+    );
+}
+```
+
+Fixture notes:
+- `values[]` is the offset-paginated key used by Jira's changelog endpoint (matches existing `get_changelog` in `src/api/jira/issues.rs`).
+- `created` is a plain `String` in `ChangelogEntry` (see `src/types/jira/changelog.rs:13`), so `"not-a-date"` deserializes and reaches `format_date`.
+- `author` is included so the row renders fully; the parse-failure path triggers on `created` alone.
+- `--verbose` is `global = true` in `src/cli/mod.rs:39`, so the positional order `["issue", "changelog", "BAD-1", "--verbose"]` is valid.
+
+- [ ] **Step 1.2: Run the two new tests, confirm the RED split**
+
+```bash
+cargo test --test issue_changelog changelog_verbose_logs_parse_failure_once changelog_parse_failure_silent_without_verbose
+```
+
+Expected:
+- `changelog_verbose_logs_parse_failure_once` — **FAIL** with `expected exactly one parse-failure log across 2 bad entries, got 0`.
+- `changelog_parse_failure_silent_without_verbose` — **PASS** (vacuously).
+
+If `changelog_verbose_logs_parse_failure_once` passes too, STOP — the implementation already emits something, and the plan needs revisiting.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add tests/issue_changelog.rs
+git commit -m "test(changelog): pin verbose parse-failure logging contract for format_date (#214)"
+```
+
+---
+
+## Task 2: GREEN — observability foundation + thread `verbose` through changelog
+
+One commit that lands the observability module, the `JiraClient::verbose()` accessor, and the changelog wiring that references both. The helper has a caller the instant it exists, so no dead-code suppression is ever needed.
+
+**Files:**
+- Create: `src/observability.rs`
+- Modify: `src/lib.rs`
+- Modify: `src/api/client.rs`
+- Modify: `src/cli/issue/changelog.rs`
+
+- [ ] **Step 2.1: Create `src/observability.rs`**
+
+```rust
+//! Lightweight observability primitives shared across commands.
+//!
+//! Intentionally tiny: the project has no tracing/log crate, and a
+//! single `--verbose`-gated `eprintln!` is the established pattern
+//! (see `src/api/client.rs` for HTTP-request logging). Expand to a
+//! real tracing layer when there is cross-subsystem need.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Log a parse-failure once per `flag` per process, gated on `verbose`.
+///
+/// `flag` is typically a function-local `static AtomicBool`, one per
+/// call-site, so each formatter fires at most one line per run. The
+/// `site` argument is a short human label (e.g. `"changelog"`,
+/// `"comment"`) included in the message for disambiguation.
+pub(crate) fn log_parse_failure_once(
+    flag: &AtomicBool,
+    site: &str,
+    iso: &str,
+    verbose: bool,
+) {
+    if verbose && !flag.swap(true, Ordering::Relaxed) {
+        eprintln!("[verbose] {site} timestamp failed to parse: {iso}");
+    }
+}
+```
+
+- [ ] **Step 2.2: Register the module in `src/lib.rs`**
+
+Add, alphabetically among the existing `pub mod ...;` lines:
+
+```rust
+pub(crate) mod observability;
+```
+
+- [ ] **Step 2.3: Add `verbose()` accessor to `JiraClient`**
+
+Inside the existing `impl JiraClient { ... }` in `src/api/client.rs` (begins at line 26), a good spot is right after `new_for_test` (around line 108):
+
+```rust
+    /// Whether the client was constructed with `--verbose` enabled.
+    /// Handlers use this to gate optional diagnostic output.
+    pub fn verbose(&self) -> bool {
+        self.verbose
+    }
+```
+
+- [ ] **Step 2.4: Change `format_date` signature and body in `src/cli/issue/changelog.rs`**
+
+Locate `format_date` (around line 197). Replace the whole function with:
+
+```rust
+/// Render a Jira ISO-8601 timestamp as `YYYY-MM-DD HH:MM` in the user's
+/// local time zone. Falls back to the raw string on parse failure; when
+/// `verbose` is true, emits a one-shot `[verbose]` stderr note the first
+/// time parsing fails in this process.
+fn format_date(iso: &str, verbose: bool) -> String {
+    use std::sync::atomic::AtomicBool;
+    static LOGGED: AtomicBool = AtomicBool::new(false);
+    match parse_created(iso) {
+        Some(dt) => dt
+            .with_timezone(&chrono::Local)
+            .format("%Y-%m-%d %H:%M")
+            .to_string(),
+        None => {
+            crate::observability::log_parse_failure_once(
+                &LOGGED, "changelog", iso, verbose,
+            );
+            iso.to_string()
+        }
+    }
+}
+```
+
+- [ ] **Step 2.5: Change `build_rows` signature and forward the flag**
+
+Locate `build_rows` (directly below `format_date`). Its current signature is:
+
+```rust
+fn build_rows(entries: &[ChangelogEntry]) -> Vec<Vec<String>> {
+```
+
+Change to:
+
+```rust
+fn build_rows(entries: &[ChangelogEntry], verbose: bool) -> Vec<Vec<String>> {
+```
+
+Inside the function body, find each call to `format_date(&entry.created)` and change it to `format_date(&entry.created, verbose)`.
+
+- [ ] **Step 2.6: Update the caller in `handle`**
+
+`handle` (begins around line 23) calls `build_rows(&entries)` in the `OutputFormat::Table` arm. Change it to `build_rows(&entries, client.verbose())`.
+
+- [ ] **Step 2.7: Update existing inline unit tests that call `format_date` directly**
+
+In `src/cli/issue/changelog.rs`, `format_date_converts_rfc3339_to_local` (around line 456) and `format_date_falls_back_to_raw_on_parse_failure` (around line 465) call `format_date(iso)`. Pass `false` as the second arg in each:
+
+```rust
+// format_date_converts_rfc3339_to_local
+let out = format_date("2026-04-16T14:02:00.000+0000", false);
+
+// format_date_falls_back_to_raw_on_parse_failure
+let out = format_date("not-a-date", false);
+```
+
+These unit tests do not exercise the verbose path (which would risk cross-test static pollution per the spec's maintainer caveat).
+
+- [ ] **Step 2.8: Run the integration tests from Task 1 — expect GREEN + STILL-GREEN**
+
+```bash
+cargo test --test issue_changelog changelog_verbose_logs_parse_failure_once changelog_parse_failure_silent_without_verbose
+```
+
+Expected: both PASS. `changelog_verbose_logs_parse_failure_once` moves FAIL → PASS; `changelog_parse_failure_silent_without_verbose` stays PASS.
+
+- [ ] **Step 2.9: Full check set**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+Expected: fmt clean, zero clippy warnings (the helper is now referenced by `format_date`, so `dead_code` will NOT trigger), all tests pass.
+
+- [ ] **Step 2.10: Commit**
+
+```bash
+git add src/observability.rs src/lib.rs src/api/client.rs src/cli/issue/changelog.rs
+git commit -m "feat(changelog): log format_date parse failures once when --verbose (#214)"
+```
+
+---
+
+## Task 3: RED — two failing comments integration tests
+
+Mirror the changelog pair for `format_comment_date` in `tests/comments.rs`. Same RED split (first test fails, second passes vacuously).
+
+**Files:**
+- Modify: `tests/comments.rs` (append two new `#[tokio::test]` functions at the end of the file)
+
+- [ ] **Step 3.1: Append the two tests**
+
+Open `tests/comments.rs`. Add at the end:
+
+```rust
+#[tokio::test]
+async fn comments_verbose_logs_parse_failure_once() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/BAD-1/comment"))
+        .and(query_param("startAt", "0"))
+        .and(query_param("maxResults", "100"))
+        .and(query_param("expand", "properties"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "comments": [
+                {
+                    "id": "10001",
+                    "author": {
+                        "accountId": "u1", "displayName": "Alice",
+                        "emailAddress": "a@test.com", "active": true
+                    },
+                    "body": { "type": "doc", "version": 1, "content": [
+                        { "type": "paragraph", "content": [
+                            { "type": "text", "text": "first" }
+                        ]}
+                    ]},
+                    "created": "not-a-date"
+                },
+                {
+                    "id": "10002",
+                    "author": {
+                        "accountId": "u1", "displayName": "Alice",
+                        "emailAddress": "a@test.com", "active": true
+                    },
+                    "body": { "type": "doc", "version": 1, "content": [
+                        { "type": "paragraph", "content": [
+                            { "type": "text", "text": "second" }
+                        ]}
+                    ]},
+                    "created": "still-not-a-date"
+                }
+            ],
+            "startAt": 0,
+            "maxResults": 100,
+            "total": 2
+        })))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "comments", "BAD-1", "--verbose"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let count = stderr.matches("timestamp failed to parse").count();
+    assert_eq!(
+        count, 1,
+        "expected exactly one parse-failure log across 2 bad comments, got {count}. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("[verbose] comment"),
+        "expected [verbose] comment prefix in stderr, got:\n{stderr}"
+    );
+}
+
+#[tokio::test]
+async fn comments_parse_failure_silent_without_verbose() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/BAD-2/comment"))
+        .and(query_param("startAt", "0"))
+        .and(query_param("maxResults", "100"))
+        .and(query_param("expand", "properties"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "comments": [
+                {
+                    "id": "10001",
+                    "author": {
+                        "accountId": "u1", "displayName": "Alice",
+                        "emailAddress": "a@test.com", "active": true
+                    },
+                    "body": { "type": "doc", "version": 1, "content": [
+                        { "type": "paragraph", "content": [
+                            { "type": "text", "text": "first" }
+                        ]}
+                    ]},
+                    "created": "not-a-date"
+                }
+            ],
+            "startAt": 0,
+            "maxResults": 100,
+            "total": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "comments", "BAD-2"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("failed to parse"),
+        "expected no verbose parse-failure output without --verbose, got:\n{stderr}"
+    );
+}
+```
+
+- [ ] **Step 3.2: Run the two new tests, confirm the RED split**
+
+```bash
+cargo test --test comments comments_verbose_logs_parse_failure_once comments_parse_failure_silent_without_verbose
+```
+
+Expected:
+- `comments_verbose_logs_parse_failure_once` — **FAIL** (stderr empty).
+- `comments_parse_failure_silent_without_verbose` — **PASS** (vacuously).
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add tests/comments.rs
+git commit -m "test(comments): pin verbose parse-failure logging contract for format_comment_date (#214)"
+```
+
+---
+
+## Task 4: GREEN — thread `verbose` through comments path
+
+Make `comments_verbose_logs_parse_failure_once` pass by threading `client.verbose()` through the comments rendering path.
+
+**Files:**
+- Modify: `src/cli/issue/list.rs`
+
+- [ ] **Step 4.1: Change `format_comment_date` signature and body**
+
+Locate `format_comment_date` (around line 592). Current body:
+
+```rust
+fn format_comment_date(iso: &str) -> String {
+    chrono::DateTime::parse_from_rfc3339(iso)
+        .or_else(|_| chrono::DateTime::parse_from_str(iso, "%Y-%m-%dT%H:%M:%S%.3f%z"))
+        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_else(|_| iso.to_string())
+}
+```
+
+Replace with:
+
+```rust
+fn format_comment_date(iso: &str, verbose: bool) -> String {
+    use std::sync::atomic::AtomicBool;
+    static LOGGED: AtomicBool = AtomicBool::new(false);
+    match chrono::DateTime::parse_from_rfc3339(iso)
+        .or_else(|_| chrono::DateTime::parse_from_str(iso, "%Y-%m-%dT%H:%M:%S%.3f%z"))
+    {
+        Ok(dt) => dt.format("%Y-%m-%d %H:%M").to_string(),
+        Err(_) => {
+            crate::observability::log_parse_failure_once(
+                &LOGGED, "comment", iso, verbose,
+            );
+            iso.to_string()
+        }
+    }
+}
+```
+
+- [ ] **Step 4.2: Change `format_comment_row` signature and forward the flag**
+
+Locate `format_comment_row` (directly below `format_comment_date`, around line 599). Current signature:
+
+```rust
+fn format_comment_row(
+    author_name: Option<&str>,
+    created: Option<&str>,
+    body_text: Option<&str>,
+) -> Vec<String> {
+```
+
+Change to:
+
+```rust
+fn format_comment_row(
+    author_name: Option<&str>,
+    created: Option<&str>,
+    body_text: Option<&str>,
+    verbose: bool,
+) -> Vec<String> {
+```
+
+Inside the body, the `created.map(format_comment_date)` line becomes:
+
+```rust
+created
+    .map(|c| format_comment_date(c, verbose))
+    .unwrap_or_else(|| "-".into()),
+```
+
+- [ ] **Step 4.3: Update `format_comment_row` callers to pass `client.verbose()`**
+
+Find every call site in `src/cli/issue/list.rs`:
+
+```bash
+grep -n "format_comment_row(" /Users/zious/Documents/GITHUB/jira-cli/.worktrees/format-date-verbose-logging/src/cli/issue/list.rs
+```
+
+Each caller should have `&client` in scope (comment-rendering happens inside handler functions that receive the client). Pass `client.verbose()` as the new last arg to every call.
+
+- [ ] **Step 4.4: Run the integration tests from Task 3 — expect GREEN + STILL-GREEN**
+
+```bash
+cargo test --test comments comments_verbose_logs_parse_failure_once comments_parse_failure_silent_without_verbose
+```
+
+Expected: both PASS.
+
+- [ ] **Step 4.5: Update existing inline unit tests that call `format_comment_date` directly**
+
+Three unit tests exist in `src/cli/issue/list.rs` (around `format_comment_date_rfc3339` at line 982, `format_comment_date_jira_offset_no_colon` at line 990, `format_comment_date_malformed_returns_raw` at line 998). Each needs the second arg:
+
+```rust
+// format_comment_date_rfc3339
+let out = format_comment_date("2026-04-16T14:02:00.000+00:00", false);
+
+// format_comment_date_jira_offset_no_colon
+let out = format_comment_date("2026-04-16T14:02:00.000+0000", false);
+
+// format_comment_date_malformed_returns_raw
+let out = format_comment_date("not-a-date", false);
+```
+
+- [ ] **Step 4.6: Full check set**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+Expected: fmt clean, zero clippy warnings, all tests pass.
+
+- [ ] **Step 4.7: Commit**
+
+```bash
+git add src/cli/issue/list.rs
+git commit -m "feat(comments): log format_comment_date parse failures once when --verbose (#214)"
+```
+
+---
+
+## Self-Review Results
+
+**Spec coverage:**
+- §"Approach" (verbose-gated eprintln with once-per-run dedup via `AtomicBool::swap(Relaxed)`) → Task 2 Step 2.1 ✓
+- §"Plumbing" (`JiraClient::verbose()` + threading through formatters) → Task 2 Steps 2.3, 2.4-2.6; Task 4 Steps 4.1-4.3 ✓
+- §"Algorithm" (function-local `static LOGGED: AtomicBool` at each call-site) → Task 2 Step 2.4 + Task 4 Step 4.1 ✓
+- §"Tests" (4 integration tests: verbose-logs-once + silent-without-verbose × 2 files) → Tasks 1 + 3 ✓
+- §"Out of scope" (no tracing crate, no per-string dedup, no help-text edit) → no task touches these ✓
+- §"Maintainer caveat" (cross-test pollution) — honored by not introducing any unit test that invokes `verbose=true` across tests ✓
+
+**Placeholder scan:** No TBD/TODO/implement-later. Every step shows exact code and commands.
+
+**Type consistency:**
+- `log_parse_failure_once(flag: &AtomicBool, site: &str, iso: &str, verbose: bool)` — used identically in Task 2.4 and Task 4.1.
+- `format_date(iso: &str, verbose: bool) -> String` — defined once, consumed once.
+- `format_comment_date(iso: &str, verbose: bool) -> String` — defined once, consumed once.
+- `build_rows(entries: &[ChangelogEntry], verbose: bool) -> Vec<Vec<String>>` — defined and consumed consistently.
+- `format_comment_row(..., verbose: bool) -> Vec<String>` — defined and consumed consistently.
+- `JiraClient::verbose(&self) -> bool` — introduced in Task 2.3, used in Task 2.6 and Task 4.3.
+
+**Dead-code check:** Every new symbol has a caller within its introducing commit — no `#[allow(dead_code)]` or `#[expect(dead_code)]` anywhere.

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -107,6 +107,12 @@ impl JiraClient {
         }
     }
 
+    /// Whether the client was constructed with `--verbose` enabled.
+    /// Handlers use this to gate optional diagnostic output.
+    pub fn verbose(&self) -> bool {
+        self.verbose
+    }
+
     /// Perform a GET request and deserialize the JSON response.
     pub async fn get<T: DeserializeOwned>(&self, path: &str) -> anyhow::Result<T> {
         let url = format!("{}{}", self.base_url, path);

--- a/src/cli/issue/changelog.rs
+++ b/src/cli/issue/changelog.rs
@@ -103,7 +103,7 @@ pub(super) async fn handle(
         }
         OutputFormat::Table => {
             let headers = &["DATE", "AUTHOR", "FIELD", "FROM", "TO"];
-            let rows = build_rows(&entries);
+            let rows = build_rows(&entries, client.verbose());
             output::print_output(output_format, headers, &rows, &entries)?;
         }
     }
@@ -159,10 +159,10 @@ fn author_matches(author: Option<&crate::types::jira::User>, needle: &AuthorNeed
 
 /// Flatten `entries` into one row per `ChangelogItem`, preserving the
 /// caller's sort order. Each row becomes `[date, author, field, from, to]`.
-fn build_rows(entries: &[ChangelogEntry]) -> Vec<Vec<String>> {
+fn build_rows(entries: &[ChangelogEntry], verbose: bool) -> Vec<Vec<String>> {
     let mut rows = Vec::new();
     for entry in entries {
-        let date = format_date(&entry.created);
+        let date = format_date(&entry.created, verbose);
         let author = entry
             .author
             .as_ref()
@@ -193,15 +193,22 @@ fn parse_created(iso: &str) -> Option<DateTime<chrono::FixedOffset>> {
 }
 
 /// Render a Jira ISO-8601 timestamp as `YYYY-MM-DD HH:MM` in the user's
-/// local time zone. Falls back to the raw string if parsing fails.
-fn format_date(iso: &str) -> String {
-    parse_created(iso)
-        .map(|dt| {
-            dt.with_timezone(&chrono::Local)
-                .format("%Y-%m-%d %H:%M")
-                .to_string()
-        })
-        .unwrap_or_else(|| iso.to_string())
+/// local time zone. Falls back to the raw string on parse failure; when
+/// `verbose` is true, emits a one-shot `[verbose]` stderr note the first
+/// time parsing fails in this process.
+fn format_date(iso: &str, verbose: bool) -> String {
+    use std::sync::atomic::AtomicBool;
+    static LOGGED: AtomicBool = AtomicBool::new(false);
+    match parse_created(iso) {
+        Some(dt) => dt
+            .with_timezone(&chrono::Local)
+            .format("%Y-%m-%d %H:%M")
+            .to_string(),
+        None => {
+            crate::observability::log_parse_failure_once(&LOGGED, "changelog", iso, verbose);
+            iso.to_string()
+        }
+    }
 }
 
 /// Truncate entries so the total row count (sum of items across all
@@ -413,7 +420,7 @@ mod tests {
                 item("resolution", None, Some("Done")),
             ],
         )];
-        let rows = build_rows(&entries);
+        let rows = build_rows(&entries, false);
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0][2], "status");
         assert_eq!(rows[1][2], "resolution");
@@ -427,7 +434,7 @@ mod tests {
             None,
             vec![item("assignee", None, Some("Alice"))],
         )];
-        let rows = build_rows(&entries);
+        let rows = build_rows(&entries, false);
         assert_eq!(rows[0][1], SYSTEM_AUTHOR);
     }
 
@@ -455,7 +462,7 @@ mod tests {
     #[test]
     fn format_date_converts_rfc3339_to_local() {
         // Just verify the shape; actual local conversion depends on runner TZ.
-        let formatted = format_date("2026-04-16T14:02:11.000+0000");
+        let formatted = format_date("2026-04-16T14:02:11.000+0000", false);
         // YYYY-MM-DD HH:MM is 16 chars.
         assert_eq!(formatted.len(), 16, "got: {formatted}");
         assert!(formatted.starts_with("2026-04-"), "got: {formatted}");
@@ -464,7 +471,7 @@ mod tests {
     #[test]
     fn format_date_falls_back_to_raw_on_parse_failure() {
         let garbage = "not-a-date";
-        assert_eq!(format_date(garbage), garbage);
+        assert_eq!(format_date(garbage, false), garbage);
     }
 
     #[test]

--- a/src/cli/issue/list.rs
+++ b/src/cli/issue/list.rs
@@ -589,22 +589,30 @@ fn build_filter_clauses(opts: FilterOptions<'_>) -> Vec<String> {
 
 // ── Comments ─────────────────────────────────────────────────────────
 
-fn format_comment_date(iso: &str) -> String {
-    chrono::DateTime::parse_from_rfc3339(iso)
+fn format_comment_date(iso: &str, verbose: bool) -> String {
+    use std::sync::atomic::AtomicBool;
+    static LOGGED: AtomicBool = AtomicBool::new(false);
+    match chrono::DateTime::parse_from_rfc3339(iso)
         .or_else(|_| chrono::DateTime::parse_from_str(iso, "%Y-%m-%dT%H:%M:%S%.3f%z"))
-        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
-        .unwrap_or_else(|_| iso.to_string())
+    {
+        Ok(dt) => dt.format("%Y-%m-%d %H:%M").to_string(),
+        Err(_) => {
+            crate::observability::log_parse_failure_once(&LOGGED, "comment", iso, verbose);
+            iso.to_string()
+        }
+    }
 }
 
 fn format_comment_row(
     author_name: Option<&str>,
     created: Option<&str>,
     body_text: Option<&str>,
+    verbose: bool,
 ) -> Vec<String> {
     vec![
         author_name.unwrap_or("(unknown)").to_string(),
         created
-            .map(format_comment_date)
+            .map(|c| format_comment_date(c, verbose))
             .unwrap_or_else(|| "-".into()),
         body_text.unwrap_or("(no content)").to_string(),
     ]
@@ -650,7 +658,12 @@ pub(super) async fn handle_comments(
                         let created = c.created.as_deref();
                         let body_text = c.body.as_ref().map(adf::adf_to_text);
                         let visibility = comment_visibility(c).unwrap_or("External");
-                        let mut row = format_comment_row(author, created, body_text.as_deref());
+                        let mut row = format_comment_row(
+                            author,
+                            created,
+                            body_text.as_deref(),
+                            client.verbose(),
+                        );
                         // Insert Visibility before Body (index 2)
                         row.insert(2, visibility.to_string());
                         row
@@ -664,7 +677,7 @@ pub(super) async fn handle_comments(
                         let author = c.author.as_ref().map(|a| a.display_name.as_str());
                         let created = c.created.as_deref();
                         let body_text = c.body.as_ref().map(adf::adf_to_text);
-                        format_comment_row(author, created, body_text.as_deref())
+                        format_comment_row(author, created, body_text.as_deref(), client.verbose())
                     })
                     .collect();
                 (vec!["Author", "Date", "Body"], rows)
@@ -810,7 +823,7 @@ pub(super) async fn handle_view(
                         .fields
                         .created
                         .as_deref()
-                        .map(format_comment_date)
+                        .map(|c| format_comment_date(c, client.verbose()))
                         .unwrap_or_else(|| "-".into()),
                 ],
                 vec![
@@ -819,7 +832,7 @@ pub(super) async fn handle_view(
                         .fields
                         .updated
                         .as_deref()
-                        .map(format_comment_date)
+                        .map(|c| format_comment_date(c, client.verbose()))
                         .unwrap_or_else(|| "-".into()),
                 ],
                 vec![
@@ -981,7 +994,7 @@ mod tests {
     #[test]
     fn format_comment_date_rfc3339() {
         assert_eq!(
-            format_comment_date("2026-03-20T14:32:00+00:00"),
+            format_comment_date("2026-03-20T14:32:00+00:00", false),
             "2026-03-20 14:32"
         );
     }
@@ -989,25 +1002,30 @@ mod tests {
     #[test]
     fn format_comment_date_jira_offset_no_colon() {
         assert_eq!(
-            format_comment_date("2026-03-20T14:32:00.000+0000"),
+            format_comment_date("2026-03-20T14:32:00.000+0000", false),
             "2026-03-20 14:32"
         );
     }
 
     #[test]
     fn format_comment_date_malformed_returns_raw() {
-        assert_eq!(format_comment_date("not-a-date"), "not-a-date");
+        assert_eq!(format_comment_date("not-a-date", false), "not-a-date");
     }
 
     #[test]
     fn format_comment_row_missing_author() {
-        let row = format_comment_row(None, Some("2026-03-20T14:32:00+00:00"), None);
+        let row = format_comment_row(None, Some("2026-03-20T14:32:00+00:00"), None, false);
         assert_eq!(row[0], "(unknown)");
     }
 
     #[test]
     fn format_comment_row_missing_body() {
-        let row = format_comment_row(Some("Jane Smith"), Some("2026-03-20T14:32:00+00:00"), None);
+        let row = format_comment_row(
+            Some("Jane Smith"),
+            Some("2026-03-20T14:32:00+00:00"),
+            None,
+            false,
+        );
         assert_eq!(row[2], "(no content)");
     }
 

--- a/src/cli/issue/list.rs
+++ b/src/cli/issue/list.rs
@@ -650,6 +650,7 @@ pub(super) async fn handle_comments(
             output::print_output(output_format, &[], &[], &comments)?;
         }
         OutputFormat::Table => {
+            let verbose = client.verbose();
             let (headers, rows) = if has_visibility {
                 let rows: Vec<Vec<String>> = comments
                     .iter()
@@ -658,12 +659,8 @@ pub(super) async fn handle_comments(
                         let created = c.created.as_deref();
                         let body_text = c.body.as_ref().map(adf::adf_to_text);
                         let visibility = comment_visibility(c).unwrap_or("External");
-                        let mut row = format_comment_row(
-                            author,
-                            created,
-                            body_text.as_deref(),
-                            client.verbose(),
-                        );
+                        let mut row =
+                            format_comment_row(author, created, body_text.as_deref(), verbose);
                         // Insert Visibility before Body (index 2)
                         row.insert(2, visibility.to_string());
                         row
@@ -677,7 +674,7 @@ pub(super) async fn handle_comments(
                         let author = c.author.as_ref().map(|a| a.display_name.as_str());
                         let created = c.created.as_deref();
                         let body_text = c.body.as_ref().map(adf::adf_to_text);
-                        format_comment_row(author, created, body_text.as_deref(), client.verbose())
+                        format_comment_row(author, created, body_text.as_deref(), verbose)
                     })
                     .collect();
                 (vec!["Author", "Date", "Body"], rows)

--- a/src/cli/issue/list.rs
+++ b/src/cli/issue/list.rs
@@ -597,7 +597,9 @@ fn format_comment_date(iso: &str, verbose: bool) -> String {
     {
         Ok(dt) => dt.format("%Y-%m-%d %H:%M").to_string(),
         Err(_) => {
-            crate::observability::log_parse_failure_once(&LOGGED, "comment", iso, verbose);
+            // Label is "date" (not "comment") because this formatter is also
+            // used by `handle_view` for the Created/Updated timestamp rows.
+            crate::observability::log_parse_failure_once(&LOGGED, "date", iso, verbose);
             iso.to_string()
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod duration;
 pub mod error;
 pub mod jql;
+pub(crate) mod observability;
 pub mod output;
 pub mod partial_match;
 pub mod types;

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -18,3 +18,22 @@ pub(crate) fn log_parse_failure_once(flag: &AtomicBool, site: &str, iso: &str, v
         eprintln!("[verbose] {site} timestamp failed to parse: {iso}");
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verbose_false_leaves_flag_untouched() {
+        // Pins the short-circuit order: the `verbose` check must happen
+        // BEFORE `flag.swap(...)`. Reversing them would silently burn the
+        // flag on a non-verbose run and suppress the first verbose log
+        // later in the same process.
+        let flag = AtomicBool::new(false);
+        log_parse_failure_once(&flag, "test", "not-a-date", false);
+        assert!(
+            !flag.load(Ordering::Relaxed),
+            "verbose=false must not flip the gate flag"
+        );
+    }
+}

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// `flag` is typically a function-local `static AtomicBool`, one per
 /// call-site, so each formatter fires at most one line per run. The
 /// `site` argument is a short human label (e.g. `"changelog"`,
-/// `"comment"`) included in the message for disambiguation.
+/// `"date"`) included in the message for disambiguation.
 pub(crate) fn log_parse_failure_once(flag: &AtomicBool, site: &str, iso: &str, verbose: bool) {
     if verbose && !flag.swap(true, Ordering::Relaxed) {
         eprintln!("[verbose] {site} timestamp failed to parse: {iso}");

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1,0 +1,20 @@
+//! Lightweight observability primitives shared across commands.
+//!
+//! Intentionally tiny: the project has no tracing/log crate, and a
+//! single `--verbose`-gated `eprintln!` is the established pattern
+//! (see `src/api/client.rs` for HTTP-request logging). Expand to a
+//! real tracing layer when there is cross-subsystem need.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Log a parse-failure once per `flag` per process, gated on `verbose`.
+///
+/// `flag` is typically a function-local `static AtomicBool`, one per
+/// call-site, so each formatter fires at most one line per run. The
+/// `site` argument is a short human label (e.g. `"changelog"`,
+/// `"comment"`) included in the message for disambiguation.
+pub(crate) fn log_parse_failure_once(flag: &AtomicBool, site: &str, iso: &str, verbose: bool) {
+    if verbose && !flag.swap(true, Ordering::Relaxed) {
+        eprintln!("[verbose] {site} timestamp failed to parse: {iso}");
+    }
+}

--- a/tests/comments.rs
+++ b/tests/comments.rs
@@ -331,14 +331,20 @@ async fn comments_verbose_logs_parse_failure_once() {
         .unwrap();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "jr exited non-zero ({:?}). stdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status.code()
+    );
     let count = stderr.matches("timestamp failed to parse").count();
     assert_eq!(
         count, 1,
         "expected exactly one parse-failure log across 2 bad comments, got {count}. stderr:\n{stderr}"
     );
     assert!(
-        stderr.contains("[verbose] comment"),
-        "expected [verbose] comment prefix in stderr, got:\n{stderr}"
+        stderr.contains("[verbose] date"),
+        "expected [verbose] date prefix in stderr, got:\n{stderr}"
     );
 }
 
@@ -383,6 +389,12 @@ async fn comments_parse_failure_silent_without_verbose() {
         .unwrap();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "jr exited non-zero ({:?}). stdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status.code()
+    );
     assert!(
         !stderr.contains("failed to parse"),
         "expected no verbose parse-failure output without --verbose, got:\n{stderr}"

--- a/tests/comments.rs
+++ b/tests/comments.rs
@@ -276,3 +276,115 @@ async fn issue_comments_network_drop_surfaces_reach_error() {
     );
     assert!(!stderr.contains("panic"), "stderr leaked a panic: {stderr}");
 }
+
+#[tokio::test]
+async fn comments_verbose_logs_parse_failure_once() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/BAD-1/comment"))
+        .and(query_param("startAt", "0"))
+        .and(query_param("maxResults", "100"))
+        .and(query_param("expand", "properties"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "comments": [
+                {
+                    "id": "10001",
+                    "author": {
+                        "accountId": "u1", "displayName": "Alice",
+                        "emailAddress": "a@test.com", "active": true
+                    },
+                    "body": { "type": "doc", "version": 1, "content": [
+                        { "type": "paragraph", "content": [
+                            { "type": "text", "text": "first" }
+                        ]}
+                    ]},
+                    "created": "not-a-date"
+                },
+                {
+                    "id": "10002",
+                    "author": {
+                        "accountId": "u1", "displayName": "Alice",
+                        "emailAddress": "a@test.com", "active": true
+                    },
+                    "body": { "type": "doc", "version": 1, "content": [
+                        { "type": "paragraph", "content": [
+                            { "type": "text", "text": "second" }
+                        ]}
+                    ]},
+                    "created": "still-not-a-date"
+                }
+            ],
+            "startAt": 0,
+            "maxResults": 100,
+            "total": 2
+        })))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "comments", "BAD-1", "--verbose"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let count = stderr.matches("timestamp failed to parse").count();
+    assert_eq!(
+        count, 1,
+        "expected exactly one parse-failure log across 2 bad comments, got {count}. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("[verbose] comment"),
+        "expected [verbose] comment prefix in stderr, got:\n{stderr}"
+    );
+}
+
+#[tokio::test]
+async fn comments_parse_failure_silent_without_verbose() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/BAD-2/comment"))
+        .and(query_param("startAt", "0"))
+        .and(query_param("maxResults", "100"))
+        .and(query_param("expand", "properties"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "comments": [
+                {
+                    "id": "10001",
+                    "author": {
+                        "accountId": "u1", "displayName": "Alice",
+                        "emailAddress": "a@test.com", "active": true
+                    },
+                    "body": { "type": "doc", "version": 1, "content": [
+                        { "type": "paragraph", "content": [
+                            { "type": "text", "text": "first" }
+                        ]}
+                    ]},
+                    "created": "not-a-date"
+                }
+            ],
+            "startAt": 0,
+            "maxResults": 100,
+            "total": 1
+        })))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "comments", "BAD-2"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("failed to parse"),
+        "expected no verbose parse-failure output without --verbose, got:\n{stderr}"
+    );
+}

--- a/tests/issue_changelog.rs
+++ b/tests/issue_changelog.rs
@@ -1376,3 +1376,103 @@ async fn changelog_parse_failure_silent_without_verbose() {
         "expected no verbose parse-failure output without --verbose, got:\n{stderr}"
     );
 }
+
+#[tokio::test]
+async fn changelog_verbose_mixed_good_bad_entries() {
+    // Scopes the verbose log: good entries render normally, only bad
+    // entries trigger `[verbose]`, and the dedup flag still caps at
+    // exactly one line across multiple bad entries.
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/MIX-1/changelog"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "values": [
+                {
+                    "id": "1",
+                    "author": {
+                        "accountId": "u1",
+                        "displayName": "Alice",
+                        "emailAddress": null,
+                        "active": true
+                    },
+                    "created": "2026-03-20T10:00:00.000+0000",
+                    "items": [{
+                        "field": "status",
+                        "fieldtype": "jira",
+                        "from": null, "fromString": "To Do",
+                        "to": null, "toString": "In Progress"
+                    }]
+                },
+                {
+                    "id": "2",
+                    "author": {
+                        "accountId": "u1",
+                        "displayName": "Alice",
+                        "emailAddress": null,
+                        "active": true
+                    },
+                    "created": "not-a-date",
+                    "items": [{
+                        "field": "status",
+                        "fieldtype": "jira",
+                        "from": null, "fromString": "In Progress",
+                        "to": null, "toString": "Done"
+                    }]
+                },
+                {
+                    "id": "3",
+                    "author": {
+                        "accountId": "u1",
+                        "displayName": "Alice",
+                        "emailAddress": null,
+                        "active": true
+                    },
+                    "created": "2026-03-21T11:00:00.000+0000",
+                    "items": [{
+                        "field": "resolution",
+                        "fieldtype": "jira",
+                        "from": null, "fromString": "Unresolved",
+                        "to": null, "toString": "Done"
+                    }]
+                }
+            ],
+            "startAt": 0,
+            "maxResults": 100,
+            "total": 3,
+            "isLast": true
+        })))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "changelog", "MIX-1", "--verbose"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    let fail_count = stderr.matches("timestamp failed to parse").count();
+    assert_eq!(
+        fail_count, 1,
+        "expected exactly one parse-failure log across 1 bad entry among 3, got {fail_count}. stderr:\n{stderr}"
+    );
+
+    // Parseable rows must still render properly in the table — presence of
+    // `2026-03-20` and `2026-03-21` (in some local-time rendering) would
+    // be fragile across timezones; instead assert that the status/resolution
+    // fields from the good rows appear in stdout.
+    assert!(
+        stdout.contains("In Progress") || stdout.contains("Unresolved"),
+        "expected good-row field content in stdout, got:\n{stdout}"
+    );
+    // The raw bad timestamp string surfaces in the date column of the bad row.
+    assert!(
+        stdout.contains("not-a-date"),
+        "expected raw-timestamp fallback to appear in stdout for the bad row, got:\n{stdout}"
+    );
+}

--- a/tests/issue_changelog.rs
+++ b/tests/issue_changelog.rs
@@ -1261,3 +1261,118 @@ async fn changelog_author_me_is_case_insensitive() {
         "Someone Else should be filtered: {stdout}"
     );
 }
+
+#[tokio::test]
+async fn changelog_verbose_logs_parse_failure_once() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/BAD-1/changelog"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "values": [
+                {
+                    "id": "1",
+                    "author": {
+                        "accountId": "u1",
+                        "displayName": "Alice",
+                        "emailAddress": null,
+                        "active": true
+                    },
+                    "created": "not-a-date",
+                    "items": [{
+                        "field": "status",
+                        "fieldtype": "jira",
+                        "from": null, "fromString": "To Do",
+                        "to": null, "toString": "In Progress"
+                    }]
+                },
+                {
+                    "id": "2",
+                    "author": {
+                        "accountId": "u1",
+                        "displayName": "Alice",
+                        "emailAddress": null,
+                        "active": true
+                    },
+                    "created": "still-not-a-date",
+                    "items": [{
+                        "field": "status",
+                        "fieldtype": "jira",
+                        "from": null, "fromString": "In Progress",
+                        "to": null, "toString": "Done"
+                    }]
+                }
+            ],
+            "startAt": 0,
+            "maxResults": 100,
+            "total": 2,
+            "isLast": true
+        })))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "changelog", "BAD-1", "--verbose"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let count = stderr.matches("timestamp failed to parse").count();
+    assert_eq!(
+        count, 1,
+        "expected exactly one parse-failure log across 2 bad entries, got {count}. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("[verbose] changelog"),
+        "expected [verbose] changelog prefix in stderr, got:\n{stderr}"
+    );
+}
+
+#[tokio::test]
+async fn changelog_parse_failure_silent_without_verbose() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/BAD-2/changelog"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "values": [{
+                "id": "1",
+                "author": {
+                    "accountId": "u1",
+                    "displayName": "Alice",
+                    "emailAddress": null,
+                    "active": true
+                },
+                "created": "not-a-date",
+                "items": [{
+                    "field": "status",
+                    "fieldtype": "jira",
+                    "from": null, "fromString": "A",
+                    "to": null, "toString": "B"
+                }]
+            }],
+            "startAt": 0,
+            "maxResults": 100,
+            "total": 1,
+            "isLast": true
+        })))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "changelog", "BAD-2"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("failed to parse"),
+        "expected no verbose parse-failure output without --verbose, got:\n{stderr}"
+    );
+}

--- a/tests/issue_changelog.rs
+++ b/tests/issue_changelog.rs
@@ -1320,6 +1320,12 @@ async fn changelog_verbose_logs_parse_failure_once() {
         .unwrap();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "jr exited non-zero ({:?}). stdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status.code()
+    );
     let count = stderr.matches("timestamp failed to parse").count();
     assert_eq!(
         count, 1,
@@ -1371,6 +1377,12 @@ async fn changelog_parse_failure_silent_without_verbose() {
         .unwrap();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "jr exited non-zero ({:?}). stdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status.code()
+    );
     assert!(
         !stderr.contains("failed to parse"),
         "expected no verbose parse-failure output without --verbose, got:\n{stderr}"
@@ -1455,6 +1467,11 @@ async fn changelog_verbose_mixed_good_bad_entries() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "jr exited non-zero ({:?}). stdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status.code()
+    );
 
     let fail_count = stderr.matches("timestamp failed to parse").count();
     assert_eq!(

--- a/tests/issue_changelog.rs
+++ b/tests/issue_changelog.rs
@@ -1462,13 +1462,13 @@ async fn changelog_verbose_mixed_good_bad_entries() {
         "expected exactly one parse-failure log across 1 bad entry among 3, got {fail_count}. stderr:\n{stderr}"
     );
 
-    // Parseable rows must still render properly in the table — presence of
-    // `2026-03-20` and `2026-03-21` (in some local-time rendering) would
-    // be fragile across timezones; instead assert that the status/resolution
-    // fields from the good rows appear in stdout.
+    // Parseable rows must still render. Use `Unresolved` from the good
+    // id=3 row — it appears in no other row's fromString/toString, so
+    // its presence uniquely proves id=3 rendered. Avoiding date
+    // substrings keeps this timezone-independent.
     assert!(
-        stdout.contains("In Progress") || stdout.contains("Unresolved"),
-        "expected good-row field content in stdout, got:\n{stdout}"
+        stdout.contains("Unresolved"),
+        "expected good-row field content ('Unresolved' from id=3) in stdout, got:\n{stdout}"
     );
     // The raw bad timestamp string surfaces in the date column of the bad row.
     assert!(


### PR DESCRIPTION
## Summary

- Adds a tiny `src/observability.rs` with `log_parse_failure_once(&AtomicBool, site, iso, verbose)` — one-shot stderr log gated on `--verbose`, dedup'd per call-site via `AtomicBool::swap(true, Relaxed)`.
- Exposes `JiraClient::verbose()` getter so handlers can thread the flag to the two timestamp formatters.
- Threads `verbose: bool` through `handle → build_rows → format_date` (changelog) and handlers → `format_comment_row → format_comment_date` (comments).
- Each formatter gets a function-local `static LOGGED: AtomicBool` — so a future Jira format regression (dropped millis, different offset width, etc.) now surfaces on stderr instead of silently corrupting the rendered table column.
- Follows the existing observability pattern in `src/api/client.rs:178` (`--verbose` → `bool` → `eprintln!("[verbose] ...")`). Adopting a full tracing crate is explicitly out of scope per the issue.

Closes #214.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 781 pass / 0 fail
- [x] 4 new integration tests (2 in `tests/issue_changelog.rs`, 2 in `tests/comments.rs`) cover verbose-logs-once + silent-without-verbose
- [x] 1 new mixed-entry integration test (`changelog_verbose_mixed_good_bad_entries`) proves scoping: good rows render, only bad rows trigger `[verbose]`, count stays at 1
- [x] 1 new unit test (`verbose_false_leaves_flag_untouched`) pins the short-circuit order: a future reorder of `swap` before the verbose check would fail this test
- [x] `jr issue changelog <KEY> --verbose` against a malformed timestamp emits one `[verbose] changelog timestamp failed to parse: ...` line
- [x] Same command without `--verbose` — stderr silent
- [x] Mirror behavior verified for `jr issue comments`
- [x] Local multi-agent review clean (code-reviewer, pr-test-analyzer, comment-analyzer)