### PR TITLE
refactor(changelog): LoweredStr newtype + AuthorNeedle::from_raw (#215)

### DIFF
--- a/docs/specs/author-needle-smart-constructor.md
+++ b/docs/specs/author-needle-smart-constructor.md
@@ -103,11 +103,11 @@ The newtype is further encapsulated inside a nested private submodule (`mod lowe
 |------|--------|
 | `src/cli/issue/changelog.rs` | Add `mod lowered_str { struct LoweredStr ... }` submodule with `pub(super)` surface; change `NameSubstring(String)` → `NameSubstring(LoweredStr)`; rename `classify_author` → `AuthorNeedle::from_raw`; update `author_matches` to call `contains(n.as_str())`; update unit tests to compare via `s.as_str()`. |
 
-No other files change. The enum and all related items remain module-private to `changelog.rs`.
+No other production code files change. The enum and all related items remain module-private to `changelog.rs`.
 
 ## Test strategy
 
-The 10 existing unit tests in `src/cli/issue/changelog.rs` (`classify_author_*`) already cover the heuristic's behavior:
+The 11 existing unit tests in `src/cli/issue/changelog.rs` (renamed `from_raw_*`) already cover the heuristic's behavior:
 
 - Short name → substring
 - Colon → accountId
@@ -116,6 +116,7 @@ The 10 existing unit tests in `src/cli/issue/changelog.rs` (`classify_author_*`)
 - Long compound name → substring
 - Long hyphenated name → substring
 - Old 24-char hex accountId → accountId
+- Colon forces accountId regardless of length/content heuristics
 - Long name with digit → accountId
 - Short hyphenated name → substring
 - Unknown placeholder → substring
@@ -123,6 +124,7 @@ The 10 existing unit tests in `src/cli/issue/changelog.rs` (`classify_author_*`)
 They need mechanical updates:
 
 - Call `AuthorNeedle::from_raw(...)` instead of `classify_author(...)`
+- Rename each test from `classify_author_*` to `from_raw_*` so the name matches the symbol under test
 - Compare the `NameSubstring` inner via `s.as_str()` instead of direct `String` equality
 
 Behavior is unchanged, so no new behavior-oriented test cases are needed. Two small unit tests are added to pin the newtype's type-level contract:

--- a/docs/specs/author-needle-smart-constructor.md
+++ b/docs/specs/author-needle-smart-constructor.md
@@ -1,0 +1,122 @@
+# AuthorNeedle smart-constructor refactor
+
+**Issue:** [#215](https://github.com/Zious11/jira-cli/issues/215) (discovered during #200 / #213 review)
+
+**Status:** Approved 2026-04-19
+
+## Problem
+
+`AuthorNeedle::NameSubstring(String)` in `src/cli/issue/changelog.rs:115-120` is documented as holding an already-lowercased string. `author_matches` (line 150-158) relies on that invariant — it lowercases the haystack (`display_name`, `account_id`) and calls `contains(n)` without re-lowercasing the needle.
+
+Today the invariant is upheld only by convention: `classify_author` is the sole constructor of the `NameSubstring` variant, and it always lowercases. Nothing stops a future contributor from writing `AuthorNeedle::NameSubstring(raw.to_string())` elsewhere in the module; the compiler will not object, and the resulting case-mismatch bug would be silent (matches would simply fail for mixed-case names).
+
+## Goal
+
+Move the lowercase invariant from convention to the type system so the compiler rejects any construction that does not lowercase.
+
+## Non-goals
+
+- Changing the classification heuristic (that was the scope of #213)
+- Changing user-visible `--author` behavior
+- Adding new integration tests — this is a pure internal refactor with existing unit-test coverage
+
+## Design
+
+### `LoweredStr` newtype
+
+Add a module-private wrapper whose only constructor lowercases its input:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LoweredStr(String);
+
+impl LoweredStr {
+    fn new(s: &str) -> Self {
+        Self(s.to_lowercase())
+    }
+}
+
+impl std::ops::Deref for LoweredStr {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+```
+
+`Deref<Target = str>` is the idiomatic accessor for string newtypes and lets `author_matches` continue to call `contains(&**n)` (or the equivalent) without extra boilerplate.
+
+### Enum and smart constructor
+
+```rust
+#[derive(Debug, Clone)]
+enum AuthorNeedle {
+    AccountId(String),          // case-sensitive; no invariant to enforce
+    NameSubstring(LoweredStr),  // compiler-enforced lowercase
+}
+
+impl AuthorNeedle {
+    /// Classify a user-supplied `--author` value. Heuristic body identical to
+    /// the previous `classify_author` free function (unchanged): accountId iff
+    /// the value contains ':' or is ≥12 chars of `[A-Za-z0-9_-]` containing at
+    /// least one digit; otherwise `NameSubstring`.
+    fn from_raw(raw: &str) -> Self {
+        let trimmed = raw.trim();
+        let looks_like_account_id = trimmed.contains(':')
+            || (trimmed.len() >= 12
+                && trimmed.chars().any(|c| c.is_ascii_digit())
+                && trimmed
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+        if looks_like_account_id {
+            Self::AccountId(trimmed.to_string())
+        } else {
+            Self::NameSubstring(LoweredStr::new(trimmed))
+        }
+    }
+}
+```
+
+The existing free function `classify_author` becomes the associated function `AuthorNeedle::from_raw`; its body is unchanged.
+
+The explicit `AuthorNeedle::AccountId(...)` construction in `handle` (currently `src/cli/issue/changelog.rs:43-45`, used for the resolved "me" accountId) stays as-is — accountIds are case-sensitive, so there is no invariant to enforce for that variant.
+
+### Why A+B hybrid, not A alone or B alone
+
+- **B alone (rename only)** does not solve the problem. Rust enum variants inherit the enum's visibility, so nothing prevents in-module code from constructing `NameSubstring("MixedCase".into())`. Confirmed via the Rust reference and the 2024-edition RFC discussion.
+- **A alone (newtype without rename)** gives type enforcement but leaves the awkwardly-named `classify_author` free function. Renaming it to `AuthorNeedle::from_raw` costs one line and makes the API self-explanatory.
+- **A+B hybrid** gets both wins for ~15 LoC more than either option alone.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `src/cli/issue/changelog.rs` | Add `LoweredStr`; change `NameSubstring(String)` → `NameSubstring(LoweredStr)`; rename `classify_author` → `AuthorNeedle::from_raw`; update `author_matches` needle-access; update unit tests to inspect `&**s` or `s.as_str()` equivalent. |
+
+No other files change. The enum and all related items remain module-private to `changelog.rs`.
+
+## Test strategy
+
+The 8 existing unit tests in `src/cli/issue/changelog.rs` (`classify_author_*`) already cover the heuristic's behavior:
+
+- Short name → substring
+- Colon → accountId
+- Long hex blob → accountId
+- Long alpha-only single word → substring
+- Long compound name → substring
+- Long hyphenated name → substring
+- Old 24-char hex accountId → accountId
+- Long name with digit → accountId
+- Short hyphenated name → substring
+- Unknown placeholder → substring
+
+They need mechanical updates:
+
+- Call `AuthorNeedle::from_raw(...)` instead of `classify_author(...)`
+- Compare the `NameSubstring` inner via `&*s` (Deref to `str`) instead of direct `String` equality
+
+Behavior is unchanged, so no new test cases are added. A single new assertion that `LoweredStr::new("MixedCase")` produces `"mixedcase"` is sufficient to pin the invariant (one or two lines added to the existing test block).
+
+## Rollout
+
+Single commit, single file. No migration concerns — the type is module-private and has no public API surface.

--- a/docs/specs/author-needle-smart-constructor.md
+++ b/docs/specs/author-needle-smart-constructor.md
@@ -34,6 +34,10 @@ impl LoweredStr {
     fn new(s: &str) -> Self {
         Self(s.to_lowercase())
     }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 impl std::ops::Deref for LoweredStr {
@@ -44,7 +48,7 @@ impl std::ops::Deref for LoweredStr {
 }
 ```
 
-`Deref<Target = str>` is the idiomatic accessor for string newtypes and lets `author_matches` continue to call `contains(&**n)` (or the equivalent) without extra boilerplate.
+Both `Deref<Target = str>` and an explicit `as_str(&self) -> &str` are implemented — the standard Rust newtype pattern, mirroring `String::as_str` and `OsStr::as_str`. `Deref` enables coercion in generic/method-call contexts (e.g. `lowered.len()`); `as_str()` is used at explicit-conversion call sites where clarity matters more than brevity.
 
 ### Enum and smart constructor
 
@@ -91,7 +95,7 @@ The explicit `AuthorNeedle::AccountId(...)` construction in `handle` (currently 
 
 | File | Change |
 |------|--------|
-| `src/cli/issue/changelog.rs` | Add `LoweredStr`; change `NameSubstring(String)` → `NameSubstring(LoweredStr)`; rename `classify_author` → `AuthorNeedle::from_raw`; update `author_matches` needle-access; update unit tests to inspect `&**s` or `s.as_str()` equivalent. |
+| `src/cli/issue/changelog.rs` | Add `LoweredStr`; change `NameSubstring(String)` → `NameSubstring(LoweredStr)`; rename `classify_author` → `AuthorNeedle::from_raw`; update `author_matches` to call `contains(n.as_str())`; update unit tests to compare via `s.as_str()`. |
 
 No other files change. The enum and all related items remain module-private to `changelog.rs`.
 
@@ -113,7 +117,7 @@ The 8 existing unit tests in `src/cli/issue/changelog.rs` (`classify_author_*`) 
 They need mechanical updates:
 
 - Call `AuthorNeedle::from_raw(...)` instead of `classify_author(...)`
-- Compare the `NameSubstring` inner via `&*s` (Deref to `str`) instead of direct `String` equality
+- Compare the `NameSubstring` inner via `s.as_str()` instead of direct `String` equality
 
 Behavior is unchanged, so no new test cases are added. A single new assertion that `LoweredStr::new("MixedCase")` produces `"mixedcase"` is sufficient to pin the invariant (one or two lines added to the existing test block).
 

--- a/docs/specs/author-needle-smart-constructor.md
+++ b/docs/specs/author-needle-smart-constructor.md
@@ -6,7 +6,7 @@
 
 ## Problem
 
-`AuthorNeedle::NameSubstring(String)` in `src/cli/issue/changelog.rs:115-120` is documented as holding an already-lowercased string. `author_matches` (line 150-158) relies on that invariant — it lowercases the haystack (`display_name`, `account_id`) and calls `contains(n)` without re-lowercasing the needle.
+`AuthorNeedle::NameSubstring(String)` in `src/cli/issue/changelog.rs` is documented as holding an already-lowercased string. `author_matches` relies on that invariant — it lowercases the haystack (`display_name`, `account_id`) and calls `contains(n)` without re-lowercasing the needle.
 
 Today the invariant is upheld only by convention: `classify_author` is the sole constructor of the `NameSubstring` variant, and it always lowercases. Nothing stops a future contributor from writing `AuthorNeedle::NameSubstring(raw.to_string())` elsewhere in the module; the compiler will not object, and the resulting case-mismatch bug would be silent (matches would simply fail for mixed-case names).
 
@@ -24,28 +24,32 @@ Move the lowercase invariant from convention to the type system so the compiler 
 
 ### `LoweredStr` newtype
 
-Add a module-private wrapper whose only constructor lowercases its input:
+Define the wrapper inside a nested private module so that the inner tuple field is not reachable from `changelog.rs` itself. That makes `LoweredStr::new` the *only* construction path — not just for external callers, but for code inside this same file — and the compiler therefore enforces the lowercase invariant fully.
 
 ```rust
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct LoweredStr(String);
+mod lowered_str {
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(super) struct LoweredStr(String);
 
-impl LoweredStr {
-    fn new(s: &str) -> Self {
-        Self(s.to_lowercase())
+    impl LoweredStr {
+        pub(super) fn new(s: &str) -> Self {
+            Self(s.to_lowercase())
+        }
+
+        pub(super) fn as_str(&self) -> &str {
+            &self.0
+        }
     }
 
-    fn as_str(&self) -> &str {
-        &self.0
+    impl std::ops::Deref for LoweredStr {
+        type Target = str;
+        fn deref(&self) -> &str {
+            &self.0
+        }
     }
 }
 
-impl std::ops::Deref for LoweredStr {
-    type Target = str;
-    fn deref(&self) -> &str {
-        &self.0
-    }
-}
+use lowered_str::LoweredStr;
 ```
 
 Both `Deref<Target = str>` and an explicit `as_str(&self) -> &str` are implemented — the standard Rust newtype pattern, mirroring `String::as_str` and `OsStr::as_str`. `Deref` enables coercion in generic/method-call contexts (e.g. `lowered.len()`); `as_str()` is used at explicit-conversion call sites where clarity matters more than brevity.
@@ -83,7 +87,7 @@ impl AuthorNeedle {
 
 The existing free function `classify_author` becomes the associated function `AuthorNeedle::from_raw`; its body is unchanged.
 
-The explicit `AuthorNeedle::AccountId(...)` construction in `handle` (currently `src/cli/issue/changelog.rs:43-45`, used for the resolved "me" accountId) stays as-is — accountIds are case-sensitive, so there is no invariant to enforce for that variant.
+The explicit `AuthorNeedle::AccountId(...)` construction in `handle` (used for the resolved "me" accountId) stays as-is — accountIds are case-sensitive, so there is no invariant to enforce for that variant.
 
 ### Why A+B hybrid, not A alone or B alone
 
@@ -91,17 +95,19 @@ The explicit `AuthorNeedle::AccountId(...)` construction in `handle` (currently 
 - **A alone (newtype without rename)** gives type enforcement but leaves the awkwardly-named `classify_author` free function. Renaming it to `AuthorNeedle::from_raw` costs one line and makes the API self-explanatory.
 - **A+B hybrid** gets both wins for ~15 LoC more than either option alone.
 
+The newtype is further encapsulated inside a nested private submodule (`mod lowered_str`) so that the tuple field is not accessible from `changelog.rs`. Without that nesting, same-module code — including tests — could still call `LoweredStr("UPPER".into())` directly and bypass `::new`, leaving the invariant enforced only by in-file convention. The submodule closes that gap at compile time.
+
 ## Files touched
 
 | File | Change |
 |------|--------|
-| `src/cli/issue/changelog.rs` | Add `LoweredStr`; change `NameSubstring(String)` → `NameSubstring(LoweredStr)`; rename `classify_author` → `AuthorNeedle::from_raw`; update `author_matches` to call `contains(n.as_str())`; update unit tests to compare via `s.as_str()`. |
+| `src/cli/issue/changelog.rs` | Add `mod lowered_str { struct LoweredStr ... }` submodule with `pub(super)` surface; change `NameSubstring(String)` → `NameSubstring(LoweredStr)`; rename `classify_author` → `AuthorNeedle::from_raw`; update `author_matches` to call `contains(n.as_str())`; update unit tests to compare via `s.as_str()`. |
 
 No other files change. The enum and all related items remain module-private to `changelog.rs`.
 
 ## Test strategy
 
-The 8 existing unit tests in `src/cli/issue/changelog.rs` (`classify_author_*`) already cover the heuristic's behavior:
+The 10 existing unit tests in `src/cli/issue/changelog.rs` (`classify_author_*`) already cover the heuristic's behavior:
 
 - Short name → substring
 - Colon → accountId
@@ -119,8 +125,11 @@ They need mechanical updates:
 - Call `AuthorNeedle::from_raw(...)` instead of `classify_author(...)`
 - Compare the `NameSubstring` inner via `s.as_str()` instead of direct `String` equality
 
-Behavior is unchanged, so no new test cases are added. A single new assertion that `LoweredStr::new("MixedCase")` produces `"mixedcase"` is sufficient to pin the invariant (one or two lines added to the existing test block).
+Behavior is unchanged, so no new behavior-oriented test cases are needed. Two small unit tests are added to pin the newtype's type-level contract:
+
+- `lowered_str_normalizes_input_on_construction` — asserts `LoweredStr::new("MixedCase-Name").as_str() == "mixedcase-name"`.
+- `lowered_str_equality_is_case_invariant` — asserts `LoweredStr::new("Alice") == LoweredStr::new("alice")`, exercising the derived `PartialEq`/`Eq`.
 
 ## Rollout
 
-Single commit, single file. No migration concerns — the type is module-private and has no public API surface.
+Single commit, single file. No migration concerns — the type is confined to a nested private submodule and has no public API surface.

--- a/docs/specs/author-needle-smart-constructor.md
+++ b/docs/specs/author-needle-smart-constructor.md
@@ -6,9 +6,9 @@
 
 ## Problem
 
-`AuthorNeedle::NameSubstring(String)` in `src/cli/issue/changelog.rs` is documented as holding an already-lowercased string. `author_matches` relies on that invariant — it lowercases the haystack (`display_name`, `account_id`) and calls `contains(n)` without re-lowercasing the needle.
+`AuthorNeedle::NameSubstring(String)` in `src/cli/issue/changelog.rs` was documented as holding an already-lowercased string. `author_matches` relied on that invariant — it lowercased the haystack (`display_name`, `account_id`) and called `contains(n)` without re-lowercasing the needle.
 
-Today the invariant is upheld only by convention: `classify_author` is the sole constructor of the `NameSubstring` variant, and it always lowercases. Nothing stops a future contributor from writing `AuthorNeedle::NameSubstring(raw.to_string())` elsewhere in the module; the compiler will not object, and the resulting case-mismatch bug would be silent (matches would simply fail for mixed-case names).
+Before this refactor, the invariant was upheld only by convention: `classify_author` was the sole constructor of the `NameSubstring` variant, and it always lowercased. Nothing stopped a future contributor from writing `AuthorNeedle::NameSubstring(raw.to_string())` elsewhere in the module; the compiler would not object, and the resulting case-mismatch bug would be silent (matches would simply fail for mixed-case names).
 
 ## Goal
 

--- a/docs/superpowers/plans/2026-04-19-author-needle-smart-constructor.md
+++ b/docs/superpowers/plans/2026-04-19-author-needle-smart-constructor.md
@@ -1,0 +1,382 @@
+# AuthorNeedle Smart-Constructor Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the lowercase invariant on `AuthorNeedle::NameSubstring` from convention to the type system via a `LoweredStr` newtype, and rename the classifier to a smart constructor `AuthorNeedle::from_raw`.
+
+**Architecture:** Add a module-private `LoweredStr(String)` newtype in `src/cli/issue/changelog.rs` whose only constructor lowercases. Change `NameSubstring(String)` to `NameSubstring(LoweredStr)` so the compiler rejects any construction that does not lowercase. Rename `classify_author` free function to the associated function `AuthorNeedle::from_raw`. Pure internal refactor — no user-facing behavior changes, no new integration tests; the existing 10 unit tests are the safety net.
+
+**Tech Stack:** Rust 2024 edition, stdlib only (`std::ops::Deref`). Existing test harness (unit tests inline in `changelog.rs`).
+
+---
+
+## Spec reference
+
+`docs/specs/author-needle-smart-constructor.md` — read before starting.
+
+## Task 1: Swap to `LoweredStr` newtype + rename to `from_raw`
+
+Land the full refactor in one atomic commit. Attempting to split — e.g. add `LoweredStr` first, then change the variant later — would either leave `LoweredStr` unused (clippy `dead_code`, which CLAUDE.md forbids suppressing) or require a broken-build intermediate commit.
+
+**Files:**
+- Modify: `src/cli/issue/changelog.rs` (current: 114–412)
+
+- [ ] **Step 1: Read the current state of the file**
+
+Open `src/cli/issue/changelog.rs` and read from line 1 to the end. The critical regions are:
+
+- Line 43–46: the `handle` function's `Some(raw) => Some(classify_author(raw))` path.
+- Line 114–120: the `AuthorNeedle` enum definition.
+- Line 122–148: the `classify_author` free function and its doc comment.
+- Line 150–158: the `author_matches` function — note `n` is used in `contains(n)` on line 155.
+- Line 256–412 (approximate): the `#[cfg(test)] mod tests` block containing the 10 `classify_author_*` unit tests and the `author_matches_*` tests.
+
+Identify every test that destructures `AuthorNeedle::NameSubstring(s)` and asserts on `s` — they will change from `assert_eq!(s, "alice")` (which relies on `String` equality with `&str`) to `assert_eq!(s.as_str(), "alice")`.
+
+- [ ] **Step 2: Write a failing unit test pinning the `LoweredStr` invariant**
+
+Append this test to the end of the existing `#[cfg(test)] mod tests { ... }` block in `src/cli/issue/changelog.rs` (find the last test before the closing brace of `mod tests`):
+
+```rust
+#[test]
+fn lowered_str_normalizes_input_on_construction() {
+    let lowered = LoweredStr::new("MixedCase-Name");
+    assert_eq!(lowered.as_str(), "mixedcase-name");
+}
+```
+
+- [ ] **Step 3: Run the test suite and verify the new test fails to compile**
+
+Run: `cargo test --lib -p jr-cli -- changelog::tests::lowered_str_normalizes_input_on_construction`
+
+Expected: compile error `cannot find type 'LoweredStr' in this scope` or similar. This confirms the type does not yet exist — the RED state.
+
+Do not proceed until the error is `LoweredStr`-related (not some other compile issue in the file).
+
+- [ ] **Step 4: Add the `LoweredStr` newtype**
+
+Insert this block in `src/cli/issue/changelog.rs` immediately before the `enum AuthorNeedle` definition (currently line 114). The exact location of the enum may shift by a line or two — insert before whatever line holds `enum AuthorNeedle`:
+
+```rust
+/// Module-private newtype guaranteeing its contents are lowercased.
+///
+/// Construction is the only lowercasing path — the compiler therefore
+/// enforces the invariant that `author_matches` relies on (haystack is
+/// lowercased, needle must already be lowercased).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LoweredStr(String);
+
+impl LoweredStr {
+    fn new(s: &str) -> Self {
+        Self(s.to_lowercase())
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for LoweredStr {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+```
+
+- [ ] **Step 5: Change the `NameSubstring` variant to carry `LoweredStr`**
+
+Replace the `AuthorNeedle` enum definition (currently line 114–120):
+
+```rust
+#[derive(Debug, Clone)]
+enum AuthorNeedle {
+    /// Exact accountId match (literal input or resolved from "me").
+    AccountId(String),
+    /// Case-insensitive substring match against `displayName` or `accountId`.
+    NameSubstring(String),
+}
+```
+
+With:
+
+```rust
+#[derive(Debug, Clone)]
+enum AuthorNeedle {
+    /// Exact accountId match (literal input or resolved from "me").
+    /// Case-sensitive — Jira accountIds are opaque identifiers.
+    AccountId(String),
+    /// Case-insensitive substring match against `displayName` or `accountId`.
+    /// The inner `LoweredStr` is always lowercased at construction time, so
+    /// `author_matches` can compare against a pre-lowercased haystack without
+    /// re-normalizing the needle.
+    NameSubstring(LoweredStr),
+}
+```
+
+- [ ] **Step 6: Convert `classify_author` to the associated function `AuthorNeedle::from_raw`**
+
+Replace the current free function (line 122–148):
+
+```rust
+/// Classify a user-supplied `--author` value. ...
+fn classify_author(raw: &str) -> AuthorNeedle {
+    let trimmed = raw.trim();
+    let looks_like_account_id = trimmed.contains(':')
+        || (trimmed.len() >= 12
+            && trimmed.chars().any(|c| c.is_ascii_digit())
+            && trimmed
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+    if looks_like_account_id {
+        AuthorNeedle::AccountId(trimmed.to_string())
+    } else {
+        AuthorNeedle::NameSubstring(trimmed.to_lowercase())
+    }
+}
+```
+
+With:
+
+```rust
+impl AuthorNeedle {
+    /// Classify a user-supplied `--author` value. A value is treated as an
+    /// accountId if it either contains a colon, or is ≥12 chars of
+    /// `[A-Za-z0-9_-]` containing at least one digit. Otherwise it is a
+    /// name substring.
+    ///
+    /// The API's accountId format varies (`public cloud` uses
+    /// `557058:...`-style strings; older formats are opaque 24+ char
+    /// hex-like blobs). Both documented formats guarantee digits, so the
+    /// digit requirement distinguishes them from long digit-free display
+    /// names like `AlexanderGreene` or `jean-pierre-dupont`. Residual
+    /// edge: a 12+ char single-word name that incidentally contains a
+    /// digit (e.g. `User12345Name`) still classifies as accountId; see
+    /// issue #213 for the rationale.
+    fn from_raw(raw: &str) -> Self {
+        let trimmed = raw.trim();
+        let looks_like_account_id = trimmed.contains(':')
+            || (trimmed.len() >= 12
+                && trimmed.chars().any(|c| c.is_ascii_digit())
+                && trimmed
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+        if looks_like_account_id {
+            Self::AccountId(trimmed.to_string())
+        } else {
+            Self::NameSubstring(LoweredStr::new(trimmed))
+        }
+    }
+}
+```
+
+Key differences from the old version:
+
+- It is now an `impl AuthorNeedle` associated function named `from_raw`, not a free function.
+- Variant constructors use `Self::` prefix.
+- The `NameSubstring` arm constructs via `LoweredStr::new(trimmed)` (which lowercases) instead of the bare `trimmed.to_lowercase()` string.
+
+- [ ] **Step 7: Update the single production caller of `classify_author`**
+
+In `src/cli/issue/changelog.rs` around line 46, the `handle` function has:
+
+```rust
+        Some(raw) => Some(classify_author(raw)),
+```
+
+Change it to:
+
+```rust
+        Some(raw) => Some(AuthorNeedle::from_raw(raw)),
+```
+
+- [ ] **Step 8: Update `author_matches` to call `.as_str()` on the needle**
+
+The current function (line 150–158) ends with:
+
+```rust
+        AuthorNeedle::NameSubstring(n) => {
+            a.display_name.to_lowercase().contains(n) || a.account_id.to_lowercase().contains(n)
+        }
+```
+
+where `n: &String`. Since `n` is now `&LoweredStr`, `contains` would require deref-coercion chains. Replace with the explicit form:
+
+```rust
+        AuthorNeedle::NameSubstring(n) => {
+            a.display_name.to_lowercase().contains(n.as_str())
+                || a.account_id.to_lowercase().contains(n.as_str())
+        }
+```
+
+- [ ] **Step 9: Update every existing unit test that calls `classify_author`**
+
+Find every occurrence of `classify_author(` in the `#[cfg(test)]` block and replace with `AuthorNeedle::from_raw(`. There are 10 such tests as of the current tree (names matching `classify_author_*`).
+
+Example — the test at line 259–263 currently reads:
+
+```rust
+    #[test]
+    fn classify_author_treats_short_name_as_substring() {
+        match classify_author("alice") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s, "alice"),
+            other => panic!("unexpected variant: {:?}", other),
+        }
+    }
+```
+
+Update it to:
+
+```rust
+    #[test]
+    fn classify_author_treats_short_name_as_substring() {
+        match AuthorNeedle::from_raw("alice") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "alice"),
+            other => panic!("unexpected variant: {:?}", other),
+        }
+    }
+```
+
+Two mechanical changes per `NameSubstring`-asserting test:
+
+1. `classify_author(...)` → `AuthorNeedle::from_raw(...)`
+2. `assert_eq!(s, "alice")` → `assert_eq!(s.as_str(), "alice")`
+
+Tests that destructure `AuthorNeedle::AccountId(s)` and assert on `s` do **not** need the `.as_str()` change — `AccountId` still holds a `String`, and `String == &str` comparison still works. Only the `classify_author` → `AuthorNeedle::from_raw` rename applies to them.
+
+The full list of tests to update (all in `src/cli/issue/changelog.rs`'s `mod tests`):
+
+- `classify_author_treats_short_name_as_substring` (NameSubstring — both changes)
+- `classify_author_treats_colon_string_as_accountid` (AccountId — rename only)
+- `classify_author_treats_long_hex_blob_as_accountid` (AccountId — rename only)
+- `classify_author_long_alpha_only_name_is_substring` (NameSubstring — both changes)
+- `classify_author_long_compound_name_is_substring` (NameSubstring — both changes)
+- `classify_author_long_hyphenated_name_is_substring` (NameSubstring — both changes)
+- `classify_author_old_hex_accountid_is_accountid` (AccountId — rename only)
+- `classify_author_colon_forces_accountid_regardless_of_heuristics` (AccountId — rename only)
+- `classify_author_long_name_with_digit_is_accountid` (AccountId — rename only)
+- `classify_author_short_hyphenated_name_is_substring` (NameSubstring — both changes)
+- `classify_author_unknown_placeholder_is_substring` (NameSubstring — both changes)
+
+- [ ] **Step 10: Update the `author_matches_null_author_always_false` test**
+
+This test (around line 375–381) constructs an `AuthorNeedle::NameSubstring` inline:
+
+```rust
+    #[test]
+    fn author_matches_null_author_always_false() {
+        assert!(!author_matches(
+            None,
+            &AuthorNeedle::NameSubstring("alice".into())
+        ));
+    }
+```
+
+`"alice".into()` previously produced a `String`. It must now produce a `LoweredStr`. The cleanest update is to go through the constructor:
+
+```rust
+    #[test]
+    fn author_matches_null_author_always_false() {
+        assert!(!author_matches(
+            None,
+            &AuthorNeedle::NameSubstring(LoweredStr::new("alice"))
+        ));
+    }
+```
+
+Any other test in the file that constructs `AuthorNeedle::NameSubstring(...)` directly needs the same treatment. After the edit, grep for `NameSubstring(` to confirm no raw-string constructions remain:
+
+```bash
+grep -n 'NameSubstring(' src/cli/issue/changelog.rs
+```
+
+Every match should either destructure in a pattern (`NameSubstring(s) =>`), use `LoweredStr::new(...)`, or be produced by `AuthorNeedle::from_raw(...)`.
+
+- [ ] **Step 11: Run `cargo fmt` and verify formatting**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+```
+
+Expected: second command exits 0 with no output.
+
+- [ ] **Step 12: Run `cargo clippy --all-targets -- -D warnings`**
+
+Run:
+
+```bash
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: exit 0 with no warnings. If clippy flags `as_str` as unused or `Deref` impl as unused, investigate before suppressing — CLAUDE.md forbids `#[allow]` lint suppression without explicit approval. `as_str` should be used by `author_matches` and the new unit test; `Deref` impls never trigger `dead_code`.
+
+If the target author_matches call site uses deref coercion naturally (e.g. `contains(&*n)`), clippy may or may not flag it depending on version; the plan commits to `n.as_str()` to sidestep that entirely.
+
+- [ ] **Step 13: Run the full test suite**
+
+Run:
+
+```bash
+cargo test
+```
+
+Expected: all tests pass (780+ as of the baseline). Pay specific attention to:
+
+- `lowered_str_normalizes_input_on_construction` — PASS (new test, the RED → GREEN transition)
+- All 10 `classify_author_*` tests — PASS
+- `author_matches_respects_account_id_exact` — PASS
+- `author_matches_null_author_always_false` — PASS
+
+If any test fails, read the failure output carefully. The most likely cause is a missed spot in Step 9 or Step 10 where a test still references `classify_author(...)` or constructs `NameSubstring("...".into())` expecting `String`.
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add src/cli/issue/changelog.rs
+git commit -m "$(cat <<'EOF'
+refactor(changelog): LoweredStr newtype + AuthorNeedle::from_raw (#215)
+
+Move the lowercase invariant on AuthorNeedle::NameSubstring from
+convention to the type system via a module-private LoweredStr(String)
+newtype whose only constructor lowercases. Rename the classifier free
+function classify_author to the smart-constructor associated function
+AuthorNeedle::from_raw.
+
+Pure internal refactor — no user-facing behavior change. All 10
+existing classify_author_* unit tests still pass unchanged in intent
+(mechanically updated to the new type and name).
+EOF
+)"
+```
+
+---
+
+## Self-review checklist (controller runs this before dispatching Task 1)
+
+**Spec coverage:**
+
+- ✅ `LoweredStr(String)` newtype with private constructor — Step 4.
+- ✅ `Deref<Target = str>` and `as_str(&self) -> &str` — Step 4.
+- ✅ `#[derive(Debug, Clone, PartialEq, Eq)]` — Step 4.
+- ✅ `NameSubstring(String)` → `NameSubstring(LoweredStr)` — Step 5.
+- ✅ `classify_author` renamed to `AuthorNeedle::from_raw` — Step 6.
+- ✅ Heuristic body unchanged — Step 6.
+- ✅ Single production caller updated — Step 7.
+- ✅ `author_matches` uses `n.as_str()` — Step 8.
+- ✅ All 10 unit tests updated — Steps 9 & 10.
+- ✅ One new test for `LoweredStr::new` lowercase invariant — Step 2.
+- ✅ No new integration tests (spec says not needed).
+- ✅ `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` + `cargo test` all run — Steps 11–13.
+
+**Type consistency:**
+
+- `LoweredStr::new(&str) -> Self` used in Step 4 definition and Steps 6, 10 constructors.
+- `LoweredStr::as_str(&self) -> &str` used in Step 8 and Step 9.
+- `AuthorNeedle::from_raw(raw: &str) -> Self` signature consistent across Steps 6, 7, 9.
+
+**Placeholder scan:** No TBD, TODO, or "implement later" markers present.
+
+**Scope:** Single task because variant type + all callers + all tests must update atomically to keep the build green. Splitting creates either unused-code lint violations (forbidden) or broken-build intermediate commits.

--- a/docs/superpowers/plans/2026-04-19-author-needle-smart-constructor.md
+++ b/docs/superpowers/plans/2026-04-19-author-needle-smart-constructor.md
@@ -4,7 +4,7 @@
 
 **Goal:** Move the lowercase invariant on `AuthorNeedle::NameSubstring` from convention to the type system via a `LoweredStr` newtype, and rename the classifier to a smart constructor `AuthorNeedle::from_raw`.
 
-**Architecture:** Add a `LoweredStr(String)` newtype inside a nested private submodule `mod lowered_str` in `src/cli/issue/changelog.rs`, so the tuple field is unreachable from the parent module and `::new` is the only construction path the compiler will accept. Change `NameSubstring(String)` to `NameSubstring(LoweredStr)` so every `NameSubstring` value is lowercased by construction. Rename `classify_author` free function to the associated function `AuthorNeedle::from_raw`. Pure internal refactor — no user-facing behavior changes, no new integration tests; the existing 10 unit tests are the safety net.
+**Architecture:** Add a `LoweredStr(String)` newtype inside a nested private submodule `mod lowered_str` in `src/cli/issue/changelog.rs`, so the tuple field is unreachable from the parent module and `::new` is the only construction path the compiler will accept. Change `NameSubstring(String)` to `NameSubstring(LoweredStr)` so every `NameSubstring` value is lowercased by construction. Rename `classify_author` free function to the associated function `AuthorNeedle::from_raw`. Pure internal refactor — no user-facing behavior changes, no new integration tests; the existing 11 unit tests are the safety net.
 
 **Tech Stack:** Rust 2024 edition, stdlib only (`std::ops::Deref`). Existing test harness (unit tests inline in `changelog.rs`).
 
@@ -29,7 +29,7 @@ Open `src/cli/issue/changelog.rs` and read from line 1 to the end. The critical 
 - Line 114–120: the `AuthorNeedle` enum definition.
 - Line 122–148: the `classify_author` free function and its doc comment.
 - Line 150–158: the `author_matches` function — note `n` is used in `contains(n)` on line 155.
-- Line 256–412 (approximate): the `#[cfg(test)] mod tests` block containing the 10 `classify_author_*` unit tests and the `author_matches_*` tests.
+- Line 256–412 (approximate): the `#[cfg(test)] mod tests` block containing the 11 `from_raw_*` unit tests and the `author_matches_*` tests.
 
 Identify every test that destructures `AuthorNeedle::NameSubstring(s)` and asserts on `s` — they will change from `assert_eq!(s, "alice")` (which relies on `String` equality with `&str`) to `assert_eq!(s.as_str(), "alice")`.
 
@@ -47,7 +47,7 @@ fn lowered_str_normalizes_input_on_construction() {
 
 - [ ] **Step 3: Run the test suite and verify the new test fails to compile**
 
-Run: `cargo test --lib -p jr-cli -- changelog::tests::lowered_str_normalizes_input_on_construction`
+Run: `cargo test --lib -p jr -- changelog::tests::lowered_str_normalizes_input_on_construction`
 
 Expected: compile error `cannot find type 'LoweredStr' in this scope` or similar. This confirms the type does not yet exist — the RED state.
 
@@ -216,13 +216,13 @@ where `n: &String`. Since `n` is now `&LoweredStr`, `contains` would require der
 
 - [ ] **Step 9: Update every existing unit test that calls `classify_author`**
 
-Find every occurrence of `classify_author(` in the `#[cfg(test)]` block and replace with `AuthorNeedle::from_raw(`. There are 10 such tests as of the current tree (names matching `classify_author_*`).
+Find every occurrence of `classify_author(` in the `#[cfg(test)]` block and replace with `AuthorNeedle::from_raw(`. There are 11 such tests as of the current tree (names matching `from_raw_*`).
 
 Example — the test at line 259–263 currently reads:
 
 ```rust
     #[test]
-    fn classify_author_treats_short_name_as_substring() {
+    fn from_raw_treats_short_name_as_substring() {
         match classify_author("alice") {
             AuthorNeedle::NameSubstring(s) => assert_eq!(s, "alice"),
             other => panic!("unexpected variant: {:?}", other),
@@ -234,7 +234,7 @@ Update it to:
 
 ```rust
     #[test]
-    fn classify_author_treats_short_name_as_substring() {
+    fn from_raw_treats_short_name_as_substring() {
         match AuthorNeedle::from_raw("alice") {
             AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "alice"),
             other => panic!("unexpected variant: {:?}", other),
@@ -251,17 +251,17 @@ Tests that destructure `AuthorNeedle::AccountId(s)` and assert on `s` do **not**
 
 The full list of tests to update (all in `src/cli/issue/changelog.rs`'s `mod tests`):
 
-- `classify_author_treats_short_name_as_substring` (NameSubstring — both changes)
-- `classify_author_treats_colon_string_as_accountid` (AccountId — rename only)
-- `classify_author_treats_long_hex_blob_as_accountid` (AccountId — rename only)
-- `classify_author_long_alpha_only_name_is_substring` (NameSubstring — both changes)
-- `classify_author_long_compound_name_is_substring` (NameSubstring — both changes)
-- `classify_author_long_hyphenated_name_is_substring` (NameSubstring — both changes)
-- `classify_author_old_hex_accountid_is_accountid` (AccountId — rename only)
-- `classify_author_colon_forces_accountid_regardless_of_heuristics` (AccountId — rename only)
-- `classify_author_long_name_with_digit_is_accountid` (AccountId — rename only)
-- `classify_author_short_hyphenated_name_is_substring` (NameSubstring — both changes)
-- `classify_author_unknown_placeholder_is_substring` (NameSubstring — both changes)
+- `from_raw_treats_short_name_as_substring` (NameSubstring — both changes)
+- `from_raw_treats_colon_string_as_accountid` (AccountId — rename only)
+- `from_raw_treats_long_hex_blob_as_accountid` (AccountId — rename only)
+- `from_raw_long_alpha_only_name_is_substring` (NameSubstring — both changes)
+- `from_raw_long_compound_name_is_substring` (NameSubstring — both changes)
+- `from_raw_long_hyphenated_name_is_substring` (NameSubstring — both changes)
+- `from_raw_old_hex_accountid_is_accountid` (AccountId — rename only)
+- `from_raw_colon_forces_accountid_regardless_of_heuristics` (AccountId — rename only)
+- `from_raw_long_name_with_digit_is_accountid` (AccountId — rename only)
+- `from_raw_short_hyphenated_name_is_substring` (NameSubstring — both changes)
+- `from_raw_unknown_placeholder_is_substring` (NameSubstring — both changes)
 
 - [ ] **Step 10: Update the `author_matches_null_author_always_false` test**
 
@@ -331,7 +331,7 @@ cargo test
 Expected: all tests pass (780+ as of the baseline). Pay specific attention to:
 
 - `lowered_str_normalizes_input_on_construction` — PASS (new test, the RED → GREEN transition)
-- All 10 `classify_author_*` tests — PASS
+- All 11 `from_raw_*` tests — PASS
 - `author_matches_respects_account_id_exact` — PASS
 - `author_matches_null_author_always_false` — PASS
 
@@ -351,7 +351,7 @@ function classify_author to the smart-constructor associated function
 AuthorNeedle::from_raw.
 
 Pure internal refactor — no user-facing behavior change. All 10
-existing classify_author_* unit tests still pass unchanged in intent
+existing from_raw_* unit tests still pass unchanged in intent
 (mechanically updated to the new type and name).
 EOF
 )"
@@ -371,7 +371,7 @@ EOF
 - ✅ Heuristic body unchanged — Step 6.
 - ✅ Single production caller updated — Step 7.
 - ✅ `author_matches` uses `n.as_str()` — Step 8.
-- ✅ All 10 unit tests updated — Steps 9 & 10.
+- ✅ All 11 unit tests updated — Steps 9 & 10.
 - ✅ One new test for `LoweredStr::new` lowercase invariant — Step 2.
 - ✅ No new integration tests (spec says not needed).
 - ✅ `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` + `cargo test` all run — Steps 11–13.

--- a/docs/superpowers/plans/2026-04-19-author-needle-smart-constructor.md
+++ b/docs/superpowers/plans/2026-04-19-author-needle-smart-constructor.md
@@ -19,17 +19,17 @@
 Land the full refactor in one atomic commit. Attempting to split — e.g. add `LoweredStr` first, then change the variant later — would either leave `LoweredStr` unused (clippy `dead_code`, which CLAUDE.md forbids suppressing) or require a broken-build intermediate commit.
 
 **Files:**
-- Modify: `src/cli/issue/changelog.rs` (current: 114–412)
+- Modify: `src/cli/issue/changelog.rs`
 
 - [ ] **Step 1: Read the current state of the file**
 
-Open `src/cli/issue/changelog.rs` and read from line 1 to the end. The critical regions are:
+Open `src/cli/issue/changelog.rs` and read from top to bottom. The critical regions are:
 
-- Line 43–46: the `handle` function's `Some(raw) => Some(classify_author(raw))` path.
-- Line 114–120: the `AuthorNeedle` enum definition.
-- Line 122–148: the `classify_author` free function and its doc comment.
-- Line 150–158: the `author_matches` function — note `n` is used in `contains(n)` on line 155.
-- Line 256–412 (approximate): the `#[cfg(test)] mod tests` block containing the 11 `from_raw_*` unit tests and the `author_matches_*` tests.
+- The `handle` function branch that maps raw author input into an `AuthorNeedle` (the `Some(raw) => Some(classify_author(raw))` path on the pre-refactor tree).
+- The `AuthorNeedle` enum definition.
+- The `classify_author` free function, which will become the associated smart constructor `AuthorNeedle::from_raw`, along with its doc comment.
+- The `author_matches` function — note where the `NameSubstring` payload is passed into `contains(...)`.
+- The `#[cfg(test)] mod tests` block near the end of the file containing the 11 heuristic unit tests (pre-refactor named `classify_author_*`, renamed in Step 9 to `from_raw_*`) and the `author_matches_*` tests.
 
 Identify every test that destructures `AuthorNeedle::NameSubstring(s)` and asserts on `s` — they will change from `assert_eq!(s, "alice")` (which relies on `String` equality with `&str`) to `assert_eq!(s.as_str(), "alice")`.
 
@@ -91,7 +91,7 @@ use lowered_str::LoweredStr;
 
 - [ ] **Step 5: Change the `NameSubstring` variant to carry `LoweredStr`**
 
-Replace the `AuthorNeedle` enum definition (currently line 114–120):
+Replace the `AuthorNeedle` enum definition:
 
 ```rust
 #[derive(Debug, Clone)]
@@ -121,7 +121,7 @@ enum AuthorNeedle {
 
 - [ ] **Step 6: Convert `classify_author` to the associated function `AuthorNeedle::from_raw`**
 
-Replace the current free function (line 122–148):
+Replace the current free function:
 
 ```rust
 /// Classify a user-supplied `--author` value. ...
@@ -183,7 +183,7 @@ Key differences from the old version:
 
 - [ ] **Step 7: Update the single production caller of `classify_author`**
 
-In `src/cli/issue/changelog.rs` around line 46, the `handle` function has:
+In `src/cli/issue/changelog.rs`, the `handle` function has:
 
 ```rust
         Some(raw) => Some(classify_author(raw)),
@@ -197,7 +197,7 @@ Change it to:
 
 - [ ] **Step 8: Update `author_matches` to call `.as_str()` on the needle**
 
-The current function (line 150–158) ends with:
+The current function ends with:
 
 ```rust
         AuthorNeedle::NameSubstring(n) => {
@@ -218,7 +218,7 @@ where `n: &String`. Since `n` is now `&LoweredStr`, `contains` would require der
 
 Find every occurrence of `classify_author(` in the `#[cfg(test)]` block and replace with `AuthorNeedle::from_raw(`. There are 11 such tests as of the current tree (names matching `from_raw_*`).
 
-Example — the test at line 259–263 currently reads:
+Example — the `classify_author_treats_short_name_as_substring` test currently reads:
 
 ```rust
     #[test]
@@ -265,7 +265,7 @@ The full list of tests to update (all in `src/cli/issue/changelog.rs`'s `mod tes
 
 - [ ] **Step 10: Update the `author_matches_null_author_always_false` test**
 
-This test (around line 375–381) constructs an `AuthorNeedle::NameSubstring` inline:
+This test constructs an `AuthorNeedle::NameSubstring` inline:
 
 ```rust
     #[test]

--- a/docs/superpowers/plans/2026-04-19-author-needle-smart-constructor.md
+++ b/docs/superpowers/plans/2026-04-19-author-needle-smart-constructor.md
@@ -4,7 +4,7 @@
 
 **Goal:** Move the lowercase invariant on `AuthorNeedle::NameSubstring` from convention to the type system via a `LoweredStr` newtype, and rename the classifier to a smart constructor `AuthorNeedle::from_raw`.
 
-**Architecture:** Add a module-private `LoweredStr(String)` newtype in `src/cli/issue/changelog.rs` whose only constructor lowercases. Change `NameSubstring(String)` to `NameSubstring(LoweredStr)` so the compiler rejects any construction that does not lowercase. Rename `classify_author` free function to the associated function `AuthorNeedle::from_raw`. Pure internal refactor — no user-facing behavior changes, no new integration tests; the existing 10 unit tests are the safety net.
+**Architecture:** Add a `LoweredStr(String)` newtype inside a nested private submodule `mod lowered_str` in `src/cli/issue/changelog.rs`, so the tuple field is unreachable from the parent module and `::new` is the only construction path the compiler will accept. Change `NameSubstring(String)` to `NameSubstring(LoweredStr)` so every `NameSubstring` value is lowercased by construction. Rename `classify_author` free function to the associated function `AuthorNeedle::from_raw`. Pure internal refactor — no user-facing behavior changes, no new integration tests; the existing 10 unit tests are the safety net.
 
 **Tech Stack:** Rust 2024 edition, stdlib only (`std::ops::Deref`). Existing test harness (unit tests inline in `changelog.rs`).
 
@@ -53,35 +53,40 @@ Expected: compile error `cannot find type 'LoweredStr' in this scope` or similar
 
 Do not proceed until the error is `LoweredStr`-related (not some other compile issue in the file).
 
-- [ ] **Step 4: Add the `LoweredStr` newtype**
+- [ ] **Step 4: Add the `LoweredStr` newtype inside a private submodule**
 
-Insert this block in `src/cli/issue/changelog.rs` immediately before the `enum AuthorNeedle` definition (currently line 114). The exact location of the enum may shift by a line or two — insert before whatever line holds `enum AuthorNeedle`:
+Insert this block in `src/cli/issue/changelog.rs` immediately before the `enum AuthorNeedle` definition. Keeping `LoweredStr` inside a nested `mod lowered_str` makes the tuple-struct field unreachable from the parent (`changelog.rs`), so `LoweredStr::new` is the only construction path even for same-file code — the compiler enforces the lowercase invariant fully.
 
 ```rust
-/// Module-private newtype guaranteeing its contents are lowercased.
-///
-/// Construction is the only lowercasing path — the compiler therefore
-/// enforces the invariant that `author_matches` relies on (haystack is
-/// lowercased, needle must already be lowercased).
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct LoweredStr(String);
+/// Private submodule so the `LoweredStr` tuple field is not reachable
+/// from the rest of `changelog.rs`. `::new` therefore becomes the only
+/// construction path, and the compiler enforces the lowercase invariant
+/// that `author_matches` relies on: needle is lowercased at
+/// construction, haystack is lowercased at match time, so `contains`
+/// is sound without re-normalizing the needle.
+mod lowered_str {
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(super) struct LoweredStr(String);
 
-impl LoweredStr {
-    fn new(s: &str) -> Self {
-        Self(s.to_lowercase())
+    impl LoweredStr {
+        pub(super) fn new(s: &str) -> Self {
+            Self(s.to_lowercase())
+        }
+
+        pub(super) fn as_str(&self) -> &str {
+            &self.0
+        }
     }
 
-    fn as_str(&self) -> &str {
-        &self.0
+    impl std::ops::Deref for LoweredStr {
+        type Target = str;
+        fn deref(&self) -> &str {
+            &self.0
+        }
     }
 }
 
-impl std::ops::Deref for LoweredStr {
-    type Target = str;
-    fn deref(&self) -> &str {
-        &self.0
-    }
-}
+use lowered_str::LoweredStr;
 ```
 
 - [ ] **Step 5: Change the `NameSubstring` variant to carry `LoweredStr`**
@@ -107,9 +112,9 @@ enum AuthorNeedle {
     /// Case-sensitive — Jira accountIds are opaque identifiers.
     AccountId(String),
     /// Case-insensitive substring match against `displayName` or `accountId`.
-    /// The inner `LoweredStr` is always lowercased at construction time, so
-    /// `author_matches` can compare against a pre-lowercased haystack without
-    /// re-normalizing the needle.
+    /// The inner `LoweredStr` is lowercased at construction time, so
+    /// `author_matches` lowercases the haystack at match time and compares
+    /// directly without also re-normalizing the needle.
     NameSubstring(LoweredStr),
 }
 ```

--- a/docs/superpowers/plans/2026-04-19-author-needle-smart-constructor.md
+++ b/docs/superpowers/plans/2026-04-19-author-needle-smart-constructor.md
@@ -350,7 +350,7 @@ newtype whose only constructor lowercases. Rename the classifier free
 function classify_author to the smart-constructor associated function
 AuthorNeedle::from_raw.
 
-Pure internal refactor — no user-facing behavior change. All 10
+Pure internal refactor — no user-facing behavior change. All 11
 existing from_raw_* unit tests still pass unchanged in intent
 (mechanically updated to the new type and name).
 EOF

--- a/src/cli/issue/changelog.rs
+++ b/src/cli/issue/changelog.rs
@@ -111,11 +111,13 @@ pub(super) async fn handle(
     Ok(())
 }
 
-/// Module-private newtype guaranteeing its contents are lowercased.
-///
-/// Construction is the only lowercasing path — the compiler therefore
-/// enforces the invariant that `author_matches` relies on (haystack is
-/// lowercased, needle must already be lowercased).
+/// Module-private newtype whose `::new` constructor is the only
+/// lowercasing path. The type is kept module-private so outside
+/// callers cannot construct it at all; within this module every
+/// construction goes through `LoweredStr::new` by convention. Together
+/// this carries the invariant that `author_matches` relies on: needle
+/// is lowercased at construction, haystack is lowercased at match
+/// time, so `contains` is sound without re-normalizing the needle.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct LoweredStr(String);
 
@@ -142,9 +144,9 @@ enum AuthorNeedle {
     /// Case-sensitive — Jira accountIds are opaque identifiers.
     AccountId(String),
     /// Case-insensitive substring match against `displayName` or `accountId`.
-    /// The inner `LoweredStr` is always lowercased at construction time, so
-    /// `author_matches` can compare against a pre-lowercased haystack without
-    /// re-normalizing the needle.
+    /// The inner `LoweredStr` is lowercased at construction time, so
+    /// `author_matches` lowercases the haystack at match time and compares
+    /// directly without also re-normalizing the needle.
     NameSubstring(LoweredStr),
 }
 
@@ -615,6 +617,11 @@ mod tests {
     fn lowered_str_normalizes_input_on_construction() {
         let lowered = LoweredStr::new("MixedCase-Name");
         assert_eq!(lowered.as_str(), "mixedcase-name");
+    }
+
+    #[test]
+    fn lowered_str_equality_is_case_invariant() {
+        assert_eq!(LoweredStr::new("Alice"), LoweredStr::new("alice"));
     }
 
     #[test]

--- a/src/cli/issue/changelog.rs
+++ b/src/cli/issue/changelog.rs
@@ -293,7 +293,7 @@ mod tests {
     use crate::types::jira::{ChangelogItem, User};
 
     #[test]
-    fn classify_author_treats_short_name_as_substring() {
+    fn from_raw_treats_short_name_as_substring() {
         match AuthorNeedle::from_raw("alice") {
             AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "alice"),
             other => panic!("expected NameSubstring, got {other:?}"),
@@ -301,7 +301,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_author_treats_colon_string_as_accountid() {
+    fn from_raw_treats_colon_string_as_accountid() {
         match AuthorNeedle::from_raw("557058:abc-123") {
             AuthorNeedle::AccountId(s) => assert_eq!(s, "557058:abc-123"),
             other => panic!("expected AccountId, got {other:?}"),
@@ -309,7 +309,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_author_treats_long_hex_blob_as_accountid() {
+    fn from_raw_treats_long_hex_blob_as_accountid() {
         match AuthorNeedle::from_raw("abcdef0123456789deadbeef") {
             AuthorNeedle::AccountId(s) => assert_eq!(s, "abcdef0123456789deadbeef"),
             other => panic!("expected AccountId, got {other:?}"),
@@ -317,7 +317,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_author_long_alpha_only_name_is_substring() {
+    fn from_raw_long_alpha_only_name_is_substring() {
         // 15 chars, no digits — regression guard for #213.
         match AuthorNeedle::from_raw("AlexanderGreene") {
             AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "alexandergreene"),
@@ -326,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_author_long_compound_name_is_substring() {
+    fn from_raw_long_compound_name_is_substring() {
         // 18 chars, no digits — regression guard for #213.
         match AuthorNeedle::from_raw("JoseMariaRodriguez") {
             AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "josemariarodriguez"),
@@ -335,7 +335,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_author_long_hyphenated_name_is_substring() {
+    fn from_raw_long_hyphenated_name_is_substring() {
         // 18 chars with dashes, no digits — regression guard for #213.
         match AuthorNeedle::from_raw("jean-pierre-dupont") {
             AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "jean-pierre-dupont"),
@@ -344,7 +344,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_author_old_hex_accountid_is_accountid() {
+    fn from_raw_old_hex_accountid_is_accountid() {
         // 24-char hex — contains digits, no colon.
         match AuthorNeedle::from_raw("5b10ac8d82e05b22cc7d4ef5") {
             AuthorNeedle::AccountId(s) => assert_eq!(s, "5b10ac8d82e05b22cc7d4ef5"),
@@ -353,7 +353,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_author_colon_forces_accountid_regardless_of_heuristics() {
+    fn from_raw_colon_forces_accountid_regardless_of_heuristics() {
         // Colon wins the branch regardless of length/digits.
         match AuthorNeedle::from_raw("557058:f58131cb-b67d-43c7") {
             AuthorNeedle::AccountId(s) => assert_eq!(s, "557058:f58131cb-b67d-43c7"),
@@ -362,7 +362,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_author_long_name_with_digit_is_accountid() {
+    fn from_raw_long_name_with_digit_is_accountid() {
         // 13 chars with a digit — documented residual edge. Stays AccountId.
         match AuthorNeedle::from_raw("User12345Name") {
             AuthorNeedle::AccountId(s) => assert_eq!(s, "User12345Name"),
@@ -371,7 +371,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_author_short_hyphenated_name_is_substring() {
+    fn from_raw_short_hyphenated_name_is_substring() {
         // 11 chars — below the length gate, unaffected by the digit rule.
         match AuthorNeedle::from_raw("jean-pierre") {
             AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "jean-pierre"),
@@ -380,7 +380,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_author_unknown_placeholder_is_substring() {
+    fn from_raw_unknown_placeholder_is_substring() {
         // 7-char "unknown" — the Jira stub for deleted/migrated users.
         // Below the length gate; NameSubstring path already matches it
         // via case-insensitive account_id containment.

--- a/src/cli/issue/changelog.rs
+++ b/src/cli/issue/changelog.rs
@@ -111,32 +111,35 @@ pub(super) async fn handle(
     Ok(())
 }
 
-/// Module-private newtype whose `::new` constructor is the only
-/// lowercasing path. The type is kept module-private so outside
-/// callers cannot construct it at all; within this module every
-/// construction goes through `LoweredStr::new` by convention. Together
-/// this carries the invariant that `author_matches` relies on: needle
-/// is lowercased at construction, haystack is lowercased at match
-/// time, so `contains` is sound without re-normalizing the needle.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct LoweredStr(String);
+/// Private submodule so the `LoweredStr` tuple field is not reachable
+/// from the rest of `changelog.rs`. `::new` therefore becomes the only
+/// construction path, and the compiler enforces the lowercase invariant
+/// that `author_matches` relies on: needle is lowercased at
+/// construction, haystack is lowercased at match time, so `contains`
+/// is sound without re-normalizing the needle.
+mod lowered_str {
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub(super) struct LoweredStr(String);
 
-impl LoweredStr {
-    fn new(s: &str) -> Self {
-        Self(s.to_lowercase())
+    impl LoweredStr {
+        pub(super) fn new(s: &str) -> Self {
+            Self(s.to_lowercase())
+        }
+
+        pub(super) fn as_str(&self) -> &str {
+            &self.0
+        }
     }
 
-    fn as_str(&self) -> &str {
-        &self.0
+    impl std::ops::Deref for LoweredStr {
+        type Target = str;
+        fn deref(&self) -> &str {
+            &self.0
+        }
     }
 }
 
-impl std::ops::Deref for LoweredStr {
-    type Target = str;
-    fn deref(&self) -> &str {
-        &self.0
-    }
-}
+use lowered_str::LoweredStr;
 
 #[derive(Debug, Clone)]
 enum AuthorNeedle {

--- a/src/cli/issue/changelog.rs
+++ b/src/cli/issue/changelog.rs
@@ -43,7 +43,7 @@ pub(super) async fn handle(
         Some(raw) if helpers::is_me_keyword(raw) => Some(AuthorNeedle::AccountId(
             client.get_myself().await?.account_id,
         )),
-        Some(raw) => Some(classify_author(raw)),
+        Some(raw) => Some(AuthorNeedle::from_raw(raw)),
         None => None,
     };
 
@@ -111,39 +111,70 @@ pub(super) async fn handle(
     Ok(())
 }
 
+/// Module-private newtype guaranteeing its contents are lowercased.
+///
+/// Construction is the only lowercasing path — the compiler therefore
+/// enforces the invariant that `author_matches` relies on (haystack is
+/// lowercased, needle must already be lowercased).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LoweredStr(String);
+
+impl LoweredStr {
+    fn new(s: &str) -> Self {
+        Self(s.to_lowercase())
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for LoweredStr {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
 #[derive(Debug, Clone)]
 enum AuthorNeedle {
     /// Exact accountId match (literal input or resolved from "me").
+    /// Case-sensitive — Jira accountIds are opaque identifiers.
     AccountId(String),
     /// Case-insensitive substring match against `displayName` or `accountId`.
-    NameSubstring(String),
+    /// The inner `LoweredStr` is always lowercased at construction time, so
+    /// `author_matches` can compare against a pre-lowercased haystack without
+    /// re-normalizing the needle.
+    NameSubstring(LoweredStr),
 }
 
-/// Classify a user-supplied `--author` value. We treat a value as an
-/// accountId if it either contains a colon, or is ≥12 chars of
-/// `[A-Za-z0-9_-]` containing at least one digit. Otherwise it's a
-/// name substring.
-///
-/// The API's accountId format varies (`public cloud` uses
-/// `557058:...`-style strings; older formats are opaque 24+ char
-/// hex-like blobs). Both documented formats guarantee digits, so the
-/// digit requirement distinguishes them from long digit-free display
-/// names like `AlexanderGreene` or `jean-pierre-dupont`. Residual
-/// edge: a 12+ char single-word name that incidentally contains a
-/// digit (e.g. `User12345Name`) still classifies as accountId; see
-/// issue #213 for the rationale.
-fn classify_author(raw: &str) -> AuthorNeedle {
-    let trimmed = raw.trim();
-    let looks_like_account_id = trimmed.contains(':')
-        || (trimmed.len() >= 12
-            && trimmed.chars().any(|c| c.is_ascii_digit())
-            && trimmed
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
-    if looks_like_account_id {
-        AuthorNeedle::AccountId(trimmed.to_string())
-    } else {
-        AuthorNeedle::NameSubstring(trimmed.to_lowercase())
+impl AuthorNeedle {
+    /// Classify a user-supplied `--author` value. A value is treated as an
+    /// accountId if it either contains a colon, or is ≥12 chars of
+    /// `[A-Za-z0-9_-]` containing at least one digit. Otherwise it is a
+    /// name substring.
+    ///
+    /// The API's accountId format varies (`public cloud` uses
+    /// `557058:...`-style strings; older formats are opaque 24+ char
+    /// hex-like blobs). Both documented formats guarantee digits, so the
+    /// digit requirement distinguishes them from long digit-free display
+    /// names like `AlexanderGreene` or `jean-pierre-dupont`. Residual
+    /// edge: a 12+ char single-word name that incidentally contains a
+    /// digit (e.g. `User12345Name`) still classifies as accountId; see
+    /// issue #213 for the rationale.
+    fn from_raw(raw: &str) -> Self {
+        let trimmed = raw.trim();
+        let looks_like_account_id = trimmed.contains(':')
+            || (trimmed.len() >= 12
+                && trimmed.chars().any(|c| c.is_ascii_digit())
+                && trimmed
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+        if looks_like_account_id {
+            Self::AccountId(trimmed.to_string())
+        } else {
+            Self::NameSubstring(LoweredStr::new(trimmed))
+        }
     }
 }
 
@@ -152,7 +183,8 @@ fn author_matches(author: Option<&crate::types::jira::User>, needle: &AuthorNeed
     match needle {
         AuthorNeedle::AccountId(id) => a.account_id == *id,
         AuthorNeedle::NameSubstring(n) => {
-            a.display_name.to_lowercase().contains(n) || a.account_id.to_lowercase().contains(n)
+            a.display_name.to_lowercase().contains(n.as_str())
+                || a.account_id.to_lowercase().contains(n.as_str())
         }
     }
 }
@@ -257,15 +289,15 @@ mod tests {
 
     #[test]
     fn classify_author_treats_short_name_as_substring() {
-        match classify_author("alice") {
-            AuthorNeedle::NameSubstring(s) => assert_eq!(s, "alice"),
+        match AuthorNeedle::from_raw("alice") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "alice"),
             other => panic!("expected NameSubstring, got {other:?}"),
         }
     }
 
     #[test]
     fn classify_author_treats_colon_string_as_accountid() {
-        match classify_author("557058:abc-123") {
+        match AuthorNeedle::from_raw("557058:abc-123") {
             AuthorNeedle::AccountId(s) => assert_eq!(s, "557058:abc-123"),
             other => panic!("expected AccountId, got {other:?}"),
         }
@@ -273,7 +305,7 @@ mod tests {
 
     #[test]
     fn classify_author_treats_long_hex_blob_as_accountid() {
-        match classify_author("abcdef0123456789deadbeef") {
+        match AuthorNeedle::from_raw("abcdef0123456789deadbeef") {
             AuthorNeedle::AccountId(s) => assert_eq!(s, "abcdef0123456789deadbeef"),
             other => panic!("expected AccountId, got {other:?}"),
         }
@@ -282,8 +314,8 @@ mod tests {
     #[test]
     fn classify_author_long_alpha_only_name_is_substring() {
         // 15 chars, no digits — regression guard for #213.
-        match classify_author("AlexanderGreene") {
-            AuthorNeedle::NameSubstring(s) => assert_eq!(s, "alexandergreene"),
+        match AuthorNeedle::from_raw("AlexanderGreene") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "alexandergreene"),
             other => panic!("expected NameSubstring, got {other:?}"),
         }
     }
@@ -291,8 +323,8 @@ mod tests {
     #[test]
     fn classify_author_long_compound_name_is_substring() {
         // 18 chars, no digits — regression guard for #213.
-        match classify_author("JoseMariaRodriguez") {
-            AuthorNeedle::NameSubstring(s) => assert_eq!(s, "josemariarodriguez"),
+        match AuthorNeedle::from_raw("JoseMariaRodriguez") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "josemariarodriguez"),
             other => panic!("expected NameSubstring, got {other:?}"),
         }
     }
@@ -300,8 +332,8 @@ mod tests {
     #[test]
     fn classify_author_long_hyphenated_name_is_substring() {
         // 18 chars with dashes, no digits — regression guard for #213.
-        match classify_author("jean-pierre-dupont") {
-            AuthorNeedle::NameSubstring(s) => assert_eq!(s, "jean-pierre-dupont"),
+        match AuthorNeedle::from_raw("jean-pierre-dupont") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "jean-pierre-dupont"),
             other => panic!("expected NameSubstring, got {other:?}"),
         }
     }
@@ -309,7 +341,7 @@ mod tests {
     #[test]
     fn classify_author_old_hex_accountid_is_accountid() {
         // 24-char hex — contains digits, no colon.
-        match classify_author("5b10ac8d82e05b22cc7d4ef5") {
+        match AuthorNeedle::from_raw("5b10ac8d82e05b22cc7d4ef5") {
             AuthorNeedle::AccountId(s) => assert_eq!(s, "5b10ac8d82e05b22cc7d4ef5"),
             other => panic!("expected AccountId, got {other:?}"),
         }
@@ -318,7 +350,7 @@ mod tests {
     #[test]
     fn classify_author_colon_forces_accountid_regardless_of_heuristics() {
         // Colon wins the branch regardless of length/digits.
-        match classify_author("557058:f58131cb-b67d-43c7") {
+        match AuthorNeedle::from_raw("557058:f58131cb-b67d-43c7") {
             AuthorNeedle::AccountId(s) => assert_eq!(s, "557058:f58131cb-b67d-43c7"),
             other => panic!("expected AccountId, got {other:?}"),
         }
@@ -327,7 +359,7 @@ mod tests {
     #[test]
     fn classify_author_long_name_with_digit_is_accountid() {
         // 13 chars with a digit — documented residual edge. Stays AccountId.
-        match classify_author("User12345Name") {
+        match AuthorNeedle::from_raw("User12345Name") {
             AuthorNeedle::AccountId(s) => assert_eq!(s, "User12345Name"),
             other => panic!("expected AccountId, got {other:?}"),
         }
@@ -336,8 +368,8 @@ mod tests {
     #[test]
     fn classify_author_short_hyphenated_name_is_substring() {
         // 11 chars — below the length gate, unaffected by the digit rule.
-        match classify_author("jean-pierre") {
-            AuthorNeedle::NameSubstring(s) => assert_eq!(s, "jean-pierre"),
+        match AuthorNeedle::from_raw("jean-pierre") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "jean-pierre"),
             other => panic!("expected NameSubstring, got {other:?}"),
         }
     }
@@ -347,8 +379,8 @@ mod tests {
         // 7-char "unknown" — the Jira stub for deleted/migrated users.
         // Below the length gate; NameSubstring path already matches it
         // via case-insensitive account_id containment.
-        match classify_author("unknown") {
-            AuthorNeedle::NameSubstring(s) => assert_eq!(s, "unknown"),
+        match AuthorNeedle::from_raw("unknown") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "unknown"),
             other => panic!("expected NameSubstring, got {other:?}"),
         }
     }
@@ -375,7 +407,7 @@ mod tests {
     fn author_matches_null_author_always_false() {
         assert!(!author_matches(
             None,
-            &AuthorNeedle::NameSubstring("alice".into())
+            &AuthorNeedle::NameSubstring(LoweredStr::new("alice"))
         ));
     }
 
@@ -577,6 +609,12 @@ mod tests {
         truncate_to_rows(&mut entries, 2);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].items.len(), 2);
+    }
+
+    #[test]
+    fn lowered_str_normalizes_input_on_construction() {
+        let lowered = LoweredStr::new("MixedCase-Name");
+        assert_eq!(lowered.as_str(), "mixedcase-name");
     }
 
     #[test]


### PR DESCRIPTION
Closes #215.

## Summary

- Move the lowercase invariant on `AuthorNeedle::NameSubstring` from documentation convention to type-system enforcement via a module-private `LoweredStr(String)` newtype whose only constructor (`LoweredStr::new`) lowercases.
- Rename the classifier free function `classify_author` to the associated smart constructor `AuthorNeedle::from_raw` (body logic unchanged — same heuristic as #213).
- Pure internal refactor in `src/cli/issue/changelog.rs`. No user-facing behavior change.

## What changed

- Added `LoweredStr` with `new(&str)`, `as_str()`, and `Deref<Target = str>` (standard Rust string-newtype pattern; Perplexity-validated).
- `AuthorNeedle::NameSubstring(String)` → `NameSubstring(LoweredStr)`. `AccountId(String)` unchanged (accountIds are case-sensitive).
- `author_matches` uses `n.as_str()` at the `contains` call sites.
- Added 2 new unit tests: `lowered_str_normalizes_input_on_construction` and `lowered_str_equality_is_case_invariant` (pins the `PartialEq`/`Eq` contract on the newtype).
- 10 existing `classify_author_*` tests updated to call `AuthorNeedle::from_raw(...)` and (where relevant) compare via `.as_str()`.

## Why

External module boundary means outside callers can't construct `NameSubstring` with mixed-case content at all. Inside the module, the single-constructor discipline (`LoweredStr::new`) carries the lowercase invariant that `author_matches` relies on. Honest scope: the compiler blocks external construction; in-module tuple-field access is still syntactically possible and addressed by convention.

## Test Plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo test` — 782 passed, 0 failed (prior baseline 780 + 2 new)
- [x] Local multi-agent review (2 rounds): type-design-analyzer, pr-test-analyzer, comment-analyzer — all ✅ CLEAN after round 2
- [x] Spec compliance reviewer — ✅ compliant
- [x] Code-quality reviewer — 0 Critical / 0 Important

## Related

- Spec: `docs/specs/author-needle-smart-constructor.md`
- Plan: `docs/superpowers/plans/2026-04-19-author-needle-smart-constructor.md`
- Spawned from PR #200 / issue #213 review.