### PR TITLE
test(changelog): pin AuthorNeedle::from_raw Unicode classification

### DIFF
--- a/src/cli/issue/changelog.rs
+++ b/src/cli/issue/changelog.rs
@@ -345,9 +345,11 @@ mod tests {
 
     #[test]
     fn from_raw_long_unicode_name_is_substring() {
-        // 18 chars with non-ASCII letters (é, í), no digits — the
-        // ASCII-alphanumeric guard rejects accented chars, so this stays
-        // NameSubstring regardless of length.
+        // 18 chars with non-ASCII letters (é, í) and no digits — the
+        // digit guard rejects this input before the ASCII-alphanumeric
+        // guard runs, so this test documents the general Unicode
+        // fall-through. The specific ASCII-guard pin is
+        // `from_raw_long_unicode_name_with_digit_is_substring`.
         match AuthorNeedle::from_raw("JoséMariaRodríguez") {
             AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "josémariarodríguez"),
             other => panic!("expected NameSubstring, got {other:?}"),
@@ -356,12 +358,27 @@ mod tests {
 
     #[test]
     fn from_raw_long_unicode_name_with_digit_is_substring() {
-        // 15 chars, non-ASCII letter (é) AND a digit — pins the
+        // 15 chars with non-ASCII letter (é) AND a digit — pins the
         // is_ascii_alphanumeric guard specifically. A refactor to
         // char::is_alphanumeric would misclassify this as AccountId
-        // because 'é' has the Unicode Alphabetic property.
+        // because `'é'.is_alphanumeric() == true` while
+        // `'é'.is_ascii_alphanumeric() == false`.
         match AuthorNeedle::from_raw("José123Mariarod") {
             AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "josé123mariarod"),
+            other => panic!("expected NameSubstring, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_raw_long_cyrillic_name_with_digit_is_substring() {
+        // 14 chars of Cyrillic letters + digits — widens the
+        // ASCII-guard pin beyond Latin-1 to any non-ASCII alphabetic
+        // script. `'А'.is_alphanumeric() == true` (Cyrillic capital A,
+        // U+0410) but `'А'.is_ascii_alphanumeric() == false`.
+        // Note: the first literal char looks like ASCII 'A' (U+0041)
+        // but is U+0410 — do not "clean up" by retyping it.
+        match AuthorNeedle::from_raw("Александр12345") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "александр12345"),
             other => panic!("expected NameSubstring, got {other:?}"),
         }
     }

--- a/src/cli/issue/changelog.rs
+++ b/src/cli/issue/changelog.rs
@@ -344,6 +344,29 @@ mod tests {
     }
 
     #[test]
+    fn from_raw_long_unicode_name_is_substring() {
+        // 18 chars with non-ASCII letters (é, í), no digits — the
+        // ASCII-alphanumeric guard rejects accented chars, so this stays
+        // NameSubstring regardless of length.
+        match AuthorNeedle::from_raw("JoséMariaRodríguez") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "josémariarodríguez"),
+            other => panic!("expected NameSubstring, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_raw_long_unicode_name_with_digit_is_substring() {
+        // 15 chars, non-ASCII letter (é) AND a digit — pins the
+        // is_ascii_alphanumeric guard specifically. A refactor to
+        // char::is_alphanumeric would misclassify this as AccountId
+        // because 'é' has the Unicode Alphabetic property.
+        match AuthorNeedle::from_raw("José123Mariarod") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "josé123mariarod"),
+            other => panic!("expected NameSubstring, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn from_raw_old_hex_accountid_is_accountid() {
         // 24-char hex — contains digits, no colon.
         match AuthorNeedle::from_raw("5b10ac8d82e05b22cc7d4ef5") {


### PR DESCRIPTION
## Summary
- Closes #218. Adds three unit tests to `src/cli/issue/changelog.rs` pinning `AuthorNeedle::from_raw` Unicode classification against a future refactor of `c.is_ascii_alphanumeric()` → `c.is_alphanumeric()`.
- `from_raw_long_unicode_name_is_substring` documents the general Unicode fall-through (Latin-1 `é`/`í`, no digits — the digit guard rejects before the ASCII guard runs).
- `from_raw_long_unicode_name_with_digit_is_substring` is the load-bearing pin — `"José123Mariarod"` has a digit AND a non-ASCII letter, so it stays `NameSubstring` only because the ASCII guard rejects `é`. A refactor to `char::is_alphanumeric` would flip it to `AccountId` (`'é'.is_alphanumeric() == true`).
- `from_raw_long_cyrillic_name_with_digit_is_substring` widens the ASCII-guard pin beyond Latin-1 — `"Александр12345"` (Cyrillic А is U+0410, not ASCII).
- Test-only. No production code changes.

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 473 lib + all integration suites pass (was 471 before; +3 new)
- [x] Local multi-agent review (comment-analyzer, pr-test-analyzer, code-reviewer), 2 rounds, all clean

## Notes
- Issue #218's original test proposal used `"JoséMariaRodríguez"` (no digits) which doesn't actually catch the `is_ascii_alphanumeric` → `is_alphanumeric` refactor it cites (fails the digit guard first). Kept as documentary test; added the two digit-bearing variants (Latin-1 and Cyrillic) that genuinely pin the guard.
- NFD combining-marks test considered and skipped: combining marks have `Alphabetic=No` and fail both guards identically, providing zero differential signal for the refactor this PR targets.
- Issue refers to `classify_author`; code was renamed to `AuthorNeedle::from_raw` in #215/#225. Tests follow current naming.