### PR TITLE
test(changelog): AuthorNeedle unit-test cluster (#219 #220 #222)

### DIFF
--- a/src/cli/issue/changelog.rs
+++ b/src/cli/issue/changelog.rs
@@ -309,14 +309,6 @@ mod tests {
     }
 
     #[test]
-    fn from_raw_treats_long_hex_blob_as_accountid() {
-        match AuthorNeedle::from_raw("abcdef0123456789deadbeef") {
-            AuthorNeedle::AccountId(s) => assert_eq!(s, "abcdef0123456789deadbeef"),
-            other => panic!("expected AccountId, got {other:?}"),
-        }
-    }
-
-    #[test]
     fn from_raw_long_alpha_only_name_is_substring() {
         // 15 chars, no digits — regression guard for #213.
         match AuthorNeedle::from_raw("AlexanderGreene") {
@@ -411,6 +403,30 @@ mod tests {
     }
 
     #[test]
+    fn from_raw_twelve_char_boundary_with_digit_is_accountid() {
+        // Exactly 12 chars with a digit — pins the `trimmed.len() >= 12`
+        // gate. A silent off-by-one to `> 12` would leave this input
+        // falling through to NameSubstring; neighboring length-based
+        // tests land on either side of the boundary and do not cover
+        // this exact value.
+        match AuthorNeedle::from_raw("abcdefghijk1") {
+            AuthorNeedle::AccountId(s) => assert_eq!(s, "abcdefghijk1"),
+            other => panic!("expected AccountId at 12-char boundary, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_raw_twelve_char_boundary_no_digit_is_substring() {
+        // Exactly 12 chars without a digit — pins that the length gate
+        // alone is not sufficient; the digit requirement still applies
+        // at the boundary.
+        match AuthorNeedle::from_raw("abcdefghijkl") {
+            AuthorNeedle::NameSubstring(s) => assert_eq!(s.as_str(), "abcdefghijkl"),
+            other => panic!("expected NameSubstring without digit, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn from_raw_short_hyphenated_name_is_substring() {
         // 11 chars — below the length gate, unaffected by the digit rule.
         match AuthorNeedle::from_raw("jean-pierre") {
@@ -445,6 +461,53 @@ mod tests {
         assert!(!author_matches(
             Some(&user),
             &AuthorNeedle::AccountId("other".into())
+        ));
+    }
+
+    #[test]
+    fn author_matches_substring_hits_display_name_case_insensitive() {
+        // Needle lowercased at construction; haystack lowercased at match.
+        let user = User {
+            account_id: "557058:xyz".into(),
+            display_name: "ALICE Smith".into(),
+            email_address: None,
+            active: Some(true),
+        };
+        assert!(author_matches(
+            Some(&user),
+            &AuthorNeedle::NameSubstring(LoweredStr::new("alice"))
+        ));
+    }
+
+    #[test]
+    fn author_matches_substring_hits_account_id_case_insensitive() {
+        // Second haystack: account_id. Pins the
+        // `account_id.to_lowercase().contains(n)` fallback so a
+        // substring needle that happens to match inside an accountId
+        // still matches even when the display_name does not.
+        let user = User {
+            account_id: "557058:ABC-123".into(),
+            display_name: "unrelated name".into(),
+            email_address: None,
+            active: Some(true),
+        };
+        assert!(author_matches(
+            Some(&user),
+            &AuthorNeedle::NameSubstring(LoweredStr::new("abc-123"))
+        ));
+    }
+
+    #[test]
+    fn author_matches_substring_misses_when_absent() {
+        let user = User {
+            account_id: "557058:xyz".into(),
+            display_name: "Alice Smith".into(),
+            email_address: None,
+            active: Some(true),
+        };
+        assert!(!author_matches(
+            Some(&user),
+            &AuthorNeedle::NameSubstring(LoweredStr::new("bob"))
         ));
     }
 


### PR DESCRIPTION
## Summary

Unit-test cluster in `src/cli/issue/changelog.rs` closing three related test issues. Test-only; no production code changes. Net: +5 tests / -1 test.

**Closes #219** — adds three direct `author_matches` tests pinning the `NameSubstring` branch (previously only exercised via integration):
- `author_matches_substring_hits_display_name_case_insensitive`
- `author_matches_substring_hits_account_id_case_insensitive` (needle `"abc-123"` vs haystack `"557058:ABC-123"` — genuinely exercises the `to_lowercase()` fold on the account_id fallback)
- `author_matches_substring_misses_when_absent`

**Closes #220** — pins the `trimmed.len() >= 12` gate at the exact boundary. Existing tests covered 11 and 13 chars; a silent off-by-one to `> 12` would previously pass all tests.
- `from_raw_twelve_char_boundary_with_digit_is_accountid` (`"abcdefghijk1"` → AccountId)
- `from_raw_twelve_char_boundary_no_digit_is_substring` (`"abcdefghijkl"` → NameSubstring — also pins that length alone isn't sufficient)

**Closes #222** — deletes `from_raw_treats_long_hex_blob_as_accountid` (synthetic `"abcdef0123456789deadbeef"`) since it exercises the same heuristic path as the realistic `from_raw_old_hex_accountid_is_accountid` (`"5b10ac8d82e05b22cc7d4ef5"`).

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 478 lib + all integration suites pass (was 474; net +4 per the +5/-1 count)
- [x] Local multi-agent review (comment-analyzer, pr-test-analyzer, code-reviewer), 2 rounds, all clean

## Notes
- Follow-up issue to file: `author_matches` edge cases (empty/whitespace needle silent-filter-bypass — `"Alice".contains("")` is `true` per Rust stdlib, confirmed via Perplexity; non-ASCII needle matching; empty User fields). All three were flagged during local review as out-of-scope for #219/#220/#222 but worth their own issue — particularly the empty-needle case which has real agent-UX implications (`jr issue changelog --author "$UNSET"` would silently return every author's events).
- Issues referenced `classify_author`; the function was renamed to `AuthorNeedle::from_raw` in #215/#225. Tests use current naming.