### PR TITLE
fix(changelog): reject empty --author to prevent silent filter bypass

### DIFF
--- a/src/cli/issue/changelog.rs
+++ b/src/cli/issue/changelog.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 
 use crate::api::client::JiraClient;
 use crate::cli::{IssueCommand, OutputFormat};
+use crate::error::JrError;
 use crate::output;
 use crate::types::jira::ChangelogEntry;
 
@@ -39,7 +40,21 @@ pub(super) async fn handle(
 
     // Resolve --author "me" (case-insensitive, shared with other commands
     // via `helpers::is_me_keyword`) up-front; other forms compare directly.
+    //
+    // An empty or whitespace-only needle is rejected before any API call.
+    // Otherwise `AuthorNeedle::from_raw("")` would produce
+    // `NameSubstring(LoweredStr(""))`, and `haystack.contains("")` is
+    // always `true` per `str::contains` — every user would silently match,
+    // which is a filter bypass for agents piping an unset shell variable
+    // as `--author "$UNSET_VAR"`.
     let author_needle = match author.as_deref() {
+        Some(raw) if raw.trim().is_empty() => {
+            return Err(JrError::UserError(
+                "--author cannot be empty or whitespace-only. Provide a name, accountId, or \"me\"."
+                    .into(),
+            )
+            .into());
+        }
         Some(raw) if helpers::is_me_keyword(raw) => Some(AuthorNeedle::AccountId(
             client.get_myself().await?.account_id,
         )),
@@ -508,6 +523,62 @@ mod tests {
         assert!(!author_matches(
             Some(&user),
             &AuthorNeedle::NameSubstring(LoweredStr::new("bob"))
+        ));
+    }
+
+    #[test]
+    fn author_matches_substring_hits_unicode_display_name() {
+        // Non-ASCII display_name + non-ASCII needle: both sides use
+        // Unicode-aware lowercasing (`str::to_lowercase`), so an accented
+        // needle must match an uppercase-accented haystack. Complements
+        // the classification pins added for #218 — those ensure Unicode
+        // input falls through to NameSubstring; this pins that the match
+        // itself works once it gets there.
+        let user = User {
+            account_id: "557058:xyz".into(),
+            display_name: "JOSÉ Rodríguez".into(),
+            email_address: None,
+            active: Some(true),
+        };
+        assert!(author_matches(
+            Some(&user),
+            &AuthorNeedle::NameSubstring(LoweredStr::new("josé"))
+        ));
+    }
+
+    #[test]
+    fn author_matches_substring_handles_empty_display_name() {
+        // Empty display_name must not panic or spuriously match; only
+        // the account_id haystack can produce a hit. "".contains("alice")
+        // is false, so the needle falls through to the account_id check.
+        let user = User {
+            account_id: "557058:xyz".into(),
+            display_name: String::new(),
+            email_address: None,
+            active: Some(true),
+        };
+        assert!(!author_matches(
+            Some(&user),
+            &AuthorNeedle::NameSubstring(LoweredStr::new("alice"))
+        ));
+    }
+
+    #[test]
+    fn author_matches_substring_handles_empty_account_id() {
+        // Empty account_id: the display_name haystack still works, so a
+        // needle that matches display_name returns true even when
+        // account_id is empty. Guards against a future refactor that
+        // conditions the display_name branch on a non-empty account_id
+        // (e.g., "only search display_name if account_id didn't match").
+        let user = User {
+            account_id: String::new(),
+            display_name: "Alice Smith".into(),
+            email_address: None,
+            active: Some(true),
+        };
+        assert!(author_matches(
+            Some(&user),
+            &AuthorNeedle::NameSubstring(LoweredStr::new("alice"))
         ));
     }
 

--- a/tests/issue_changelog.rs
+++ b/tests/issue_changelog.rs
@@ -462,6 +462,80 @@ async fn changelog_author_me_resolves_via_myself() {
     assert!(!stdout.contains("Someone Else"));
 }
 
+// Empty or whitespace-only `--author` must be rejected before any API
+// call. Without the guard, the needle lowercases to `""` and
+// `haystack.contains("")` is always `true` per Rust's `str::contains`,
+// so every author silently matches — a filter bypass that surfaces when
+// an agent passes an unset shell variable as `--author "$UNSET_VAR"`.
+//
+// `MockServer::start()` is created but registers no mocks: it exists
+// so the handler can construct a `JiraClient` against a valid
+// `JR_BASE_URL`. If the guard regresses, the handler would reach the
+// unmocked changelog path and exit with a non-64 code, which the
+// `Some(64)` assertion catches.
+#[tokio::test]
+async fn changelog_rejects_empty_author() {
+    let server = MockServer::start().await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "changelog", "FOO-1", "--author", ""])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "expected exit 64 (UserError), got: {:?}",
+        output.status.code()
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--author cannot be empty"),
+        "expected '--author cannot be empty' in stderr: {stderr}"
+    );
+}
+
+#[tokio::test]
+async fn changelog_rejects_whitespace_only_author() {
+    let server = MockServer::start().await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "changelog", "FOO-1", "--author", "   "])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(64));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--author cannot be empty"));
+}
+
+// Tabs and newlines are Unicode `White_Space` per the stdlib, so
+// `str::trim()` strips them. Pins that the guard correctly rejects
+// these forms too — an agent that renders `$UNSET_VAR` via a template
+// could end up with `\t` or `\n` as the entire argument.
+#[tokio::test]
+async fn changelog_rejects_tab_or_newline_only_author() {
+    let server = MockServer::start().await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "changelog", "FOO-1", "--author", "\t\n"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(64));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--author cannot be empty"));
+}
+
 #[tokio::test]
 async fn changelog_author_name_substring_case_insensitive() {
     let server = MockServer::start().await;


### PR DESCRIPTION
## Summary

**Closes #229.** Fixes a silent filter bypass in `jr issue changelog --author` where an empty or whitespace-only value previously matched every author (because `"Alice".contains("")` is `true` per Rust's `str::contains`). Most painful under `jr issue changelog --author "$UNSET_VAR"` where an agent would receive "all events matched" and proceed on bad data.

- Reject empty/whitespace-only `--author` in the `Changelog` handler with `JrError::UserError` (exit 64) before any API call. Error message: `--author cannot be empty or whitespace-only. Provide a name, accountId, or "me".`
- Three new integration tests in `tests/issue_changelog.rs`: `""`, `"   "`, `"\t\n"` — each asserts exit 64 and the stable stderr prefix.
- Three new unit tests in `src/cli/issue/changelog.rs` covering #229 parts 2 & 3:
  - `author_matches_substring_hits_unicode_display_name` — pins end-to-end Unicode match after #218's classification pins
  - `author_matches_substring_handles_empty_display_name` — guards display_name-absent case
  - `author_matches_substring_handles_empty_account_id` — guards account_id-absent case

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 481 lib + 34 changelog integration + all other suites (was 478 / 31; net +3 / +3)
- [x] Local multi-agent review: comment-analyzer, silent-failure-hunter, code-reviewer — 2 rounds, all clean

## Follow-up

Local review surfaced that `--field ""` on `jr issue changelog` has the **same** silent-filter-bypass bug (`needles.iter().any(|n| h.contains(n))` — `contains("")` always true). Will file a separate issue and PR with the same fix pattern. Kept out of this PR to keep blast radius narrow.

## Notes
- Perplexity-validated: `str::contains("")` → always true ("Always returns true if needle is an empty slice" per stdlib docs); `str::trim()` strips Unicode `White_Space` including `\t`/`\n`/`\r`.