### PR TITLE
fix(changelog): reject empty --field to prevent silent filter bypass

### DIFF
--- a/src/cli/issue/changelog.rs
+++ b/src/cli/issue/changelog.rs
@@ -62,6 +62,22 @@ pub(super) async fn handle(
         None => None,
     };
 
+    // --field is subject to the same silent filter bypass: the filter
+    // runs `needles.iter().any(|n| h.contains(n))` with lowercased
+    // user input, and `contains("")` is always `true` per `str::contains`.
+    // An empty needle would make every item match (or, in the
+    // repeated-flag `Vec<String>` form, OR with any other needle to
+    // the same effect). Reject before the API call, matching the
+    // --author rejection above.
+    for raw in &field {
+        if raw.trim().is_empty() {
+            return Err(JrError::UserError(
+                "--field cannot be empty or whitespace-only. Provide a field name like \"status\" or \"assignee\".".into(),
+            )
+            .into());
+        }
+    }
+
     let mut entries = client.get_changelog(&key).await?;
 
     // Sort chronologically by parsed `created`. Unparseable entries fall

--- a/tests/issue_changelog.rs
+++ b/tests/issue_changelog.rs
@@ -536,6 +536,103 @@ async fn changelog_rejects_tab_or_newline_only_author() {
     assert!(stderr.contains("--author cannot be empty"));
 }
 
+// --field suffers the same class of silent-filter-bypass as --author:
+// the filter is `needles.iter().any(|n| h.contains(n))` with lowercased
+// user input, and `contains("")` is always `true` per `str::contains`,
+// so an empty value would make every item match. Reject before the API
+// call for the same reasons (exit 64 / JrError::UserError). MockServer
+// mounts no expectations — a regression would reach the unmocked
+// changelog path and exit with a non-64 code.
+#[tokio::test]
+async fn changelog_rejects_empty_field() {
+    let server = MockServer::start().await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "changelog", "FOO-1", "--field", ""])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "expected exit 64 (UserError), got: {:?}",
+        output.status.code()
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--field cannot be empty"),
+        "expected '--field cannot be empty' in stderr: {stderr}"
+    );
+}
+
+#[tokio::test]
+async fn changelog_rejects_whitespace_only_field() {
+    let server = MockServer::start().await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "changelog", "FOO-1", "--field", "   "])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(64));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--field cannot be empty"));
+}
+
+// Parity with the --author guard: tabs/newlines are Unicode
+// `White_Space` and `str::trim()` strips them, so the rejection
+// fires for these forms too.
+#[tokio::test]
+async fn changelog_rejects_tab_or_newline_only_field() {
+    let server = MockServer::start().await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "changelog", "FOO-1", "--field", "\t\n"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(64));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--field cannot be empty"));
+}
+
+// --field is repeatable (`Vec<String>`). A mixed invocation with one
+// valid + one empty value must still reject — otherwise the empty
+// needle would OR with the valid one and match every item anyway.
+#[tokio::test]
+async fn changelog_rejects_empty_field_among_valid() {
+    let server = MockServer::start().await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args([
+            "issue",
+            "changelog",
+            "FOO-1",
+            "--field",
+            "status",
+            "--field",
+            "",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(64));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--field cannot be empty"));
+}
+
 #[tokio::test]
 async fn changelog_author_name_substring_case_insensitive() {
     let server = MockServer::start().await;


### PR DESCRIPTION
## Summary

**Closes #231.** Applies the same fix pattern as PR #230 (which closed #229 for `--author`) to the `--field` flag on `jr issue changelog`. Empty/whitespace-only `--field` values previously silently matched every item because `str::contains("")` is always `true` per the Rust stdlib.

- Reject any empty/whitespace-only `--field` entry in the handler with `JrError::UserError` (exit 64) before any API call. Placed adjacent to the existing `--author` rejection.
- Four new integration tests in `tests/issue_changelog.rs`:
  - `changelog_rejects_empty_field` — `--field ""`
  - `changelog_rejects_whitespace_only_field` — `--field "   "`
  - `changelog_rejects_tab_or_newline_only_field` — `--field "\t\n"` (parity with `--author`'s coverage)
  - `changelog_rejects_empty_field_among_valid` — `--field status --field ""` (pins that the empty needle still rejects even when mixed with a valid one, since any empty entry OR's with valid ones to match every item anyway)

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 481 lib + 37 changelog integration + all other suites pass
- [x] Local multi-agent review (silent-failure-hunter, code-reviewer) — both approve, no Critical/Important

## Broader audit (context)

Perplexity-validated during review that the full `str::{contains,starts_with,ends_with,find,rfind}` family shares the empty-needle silent-pass semantic. Grep for `.to_lowercase().<str_search>(<user_input>)` across production source returns:

- `changelog.rs:112` (`--field`) — fixed in this PR
- `changelog.rs:222-223` (`author_matches` NameSubstring) — protected by #229's `--author` guard
- `partial_match.rs:35` — different failure mode (returns structured `MatchResult::Ambiguous(all_candidates)` on empty input, not a silent filter pass; caller-dependent whether that's wrong)

No further direct bypass sites in filter paths. `partial_match` empty-input behavior is worth a separate audit but out of scope — different failure mode, caller-dependent impact.

## Notes
- Deliberately did not factor the rejection into a shared helper (silent-failure-hunter Suggestion). Only two use sites (`--author` in #230, `--field` here), and CLAUDE.md: "Don't design for hypothetical future requirements. Three similar lines is better than a premature abstraction." Revisit if/when a third filter flag lands.