### PR TITLE
test(changelog): end-to-end --author long-alpha-name regression pin

### DIFF
--- a/tests/issue_changelog.rs
+++ b/tests/issue_changelog.rs
@@ -676,6 +676,62 @@ async fn changelog_author_name_substring_case_insensitive() {
     assert!(!stdout.contains("Bob Jones"));
 }
 
+// End-to-end regression pin for the #213 bug: a long single-word
+// display name (≥12 chars, no digits) must classify as NameSubstring,
+// not AccountId, or the CLI silently returns zero matches. The
+// existing `from_raw_long_alpha_only_name_is_substring` unit test
+// pins the classifier; this pins the full pipeline from argv through
+// the wiremock-stubbed changelog response to rendered stdout.
+#[tokio::test]
+async fn changelog_author_long_alpha_name_matches_display_name() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/changelog"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "startAt": 0, "maxResults": 100, "total": 2, "isLast": true,
+            "values": [
+                {
+                    "id": "1",
+                    "author": { "accountId": "a", "displayName": "AlexanderGreene", "active": true },
+                    "created": "2026-04-16T14:02:00.000+0000",
+                    "items": [{"field": "status", "fieldtype": "jira",
+                               "from": "1", "fromString": "To Do",
+                               "to": "3", "toString": "Done"}]
+                },
+                {
+                    "id": "2",
+                    "author": { "accountId": "b", "displayName": "Bob Jones", "active": true },
+                    "created": "2026-04-15T10:00:00.000+0000",
+                    "items": [{"field": "labels", "fieldtype": "jira",
+                               "from": "", "to": "x"}]
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["issue", "changelog", "FOO-1", "--author", "AlexanderGreene"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("AlexanderGreene"),
+        "long single-word display name was missed — possible regression of #213: {stdout}"
+    );
+    assert!(!stdout.contains("Bob Jones"));
+}
+
 // Short (< 12 chars, no colon) `--author` values go through
 // `AuthorNeedle::NameSubstring`, which matches against both `displayName`
 // and `accountId` — so a short accountId prefix still works. This test


### PR DESCRIPTION
## Summary

**Closes #221.** Adds one integration test in `tests/issue_changelog.rs` pinning the #213 bug fix at the CLI layer — a long single-word display name (e.g. "AlexanderGreene", 15 chars, no digits) must classify as `NameSubstring` so `jr issue changelog FOO-1 --author AlexanderGreene` returns matches instead of silently rendering nothing.

The classifier itself is already pinned by the unit test `from_raw_long_alpha_only_name_is_substring`. This new test pins the full pipeline from argv through the wiremock-stubbed changelog response to rendered stdout.

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 481 lib + 39 changelog integration + all other suites pass
- [x] Local code-reviewer: clean, no changes needed

## Notes

This closes the post-#213 test follow-up cluster. Issues #218, #219, #220, #222, #229, #231 all landed earlier in the same session; #221 is the last piece.