### PR TITLE
chore(release): v0.5.0-dev.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary

Bump version from `0.5.0-dev.1` to `0.5.0-dev.2` (Cargo.toml + Cargo.lock).

## Changes since v0.5.0-dev.1

**Features**
- `jr issue changelog` command (#216)
- `jr auth refresh` subcommand + non-interactive flag parity (#207)
- `--verbose` changelog/comment date parse-failure logging (#214 / #224)

**Fixes**
- `--author` accountId classification now requires a digit (#213 / #223) — long alpha-only display names (e.g. "AlexanderGreene") no longer misclassify
- `--author ""` silent filter bypass (#229 / #230) — rejects empty needle with exit 64
- `--field ""` silent filter bypass (#231 / #232) — same class of bug on the field filter

**Refactor**
- `LoweredStr` newtype + `AuthorNeedle::from_raw` smart constructor (#215 / #225) — encapsulates the lowercase invariant in the type system

**Tests & docs**
- AuthorNeedle classification pins: Unicode (#218 / #227), 12-char boundary + consolidation (#219/#220/#222 / #228), end-to-end long-alpha-name (#221 / #233)
- `--author "me"` reservation + accountId exact-match semantics documented (#212 / #217)

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 481 lib + all integration suites pass

## Next step

Merge this PR → tag `v0.5.0-dev.2` on the squashed develop commit → push tag → `.github/workflows/release.yml` fires on `tags: ["v*"]` and publishes a prerelease (tag contains `-`).