### PR TITLE
docs: fix crate/package name in CLAUDE.md (#226)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # jr — Jira CLI
 
-A Rust CLI tool for automating Jira Cloud workflows. Binary name: `jr`, crate name: `jr-cli`.
+A Rust CLI tool for automating Jira Cloud workflows. Binary name: `jr`, package name: `jr`.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- CLAUDE.md header said `crate name: jr-cli`, but `Cargo.toml` declares `name = "jr"`. Commands copied from the header (e.g., `cargo test -p jr-cli`) fail with "package ID specification did not match any packages."
- Update the header to `Binary name: jr, package name: jr`.

## Scope
- Only CLAUDE.md:3 is touched. README.md's `cargo install jr-cli` line is under "Crates.io (planned)" — the crates.io publishing name is a separate decision, out of scope for this fix.
- Historical spec/plan docs in `docs/superpowers/` are not edited (immutable design artifacts).

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 481/481 pass
- [x] Verified `cargo test -p jr` succeeds after the fix (the command the header now suggests)

Closes #226