### PR TITLE
test: integration tests for partial_match substring rejection (#193)

### DIFF
--- a/tests/issue_commands.rs
+++ b/tests/issue_commands.rs
@@ -1685,3 +1685,136 @@ async fn test_assign_issue_invalid_account_id_returns_error() {
         "Expected Jira error message in error, got: {msg}"
     );
 }
+
+// ── partial_match single-substring rejection (issue #193) ────────────
+//
+// These lock the guarantee that a single substring-only hit under
+// `--no-input` routes through `Ambiguous` and errors before any
+// state-changing HTTP call is made. The unit tests in partial_match.rs
+// cover the matcher itself; these cover the handler wiring at each
+// call site.
+
+#[tokio::test]
+async fn test_move_single_substring_rejected_no_input() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/transitions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            common::fixtures::transitions_response_with_status(vec![
+                ("21", "Start", "In Progress"),
+                ("31", "Close", "Closed"),
+            ]),
+        ))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(common::fixtures::issue_response(
+                "FOO-1",
+                "Test issue",
+                "To Do",
+            )),
+        )
+        .mount(&server)
+        .await;
+
+    // Assert no transition POST occurs — the substring must short-circuit.
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue/FOO-1/transitions"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let output = assert_cmd::Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["--no-input", "issue", "move", "FOO-1", "prog"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "Expected failure on ambiguous substring, stderr: {stderr}"
+    );
+    // workflow.rs uses `anyhow::bail!` which doesn't inject a JrError into
+    // the cause chain → main.rs falls back to exit 1. Pinning this lets a
+    // future refactor to JrError::UserError (exit 64) flag the test for review.
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "Ambiguous transition currently exits 1 via anyhow::bail!, got: {:?}",
+        output.status.code()
+    );
+    assert!(
+        stderr.contains("Ambiguous transition"),
+        "Expected 'Ambiguous transition' in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("In Progress"),
+        "Expected matched candidate 'In Progress' in stderr: {stderr}"
+    );
+}
+
+#[tokio::test]
+async fn test_link_single_substring_rejected_no_input() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issueLinkType"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(common::fixtures::link_types_response()),
+        )
+        .mount(&server)
+        .await;
+
+    // Assert no link POST occurs — the substring must short-circuit.
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issueLink"))
+        .respond_with(ResponseTemplate::new(201))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let output = assert_cmd::Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args([
+            "--no-input",
+            "issue",
+            "link",
+            "FOO-1",
+            "FOO-2",
+            "--type",
+            "block",
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "Expected failure on ambiguous substring, stderr: {stderr}"
+    );
+    // links.rs uses `anyhow::bail!` → exit 1 (see move test for rationale).
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "Ambiguous link type currently exits 1 via anyhow::bail!, got: {:?}",
+        output.status.code()
+    );
+    assert!(
+        stderr.contains("Ambiguous link type"),
+        "Expected 'Ambiguous link type' in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Blocks"),
+        "Expected matched candidate 'Blocks' in stderr: {stderr}"
+    );
+}

--- a/tests/issue_list_errors.rs
+++ b/tests/issue_list_errors.rs
@@ -358,3 +358,66 @@ async fn issue_list_network_drop_surfaces_reach_error() {
     );
     assert!(!stderr.contains("panic"), "stderr leaked a panic: {stderr}");
 }
+
+// ── partial_match single-substring rejection (issue #193) ────────────
+
+/// Asserts `issue list --status <substring>` rejects a single-hit
+/// substring with a disambiguation error and exit code 64, without
+/// issuing a JQL search. Locks the handler-level guarantee from the
+/// strict-matching rollout (unit-tested in src/partial_match.rs).
+#[tokio::test]
+async fn issue_list_status_single_substring_rejected() {
+    let server = MockServer::start().await;
+
+    // Project statuses response — candidates include "In Progress"; "prog"
+    // is a single-hit substring → routes through Ambiguous.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/project/PROJ/statuses"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(common::fixtures::project_statuses_response()),
+        )
+        .mount(&server)
+        .await;
+
+    // Assert no JQL search fires — ambiguous status must short-circuit.
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/search/jql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "issues": [], "nextPageToken": null
+        })))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let project_dir = tempfile::tempdir().unwrap();
+    std::fs::write(project_dir.path().join(".jr.toml"), "project = \"PROJ\"\n").unwrap();
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .current_dir(project_dir.path())
+        .args(["--no-input", "issue", "list", "--status", "prog"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "Expected failure on ambiguous substring, stderr: {stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "Ambiguous status should exit 64 (UserError), got: {:?}",
+        output.status.code()
+    );
+    assert!(
+        stderr.contains("Ambiguous status"),
+        "Expected 'Ambiguous status' in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("In Progress"),
+        "Expected matched candidate 'In Progress' in stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
- Lock the handler-level guarantee that single-hit substrings under `--no-input` route through `MatchResult::Ambiguous` and error **before** any state-changing HTTP call.
- Covers the three call sites named in #193: `issue move`, `issue link`, `issue list --status`.
- No production code changes — tests only.

## How it works
Each test mocks the candidate-list GET and mounts the state-changing POST with `.expect(0)`. wiremock fails the test if the short-circuit is ever bypassed. Inputs are chosen so `partial_match` resolves to exactly one candidate (e.g., `"prog"` → `"In Progress"`), exercising the Ambiguous-single-hit path rather than None or Ambiguous-multi-hit.

## Findings from local review (addressed / deferred)
- **Addressed:** exit codes now pinned — move/link → 1 (anyhow::bail), list → 64 (JrError::UserError). Review flagged the missing assertions.
- **Deferred to #236:** additional uncovered `partial_match` callers (unlink, helpers team/user/asset, assets search/schema/tickets, queue view).
- **Deferred to #237:** production-side inconsistency — move/link use `bail!` and exit 1, while list uses `UserError` and exits 64. All three are user-input errors and should surface as 64.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 803 passed, 0 failed (baseline 782 + 21)
- [x] The 3 new tests isolated and passing:
  - `test_move_single_substring_rejected_no_input`
  - `test_link_single_substring_rejected_no_input`
  - `issue_list_status_single_substring_rejected`

Closes #193