### PR TITLE
refactor: exit 64 for ambiguous partial_match input (#237)

### DIFF
--- a/src/cli/issue/links.rs
+++ b/src/cli/issue/links.rs
@@ -3,6 +3,7 @@ use anyhow::{Context, Result, bail};
 
 use crate::api::client::JiraClient;
 use crate::cli::{IssueCommand, OutputFormat};
+use crate::error::JrError;
 use crate::output;
 use crate::partial_match::{self, MatchResult};
 
@@ -65,11 +66,12 @@ pub(super) async fn handle_link(
         MatchResult::ExactMultiple(name) => name,
         MatchResult::Ambiguous(matches) => {
             if no_input {
-                bail!(
+                return Err(JrError::UserError(format!(
                     "Ambiguous link type \"{}\". Matches: {}",
                     link_type_name,
                     matches.join(", ")
-                );
+                ))
+                .into());
             }
             let selection = dialoguer::Select::new()
                 .with_prompt(format!("Multiple types match \"{link_type_name}\""))
@@ -135,11 +137,12 @@ pub(super) async fn handle_unlink(
             MatchResult::ExactMultiple(name) => name,
             MatchResult::Ambiguous(matches) => {
                 if no_input {
-                    bail!(
+                    return Err(JrError::UserError(format!(
                         "Ambiguous link type \"{}\". Matches: {}",
                         type_name,
                         matches.join(", ")
-                    );
+                    ))
+                    .into());
                 }
                 let selection = dialoguer::Select::new()
                     .with_prompt(format!("Multiple types match \"{type_name}\""))

--- a/src/cli/issue/workflow.rs
+++ b/src/cli/issue/workflow.rs
@@ -156,11 +156,12 @@ pub(super) async fn handle_move(
             }
             MatchResult::Ambiguous(matches) => {
                 if no_input {
-                    bail!(
+                    return Err(JrError::UserError(format!(
                         "Ambiguous transition \"{}\". Matches: {}",
                         target_status,
                         matches.join(", ")
-                    );
+                    ))
+                    .into());
                 }
                 // Interactive disambiguation
                 eprintln!(

--- a/tests/issue_commands.rs
+++ b/tests/issue_commands.rs
@@ -1742,13 +1742,10 @@ async fn test_move_single_substring_rejected_no_input() {
         !output.status.success(),
         "Expected failure on ambiguous substring, stderr: {stderr}"
     );
-    // workflow.rs uses `anyhow::bail!` which doesn't inject a JrError into
-    // the cause chain → main.rs falls back to exit 1. Pinning this lets a
-    // future refactor to JrError::UserError (exit 64) flag the test for review.
     assert_eq!(
         output.status.code(),
-        Some(1),
-        "Ambiguous transition currently exits 1 via anyhow::bail!, got: {:?}",
+        Some(64),
+        "Ambiguous transition should exit 64 (UserError), got: {:?}",
         output.status.code()
     );
     assert!(
@@ -1802,11 +1799,10 @@ async fn test_link_single_substring_rejected_no_input() {
         !output.status.success(),
         "Expected failure on ambiguous substring, stderr: {stderr}"
     );
-    // links.rs uses `anyhow::bail!` → exit 1 (see move test for rationale).
     assert_eq!(
         output.status.code(),
-        Some(1),
-        "Ambiguous link type currently exits 1 via anyhow::bail!, got: {:?}",
+        Some(64),
+        "Ambiguous link type should exit 64 (UserError), got: {:?}",
         output.status.code()
     );
     assert!(


### PR DESCRIPTION
## Summary
- Unify exit codes across the four `partial_match` handlers: all ambiguous-substring errors now exit **64** (`JrError::UserError`).
- Before: `move` / `link` / `unlink` used `anyhow::bail!` → exit 1. `list --status` already used `UserError` → exit 64.
- After: all four use `UserError` → exit 64.
- **Error text unchanged byte-for-byte** — scripts/greps looking for `"Ambiguous transition"` or `"Ambiguous link type"` keep working.

## Why it matters
An AI agent or shell pipeline checking `\$? == 64` for "bad user input" previously missed move/link/unlink ambiguity and treated them as transient errors. Now the contract is consistent.

## Changes
- `src/cli/issue/workflow.rs:157` — `bail!` → `JrError::UserError` (Ambiguous transition, `--no-input`)
- `src/cli/issue/links.rs:67` — same (link, Ambiguous link type)
- `src/cli/issue/links.rs:136` — same (unlink, Ambiguous link type)
- `tests/issue_commands.rs` — flip pinned `Some(1)` → `Some(64)` for the two tests added in PR #238, remove stale "currently exits 1" comments.

## Scope notes
- `bail!` remains used elsewhere in both files (for non-user errors and `None` branches); import is still needed.
- The `MatchResult::None(_)` branches (no-match-at-all) also exit 1 today via `bail!`. Out of scope here — #237 is specifically about ambiguity. Can be revisited if the same consistency concern applies.
- No new `unlink` integration test in this PR; that gap is tracked in #236.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 803 passed, 0 failed
- [x] The two flipped tests pass with `Some(64)`:
  - `test_move_single_substring_rejected_no_input`
  - `test_link_single_substring_rejected_no_input`

Closes #237