### PR TITLE
test: substring-rejection tests for unlink, queue, assets schema (#236)

### DIFF
--- a/tests/assets.rs
+++ b/tests/assets.rs
@@ -1382,3 +1382,91 @@ async fn schema_table_filters_system_attrs() {
     // System attrs "Key" and "Created" should be filtered out
     assert!(!stdout.contains("Created"));
 }
+
+/// Single-substring hit on `--schema` must route through Ambiguous and
+/// error with exit 64. Locks the resolve_schema branch at assets.rs:471.
+/// No object-type listing or object-schema-attribute fetch should occur.
+#[tokio::test]
+async fn schema_single_substring_schema_filter_rejected() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/servicedeskapi/assets/workspace"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "size": 1, "start": 0, "limit": 50, "isLastPage": true,
+            "values": [{ "workspaceId": "ws-123" }]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/jsm/assets/workspace/ws-123/v1/objectschema/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "startAt": 0, "maxResults": 25, "total": 2, "isLast": true,
+            "values": [
+                { "id": "6", "name": "ITSM", "objectSchemaKey": "ITSM",
+                  "status": "Ok", "objectCount": 95, "objectTypeCount": 2 },
+                { "id": "7", "name": "Office", "objectSchemaKey": "OFF",
+                  "status": "Ok", "objectCount": 50, "objectTypeCount": 3 }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    // Assert no object-type listing fires — schema resolution must
+    // short-circuit.
+    Mock::given(method("GET"))
+        .and(path(
+            "/jsm/assets/workspace/ws-123/v1/objectschema/6/objecttypes/flat",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .expect(0)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/jsm/assets/workspace/ws-123/v1/objectschema/7/objecttypes/flat",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let _guard = set_cache_dir(cache_dir.path()).await;
+
+    let output = assert_cmd::Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args([
+            "--no-input",
+            "assets",
+            "schema",
+            "AnyType",
+            "--schema",
+            "its",
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "Expected failure on ambiguous schema filter, stderr: {stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "Ambiguous schema should exit 64 (UserError), got: {:?}",
+        output.status.code()
+    );
+    assert!(
+        stderr.contains("Ambiguous schema"),
+        "Expected 'Ambiguous schema' in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("ITSM"),
+        "Expected matched schema 'ITSM' in stderr: {stderr}"
+    );
+}

--- a/tests/issue_commands.rs
+++ b/tests/issue_commands.rs
@@ -1814,3 +1814,56 @@ async fn test_link_single_substring_rejected_no_input() {
         "Expected matched candidate 'Blocks' in stderr: {stderr}"
     );
 }
+
+#[tokio::test]
+async fn test_unlink_single_substring_rejected_no_input() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issueLinkType"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(common::fixtures::link_types_response()),
+        )
+        .mount(&server)
+        .await;
+
+    // Assert no DELETE /issueLink/* occurs — the substring must short-circuit.
+    // Unlink also fetches candidate links (GET /rest/api/3/issue/FOO-1?fields=issuelinks)
+    // before any delete, but that's irrelevant here since we error out before
+    // reaching that call. No DELETE mock is mounted at all.
+    let output = assert_cmd::Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args([
+            "--no-input",
+            "issue",
+            "unlink",
+            "FOO-1",
+            "FOO-2",
+            "--type",
+            "block",
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "Expected failure on ambiguous substring, stderr: {stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "Ambiguous link type should exit 64 (UserError), got: {:?}",
+        output.status.code()
+    );
+    assert!(
+        stderr.contains("Ambiguous link type"),
+        "Expected 'Ambiguous link type' in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Blocks"),
+        "Expected matched candidate 'Blocks' in stderr: {stderr}"
+    );
+}

--- a/tests/queue.rs
+++ b/tests/queue.rs
@@ -229,6 +229,58 @@ async fn resolve_queue_duplicate_names_error_message() {
     );
 }
 
+/// Single-substring hit on a queue name must route through Ambiguous and
+/// error with the disambiguation message + UserError (exit 64 in the
+/// binary). Complements the ExactMultiple coverage above and locks the
+/// behavior at queue.rs:169 from the #193 strict-matching rollout.
+#[tokio::test]
+async fn resolve_queue_single_substring_is_ambiguous() {
+    let server = MockServer::start().await;
+
+    // "escal" is a single-substring of "Escalations" only — "General Requests"
+    // shares no substring. The input is neither exact nor a multi-hit, which
+    // is the exact scenario the #193 strict-matching rollout now routes
+    // through Ambiguous.
+    Mock::given(method("GET"))
+        .and(path("/rest/servicedeskapi/servicedesk/15/queue"))
+        .and(query_param("includeCount", "true"))
+        .and(query_param("start", "0"))
+        .and(query_param("limit", "50"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "size": 2,
+            "start": 0,
+            "limit": 50,
+            "isLastPage": true,
+            "values": [
+                { "id": "10", "name": "Escalations", "issueCount": 5 },
+                { "id": "20", "name": "General Requests", "issueCount": 3 }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let client =
+        jr::api::client::JiraClient::new_for_test(server.uri(), "Basic dGVzdDp0ZXN0".into());
+    let result = jr::cli::queue::resolve_queue_by_name("15", "escal", &client).await;
+
+    let err = result.unwrap_err();
+    assert!(
+        err.downcast_ref::<jr::error::JrError>()
+            .is_some_and(|e| matches!(e, jr::error::JrError::UserError(_))),
+        "Expected JrError::UserError, got: {err}"
+    );
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("matches multiple queues"),
+        "Expected disambiguation phrase in error, got: {msg}"
+    );
+    assert!(
+        msg.contains("Escalations"),
+        "Expected matched queue 'Escalations' in error, got: {msg}"
+    );
+}
+
 #[tokio::test]
 async fn resolve_queue_mixed_case_duplicate_names_error_message() {
     let server = MockServer::start().await;


### PR DESCRIPTION
## Summary
Extends handler-level `partial_match` single-substring rejection coverage to three more call sites from #236:
- **`issue unlink`** (binary test) — `jr unlink --type block` → exit 64, `Ambiguous link type`, no DELETE fires
- **`queue resolve`** (library test on `resolve_queue_by_name`) — complements existing `ExactMultiple` test; asserts `JrError::UserError` via downcast
- **`assets schema --schema`** (binary test) — `jr assets schema AnyType --schema its` → exit 64, `Ambiguous schema`, no object-type listing fires

Each test uses a genuine single-hit substring (`block`, `escal`, `its`) against a candidate list where only one entry substring-matches, so the test exercises the #193 regression surface directly (single-hit substrings that used to resolve silently now route through `Ambiguous`).

## Scope
This PR covers **3 of the 8** call sites listed in #236. The remaining 5 are **deferred to #240**:
- `helpers.rs` team/user/asset resolution — uses `bail!` (exit 1) and needs a parallel refactor similar to #237
- `assets search --status` — needs AQL + ticket-enrichment plumbing
- `assets schema <type_name>` object-type match — needs schemas + objecttypes/flat mocks

## Design choices
- **Queue test is library-level**, not binary. The full binary path for `jr queue view` requires project-meta + service-desk discovery + queue list mocks (3 chained mocks). The test precedent at `queue.rs:190` (`resolve_queue_duplicate_names_error_message`) is library-level; this PR mirrors that pattern for the Ambiguous variant.
- **Unlink test mounts no DELETE mock** — wiremock 404s unmatched requests, which would surface as a different error if a delete were attempted. Combined with the exit 64 + `Ambiguous link type` assertions this implicitly locks the short-circuit.
- **Assets schema test uses `.expect(0)`** on both `objecttypes/flat` endpoints — explicit short-circuit assertion.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 806 passed, 0 failed (+3 new over baseline 803)
- [x] Local code review: no critical/important findings

Refs #236