### PR TITLE
feat: warn on unexpected team field shape in verbose mode (#195)

### DIFF
--- a/src/cli/issue/list.rs
+++ b/src/cli/issue/list.rs
@@ -931,7 +931,7 @@ pub(super) async fn handle_view(
             }
 
             if let Some(field_id) = team_field_id {
-                if let Some(team_uuid) = issue.fields.team_id(field_id) {
+                if let Some(team_uuid) = issue.fields.team_id(field_id, client.verbose()) {
                     let team_display = match crate::cache::read_team_cache() {
                         Ok(Some(c)) => c
                             .teams

--- a/src/types/jira/issue.rs
+++ b/src/types/jira/issue.rs
@@ -84,8 +84,41 @@ impl IssueFields {
         self.extra.get(field_id)?.as_f64()
     }
 
-    pub fn team_id(&self, field_id: &str) -> Option<String> {
-        self.extra.get(field_id)?.as_str().map(String::from)
+    /// Extract the team UUID from the issue's team field.
+    ///
+    /// Returns `None` when the field is missing, null, or present but not
+    /// a JSON string. In the present-but-not-a-string case — typically an
+    /// object like `{"id": "..."}` from a misconfigured `team_field_id`
+    /// pointing at a non-Teams custom field — emits a once-per-process
+    /// `[verbose]` hint on stderr so users can diagnose the silent drop.
+    pub fn team_id(&self, field_id: &str, verbose: bool) -> Option<String> {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        static LOGGED: AtomicBool = AtomicBool::new(false);
+        let value = self.extra.get(field_id)?;
+        match value.as_str() {
+            Some(s) => Some(s.to_string()),
+            None => {
+                if !value.is_null() && verbose && !LOGGED.swap(true, Ordering::Relaxed) {
+                    eprintln!(
+                        "[verbose] team field \"{field_id}\" has unexpected shape \
+                         (expected string UUID, got {}). Check team_field_id in config.",
+                        value_kind(value)
+                    );
+                }
+                None
+            }
+        }
+    }
+}
+
+fn value_kind(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
     }
 }
 
@@ -187,7 +220,7 @@ mod tests {
             json!("36885b3c-1bf0-4f85-a357-c5b858c31de4"),
         );
         assert_eq!(
-            fields.team_id("customfield_10001"),
+            fields.team_id("customfield_10001", false),
             Some("36885b3c-1bf0-4f85-a357-c5b858c31de4".to_string())
         );
     }
@@ -195,13 +228,32 @@ mod tests {
     #[test]
     fn team_id_returns_none_for_null_value() {
         let fields = fields_with_extra("customfield_10001", json!(null));
-        assert_eq!(fields.team_id("customfield_10001"), None);
+        assert_eq!(fields.team_id("customfield_10001", false), None);
     }
 
     #[test]
     fn team_id_returns_none_for_missing_key() {
         let fields = IssueFields::default();
-        assert_eq!(fields.team_id("customfield_10001"), None);
+        assert_eq!(fields.team_id("customfield_10001", false), None);
+    }
+
+    #[test]
+    fn team_id_returns_none_for_object_value() {
+        // Misconfigured team_field_id pointing at a non-Teams custom field
+        // (e.g., user-picker) can deliver an object like {"id": "..."}.
+        // team_id returns None and — if verbose — logs once; with verbose=false
+        // here, this just pins the None return without touching the gate flag.
+        let fields = fields_with_extra(
+            "customfield_10001",
+            json!({"id": "36885b3c-1bf0-4f85-a357-c5b858c31de4"}),
+        );
+        assert_eq!(fields.team_id("customfield_10001", false), None);
+    }
+
+    #[test]
+    fn team_id_returns_none_for_array_value() {
+        let fields = fields_with_extra("customfield_10001", json!([1, 2, 3]));
+        assert_eq!(fields.team_id("customfield_10001", false), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
`IssueFields::team_id` previously returned `None` silently when the team field was present but not a JSON string — typically an object like `{"id": "..."}` delivered by a misconfigured `team_field_id` pointing at a non-Teams custom field. The Team row on `jr issue view` silently disappeared with no diagnostic.

This change adds a `verbose: bool` parameter. On the "present but not a string, not null" path, we emit a once-per-process `[verbose]` hint to stderr naming the field and the actual value kind (`object`, `array`, `number`, `bool`). Null and missing remain silent — those are well-formed "no team set" states, not configuration errors.

## Design
Follows the existing pattern from `src/observability.rs::log_parse_failure_once`: inline `static AtomicBool` gate + `eprintln!("[verbose] ...")`. The gate ordering (verbose check before `swap(true)`) preserves the same invariant pinned in `observability::tests::verbose_false_leaves_flag_untouched` — a non-verbose run doesn't burn the flag.

I considered refactoring `log_parse_failure_once` into a shared helper, but kept inline duplication: the existing helper encodes a fixed message template (`"{site} timestamp failed to parse: {iso}"`) and generalizing it for a second caller would widen its responsibility and add public API surface for a two-caller pattern. YAGNI.

## Changes
- `src/types/jira/issue.rs` — `team_id(&self, field_id, verbose)` signature + `value_kind()` helper
- `src/cli/issue/list.rs:934` — call site passes `client.verbose()`
- 3 existing unit tests updated; 2 new unit tests for object + array value shapes

## Scope notes
- Single production call site (`handle_view` in list.rs). The signature change is narrow.
- No logging for null/missing — those are valid "no team set" responses.
- The warning is gated on `--verbose` per the project's existing verbose-logging convention (no tracing crate).

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 805 passed, 0 failed (baseline 803 + 2 new)
- [x] 5 `team_id_*` unit tests all pass
- [x] Local code review: no critical/important findings

Closes #195