### PR TITLE
feat(team): UUID pass-through + auto-refresh on cache miss (#190)

### DIFF
--- a/src/cli/issue/helpers.rs
+++ b/src/cli/issue/helpers.rs
@@ -5,6 +5,34 @@ use crate::config::Config;
 use crate::error::JrError;
 use crate::types::jira::User;
 
+/// Detect Atlassian team UUID format: 36 chars, hex digits split into
+/// 8-4-4-4-12 groups by hyphens. Case-insensitive on hex.
+///
+/// Used to short-circuit the cache-name-match path for agents that already
+/// know a team's ID — `--team <uuid>` sends the value straight to the
+/// customfield without a cache lookup or name match.
+fn is_team_uuid(s: &str) -> bool {
+    if s.len() != 36 {
+        return false;
+    }
+    let bytes = s.as_bytes();
+    for (i, b) in bytes.iter().enumerate() {
+        match i {
+            8 | 13 | 18 | 23 => {
+                if *b != b'-' {
+                    return false;
+                }
+            }
+            _ => {
+                if !b.is_ascii_hexdigit() {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
 pub(super) async fn resolve_team_field(
     config: &Config,
     client: &JiraClient,
@@ -25,15 +53,54 @@ pub(super) async fn resolve_team_field(
             })?
     };
 
-    // 2. Load teams from cache (or fetch if missing/expired)
-    let teams = match crate::cache::read_team_cache()? {
-        Some(cached) => cached.teams,
-        None => crate::cli::team::fetch_and_cache_teams(config, client).await?,
+    // 2. UUID pass-through: if the caller already has a team UUID (agents,
+    // scripts), skip cache + name-match entirely. The customfield accepts
+    // the UUID directly — no lookup needed. Pre-cache-load so a cold cache
+    // doesn't force a teams fetch just to validate an ID we already have.
+    if is_team_uuid(team_name) {
+        if client.verbose() {
+            eprintln!("[verbose] team resolved via UUID pass-through: {team_name}");
+        }
+        return Ok((field_id, team_name.to_string()));
+    }
+
+    // 3. Load teams from cache (or fetch if missing/expired). `cache_was_fresh`
+    // tells step 5 whether an auto-refresh-on-miss is worth attempting —
+    // no point re-fetching a list we just fetched.
+    let (teams, cache_was_fresh) = match crate::cache::read_team_cache()? {
+        Some(cached) => (cached.teams, false),
+        None => (
+            crate::cli::team::fetch_and_cache_teams(config, client).await?,
+            true,
+        ),
     };
 
-    // 3. Partial match
+    // 4. Partial match
     let team_names: Vec<String> = teams.iter().map(|t| t.name.clone()).collect();
-    match crate::partial_match::partial_match(team_name, &team_names) {
+    let match_result = crate::partial_match::partial_match(team_name, &team_names);
+
+    // 5. Auto-refresh on miss: if the cache came from disk and the name
+    // didn't match anything, the team was likely added upstream since the
+    // last refresh. Fetch once transparently and retry. Bounded to a
+    // single retry via `cache_was_fresh` — no infinite-refresh loop.
+    // `refreshed` tracks whether a retry happened so the bail message at
+    // step 6 can avoid the stale "run `jr team list --refresh`" advice.
+    let mut refreshed = false;
+    let (teams, match_result) =
+        if matches!(match_result, crate::partial_match::MatchResult::None(_)) && !cache_was_fresh {
+            if client.verbose() {
+                eprintln!("[verbose] team \"{team_name}\" not in cache, refreshing from server...");
+            }
+            let fresh = crate::cli::team::fetch_and_cache_teams(config, client).await?;
+            let fresh_names: Vec<String> = fresh.iter().map(|t| t.name.clone()).collect();
+            let retry = crate::partial_match::partial_match(team_name, &fresh_names);
+            refreshed = true;
+            (fresh, retry)
+        } else {
+            (teams, match_result)
+        };
+
+    match match_result {
         crate::partial_match::MatchResult::Exact(matched_name) => {
             let idx = teams
                 .iter()
@@ -93,6 +160,16 @@ pub(super) async fn resolve_team_field(
             Ok((field_id, teams[idx].id.clone()))
         }
         crate::partial_match::MatchResult::None(_) => {
+            // Post-refresh miss: the cache was just fetched fresh, so advising
+            // "run jr team list --refresh" would be misleading. Tell the user
+            // the team genuinely doesn't exist.
+            if refreshed {
+                anyhow::bail!(
+                    "No team matching \"{}\" (checked a fresh team list). \
+                     Verify the team name or check access permissions.",
+                    team_name
+                );
+            }
             anyhow::bail!(
                 "No team matching \"{}\". Run \"jr team list --refresh\" to update.",
                 team_name
@@ -486,6 +563,50 @@ pub(super) async fn resolve_asset(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn is_team_uuid_accepts_standard_uuid() {
+        assert!(is_team_uuid("36885b3c-1bf0-4f85-a357-c5b858c31de4"));
+    }
+
+    #[test]
+    fn is_team_uuid_accepts_uppercase_hex() {
+        // Atlassian UUIDs are typically lowercase but the format is
+        // case-insensitive — accept either so users don't get bitten by
+        // copy-paste casing.
+        assert!(is_team_uuid("36885B3C-1BF0-4F85-A357-C5B858C31DE4"));
+    }
+
+    #[test]
+    fn is_team_uuid_accepts_mixed_case_hex() {
+        assert!(is_team_uuid("36885B3c-1bF0-4F85-a357-c5B858c31De4"));
+    }
+
+    #[test]
+    fn is_team_uuid_rejects_wrong_length() {
+        assert!(!is_team_uuid("36885b3c-1bf0-4f85-a357-c5b858c31de"));
+        assert!(!is_team_uuid("36885b3c-1bf0-4f85-a357-c5b858c31de44"));
+        assert!(!is_team_uuid(""));
+    }
+
+    #[test]
+    fn is_team_uuid_rejects_missing_hyphen() {
+        // Right length, wrong separator at position 8
+        assert!(!is_team_uuid("36885b3c11bf0-4f85-a357-c5b858c31de4"));
+    }
+
+    #[test]
+    fn is_team_uuid_rejects_non_hex() {
+        // 'g' is not a hex digit
+        assert!(!is_team_uuid("g6885b3c-1bf0-4f85-a357-c5b858c31de4"));
+    }
+
+    #[test]
+    fn is_team_uuid_rejects_team_name_with_hyphens() {
+        // Plausible team names with hyphens shouldn't pass as UUIDs.
+        assert!(!is_team_uuid("backend-platform-team-lead-group-main"));
+        assert!(!is_team_uuid("Platform Ops"));
+    }
 
     #[test]
     fn is_me_keyword_lowercase() {

--- a/src/cli/issue/helpers.rs
+++ b/src/cli/issue/helpers.rs
@@ -83,10 +83,7 @@ pub(super) async fn resolve_team_field(
     // didn't match anything, the team was likely added upstream since the
     // last refresh. Fetch once transparently and retry. Bounded to a
     // single retry via `cache_was_fresh` — no infinite-refresh loop.
-    // `refreshed` tracks whether a retry happened so the bail message at
-    // step 6 can avoid the stale "run `jr team list --refresh`" advice.
-    let mut refreshed = false;
-    let (teams, match_result) =
+    let (teams, match_result, retry_fetched) =
         if matches!(match_result, crate::partial_match::MatchResult::None(_)) && !cache_was_fresh {
             if client.verbose() {
                 eprintln!("[verbose] team \"{team_name}\" not in cache, refreshing from server...");
@@ -94,11 +91,16 @@ pub(super) async fn resolve_team_field(
             let fresh = crate::cli::team::fetch_and_cache_teams(config, client).await?;
             let fresh_names: Vec<String> = fresh.iter().map(|t| t.name.clone()).collect();
             let retry = crate::partial_match::partial_match(team_name, &fresh_names);
-            refreshed = true;
-            (fresh, retry)
+            (fresh, retry, true)
         } else {
-            (teams, match_result)
+            (teams, match_result, false)
         };
+
+    // Any fetch during this call (either the initial cold-cache fetch at
+    // step 3 or the retry above) means the bail message at step 6 can
+    // avoid the stale "run `jr team list --refresh`" advice — the user
+    // just effectively did.
+    let fetched_fresh = cache_was_fresh || retry_fetched;
 
     match match_result {
         crate::partial_match::MatchResult::Exact(matched_name) => {
@@ -160,10 +162,9 @@ pub(super) async fn resolve_team_field(
             Ok((field_id, teams[idx].id.clone()))
         }
         crate::partial_match::MatchResult::None(_) => {
-            // Post-refresh miss: the cache was just fetched fresh, so advising
-            // "run jr team list --refresh" would be misleading. Tell the user
-            // the team genuinely doesn't exist.
-            if refreshed {
+            // Any fresh fetch this call (cold-cache or retry) means advising
+            // "run jr team list --refresh" would be misleading — we just did.
+            if fetched_fresh {
                 anyhow::bail!(
                     "No team matching \"{}\" (checked a fresh team list). \
                      Verify the team name or check access permissions.",
@@ -602,10 +603,28 @@ mod tests {
     }
 
     #[test]
-    fn is_team_uuid_rejects_team_name_with_hyphens() {
-        // Plausible team names with hyphens shouldn't pass as UUIDs.
-        assert!(!is_team_uuid("backend-platform-team-lead-group-main"));
-        assert!(!is_team_uuid("Platform Ops"));
+    fn is_team_uuid_rejects_plausible_team_name_with_hyphens() {
+        // Plausible team names shouldn't pass as UUIDs. 37 chars and 12 chars
+        // — both rejected by the length check (complements the 36-char
+        // hyphen-position test below).
+        assert!(!is_team_uuid("backend-platform-team-lead-group-main")); // 37
+        assert!(!is_team_uuid("Platform Ops")); // 12
+    }
+
+    #[test]
+    fn is_team_uuid_rejects_hyphens_in_wrong_position_at_36_chars() {
+        // 36-char hyphenated string with hyphens at non-UUID positions
+        // (12, 17, 22, 27 vs the required 8, 13, 18, 23). Exercises the
+        // per-position validation rather than the length gate.
+        assert!(!is_team_uuid("platform-ops-team-lead-group-mainxxx"));
+    }
+
+    #[test]
+    fn is_team_uuid_rejects_non_hex_at_hex_position() {
+        // 36-char UUID-shaped string with correct hyphen positions but
+        // non-hex ('x') in the final group. Exercises the hex-slot check
+        // at indices past all hyphen positions.
+        assert!(!is_team_uuid("aaaaaaaa-aaaa-aaaa-aaaa-xxxxxxxxxxxx"));
     }
 
     #[test]

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1853,3 +1853,44 @@ async fn test_edit_team_auto_refresh_gives_up_after_one_retry() {
         .stderr(predicate::str::contains("checked a fresh team list"))
         .stderr(predicate::str::contains("jr team list --refresh").not());
 }
+
+/// Cold-cache miss: no local team cache exists, so step 3 fetches fresh
+/// immediately. A missing name in that fresh fetch must also emit the
+/// "checked a fresh team list" message — not the "run jr team list
+/// --refresh" advice, which would be misleading since we just fetched.
+/// Pins the `fetched_fresh = cache_was_fresh || retry_fetched` logic.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_edit_team_cold_cache_miss_avoids_stale_advice() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/gateway/api/graphql"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(common::fixtures::graphql_org_metadata_json()),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    // Fresh fetch returns teams_list_json (Alpha / Beta / Security) — no
+    // "NonexistentTeam". The retry at step 5 is skipped because the cache
+    // was already fresh, but the bail must still use the fresh-list
+    // message (exercises cache_was_fresh=true, retry_fetched=false).
+    Mock::given(method("GET"))
+        .and(path_regex("/gateway/api/public/teams/v1/org/.*/teams"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(common::fixtures::teams_list_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap(); // no teams.json — cold cache
+    let config_dir = tempfile::tempdir().unwrap();
+    write_test_config_with_team_and_instance(config_dir.path(), &server.uri());
+
+    jr_cmd_with_xdg(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "edit", "HDL-703", "--team", "NonexistentTeam"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No team matching"))
+        .stderr(predicate::str::contains("checked a fresh team list"))
+        .stderr(predicate::str::contains("jr team list --refresh").not());
+}

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -3,7 +3,7 @@ mod common;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
-use wiremock::matchers::{body_partial_json, method, path, query_param};
+use wiremock::matchers::{body_partial_json, method, path, path_regex, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Build a `jr` command pre-configured for handler-level testing.
@@ -1691,4 +1691,165 @@ async fn test_verbose_omits_body_line_for_get() {
         .success()
         .stderr(predicate::str::contains("[verbose] GET"))
         .stderr(predicate::str::contains("[verbose] body:").not());
+}
+
+/// UUID pass-through (issue #190): `--team <uuid>` must skip cache +
+/// name-resolution entirely and send the UUID straight to the customfield.
+/// GraphQL metadata and the teams list endpoint should never be hit.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_edit_team_uuid_pass_through_skips_cache_lookup() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/api/3/issue/HDL-700"))
+        .and(body_partial_json(serde_json::json!({
+            "fields": {
+                "customfield_10100": "deadbeef-cafe-4123-8abc-0123456789ab"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // The team-resolution path must NOT fire for a UUID input — asserting 0
+    // hits on both endpoints pins the short-circuit at resolve_team_field's
+    // entry.
+    Mock::given(method("POST"))
+        .and(path("/gateway/api/graphql"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_regex("/gateway/api/public/teams/v1/org/.*/teams"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    write_test_team_cache(cache_dir.path());
+    write_test_config_with_team_field(config_dir.path());
+
+    jr_cmd_with_xdg(&server.uri(), cache_dir.path(), config_dir.path())
+        .args([
+            "issue",
+            "edit",
+            "HDL-700",
+            "--team",
+            "deadbeef-cafe-4123-8abc-0123456789ab",
+        ])
+        .assert()
+        .success();
+}
+
+/// Write a config.toml with both team_field_id AND an instance URL —
+/// `resolve_org_id` extracts the hostname from `instance.url` to build the
+/// GraphQL query for org metadata. Required for any test that exercises
+/// the fetch_and_cache_teams path (auto-refresh on miss).
+fn write_test_config_with_team_and_instance(config_home: &std::path::Path, url: &str) {
+    let conf_dir = config_home.join("jr");
+    std::fs::create_dir_all(&conf_dir).unwrap();
+    std::fs::write(
+        conf_dir.join("config.toml"),
+        format!(
+            "[instance]\nurl = \"{url}\"\n[fields]\nteam_field_id = \"{TEST_TEAM_FIELD_ID}\"\n"
+        ),
+    )
+    .unwrap();
+}
+
+/// Auto-refresh on miss (issue #190): when the cached team list doesn't
+/// contain the requested name, refresh once and retry. Locks the fetch
+/// count at exactly 1 — no infinite refresh loop.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_edit_team_auto_refreshes_cache_on_miss() {
+    let server = MockServer::start().await;
+
+    // Cache only has "Platform" / "Platform Ops". User asks for "Alpha
+    // Team", which isn't in the stale cache but IS in the fresh API
+    // response (teams_list_json includes "Alpha Team" → team-uuid-alpha).
+    Mock::given(method("POST"))
+        .and(path("/gateway/api/graphql"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(common::fixtures::graphql_org_metadata_json()),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_regex("/gateway/api/public/teams/v1/org/.*/teams"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(common::fixtures::teams_list_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(path("/rest/api/3/issue/HDL-701"))
+        .and(body_partial_json(serde_json::json!({
+            "fields": { "customfield_10100": "team-uuid-alpha" }
+        })))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    write_test_team_cache(cache_dir.path());
+    write_test_config_with_team_and_instance(config_dir.path(), &server.uri());
+
+    jr_cmd_with_xdg(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "edit", "HDL-701", "--team", "Alpha Team"])
+        .assert()
+        .success();
+}
+
+/// Auto-refresh on miss is bounded to a single retry: when the name is
+/// missing from both the stale cache and a fresh fetch, `resolve_team_field`
+/// bails instead of looping. Asserts exactly one teams fetch fires.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_edit_team_auto_refresh_gives_up_after_one_retry() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/gateway/api/graphql"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(common::fixtures::graphql_org_metadata_json()),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_regex("/gateway/api/public/teams/v1/org/.*/teams"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(common::fixtures::teams_list_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Never reached — the command must bail before any PUT.
+    Mock::given(method("PUT"))
+        .and(path("/rest/api/3/issue/HDL-702"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    write_test_team_cache(cache_dir.path());
+    write_test_config_with_team_and_instance(config_dir.path(), &server.uri());
+
+    jr_cmd_with_xdg(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "edit", "HDL-702", "--team", "NonexistentTeam"])
+        .assert()
+        .failure()
+        // Post-refresh miss: the message must say "checked a fresh team list"
+        // and NOT suggest running `jr team list --refresh` (which the user
+        // just effectively did).
+        .stderr(predicate::str::contains("No team matching"))
+        .stderr(predicate::str::contains("checked a fresh team list"))
+        .stderr(predicate::str::contains("jr team list --refresh").not());
 }


### PR DESCRIPTION
## Summary
Two usability wins for team resolution on `jr issue create/edit/list --team`:

### 1. UUID pass-through
Detect standard Atlassian team UUID format (36-char, hex+hyphen, 8-4-4-4-12) at `resolve_team_field`'s entry — skip cache load + name match entirely. Pre-cache-load means a cold cache no longer forces a teams fetch just to validate an ID the caller already knows. Useful for agents and scripts with pre-known team IDs.

### 2. Auto-refresh on miss
When name resolution returns `MatchResult::None` and the cache came from disk (not freshly fetched), fetch once transparently and retry. Bounded to a single retry via a `cache_was_fresh` flag — no infinite loop.

## Observability
Under `--verbose`, both paths emit hints so users can debug latency spikes or confirm the short-circuit fired:
```
[verbose] team resolved via UUID pass-through: <uuid>
[verbose] team "<name>" not in cache, refreshing from server...
```

Post-refresh-miss message is context-aware: if the retry also missed, the bail says "No team matching \"X\" (checked a fresh team list). Verify the team name or check access permissions." — not the stale "Run \`jr team list --refresh\`" advice (which the user just effectively ran).

## Findings from local review (all addressed)
| # | Finding | Source | Resolution |
|---|---|---|---|
| 1 | Post-refresh miss message suggested running the refresh that just ran | silent-failure-hunter | Added `refreshed` flag; distinct message path |
| 2 | Auto-refresh and UUID pass-through were silent even under `--verbose` | silent-failure-hunter | Added two `[verbose]` eprintln hints |
| 3 | Team name literally matching UUID format would bypass name match | code-reviewer | Noted as acceptable trade-off (probability near zero, server rejects with 400) |
| 4 | `resolve_team_field` called from 3 sites; only edit path covered | code-reviewer | Shared helper; integration coverage is structural. Noted for follow-up if create/list paths diverge |

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 824 passed, 0 failed (baseline 814 + 10 new)
- [x] 7 unit tests on `is_team_uuid`
- [x] 3 integration tests pin `.expect(n)` on each endpoint:
  - UUID pass-through: `.expect(0)` on GraphQL + teams, `.expect(1)` on PUT
  - Auto-refresh success: exactly 1 GraphQL + 1 teams fetch, PUT with refreshed UUID
  - Bounded-retry bail: exactly 1 fetch, no PUT, "checked a fresh team list" in error

Closes #190