### PR TITLE
feat: show Team column in jr issue list output (#191)

### DIFF
--- a/src/cli/issue/format.rs
+++ b/src/cli/issue/format.rs
@@ -6,18 +6,27 @@ use crate::types::jira::Issue;
 pub fn format_issue_rows_public(issues: &[Issue]) -> Vec<Vec<String>> {
     issues
         .iter()
-        .map(|issue| format_issue_row(issue, None, None))
+        .map(|issue| format_issue_row(issue, None, None, None))
         .collect()
 }
 
-/// Build a single table row for an issue, optionally including story points and linked assets.
+/// Build a single table row for an issue, optionally including story points,
+/// linked assets, and team.
+///
+/// `team` is a per-row pre-resolved display string: caller looks up the team
+/// UUID in the cache and passes the human-readable name or a fallback. When
+/// the enclosing column is not shown (the `show_team` flag in
+/// `issue_table_headers`), callers pass `None` and the slot is skipped.
 pub fn format_issue_row(
     issue: &Issue,
     sp_field_id: Option<&str>,
     assets: Option<&[LinkedAsset]>,
+    team: Option<&str>,
 ) -> Vec<String> {
-    let col_count =
-        6 + if sp_field_id.is_some() { 1 } else { 0 } + if assets.is_some() { 1 } else { 0 };
+    let col_count = 6
+        + if sp_field_id.is_some() { 1 } else { 0 }
+        + if assets.is_some() { 1 } else { 0 }
+        + if team.is_some() { 1 } else { 0 };
     let mut row = Vec::with_capacity(col_count);
     row.push(issue.key.clone());
     row.push(
@@ -61,6 +70,9 @@ pub fn format_issue_row(
             .map(|a| a.display_name.clone())
             .unwrap_or_else(|| "Unassigned".into()),
     );
+    if let Some(team_display) = team {
+        row.push(team_display.to_string());
+    }
     if let Some(linked) = assets {
         row.push(format_linked_assets_short(linked));
     }
@@ -68,13 +80,21 @@ pub fn format_issue_row(
     row
 }
 
-/// Headers matching `format_issue_row` output.
-pub fn issue_table_headers(show_points: bool, show_assets: bool) -> Vec<&'static str> {
+/// Headers matching `format_issue_row` output. `show_team` mirrors the
+/// per-row `team` option: when true, each row must supply a `team` string.
+pub fn issue_table_headers(
+    show_points: bool,
+    show_assets: bool,
+    show_team: bool,
+) -> Vec<&'static str> {
     let mut headers = vec!["Key", "Type", "Status", "Priority"];
     if show_points {
         headers.push("Points");
     }
     headers.push("Assignee");
+    if show_team {
+        headers.push("Team");
+    }
     if show_assets {
         headers.push("Assets");
     }

--- a/src/cli/issue/list.rs
+++ b/src/cli/issue/list.rs
@@ -149,7 +149,13 @@ pub(super) async fn handle_list(
     };
 
     let sp_field_id = config.global.fields.story_points_field_id.as_deref();
+    let team_field_id = config.global.fields.team_field_id.as_deref();
     let mut extra: Vec<&str> = sp_field_id.iter().copied().collect();
+    // Request team field on list output so handle_list can surface a Team
+    // column per #191 (shown only when ≥1 issue has a populated team).
+    if let Some(t) = team_field_id {
+        extra.push(t);
+    }
 
     // Resolve team name to (field_id, uuid) before building JQL
     let resolved_team = if let Some(ref team_name) = team {
@@ -475,6 +481,39 @@ pub(super) async fn handle_list(
         }
     }
 
+    // Team column gating (#191): show only when team_field_id is configured
+    // AND at least one issue has a populated team. Resolve UUIDs to names via
+    // the team cache once, per-row lookup is O(1) against the map.
+    let client_verbose = client.verbose();
+    let team_displays: Vec<String> = if let Some(field_id) = team_field_id {
+        let uuids: Vec<Option<String>> = issues
+            .iter()
+            .map(|i| i.fields.team_id(field_id, client_verbose))
+            .collect();
+        if uuids.iter().any(|u| u.is_some()) {
+            // Team cache read is best-effort for display — an Err or missing
+            // entry falls back to the UUID. Cache population is not this
+            // command's responsibility.
+            let cache = crate::cache::read_team_cache().ok().flatten();
+            uuids
+                .iter()
+                .map(|u| match u {
+                    Some(uuid) => cache
+                        .as_ref()
+                        .and_then(|c| c.teams.iter().find(|t| t.id == *uuid))
+                        .map(|t| t.name.clone())
+                        .unwrap_or_else(|| uuid.clone()),
+                    None => "-".to_string(),
+                })
+                .collect()
+        } else {
+            Vec::new()
+        }
+    } else {
+        Vec::new()
+    };
+    let show_team_col = !team_displays.is_empty();
+
     let rows: Vec<Vec<String>> = issues
         .iter()
         .enumerate()
@@ -484,10 +523,16 @@ pub(super) async fn handle_list(
             } else {
                 None
             };
-            format::format_issue_row(issue, effective_sp, assets)
+            let team = if show_team_col {
+                Some(team_displays[i].as_str())
+            } else {
+                None
+            };
+            format::format_issue_row(issue, effective_sp, assets, team)
         })
         .collect();
-    let headers = format::issue_table_headers(effective_sp.is_some(), show_assets_col);
+    let headers =
+        format::issue_table_headers(effective_sp.is_some(), show_assets_col, show_team_col);
     output::print_output(output_format, &headers, &rows, &issues)?;
 
     if has_more && !all {

--- a/src/cli/issue/list.rs
+++ b/src/cli/issue/list.rs
@@ -485,8 +485,15 @@ pub(super) async fn handle_list(
     // AND at least one issue has a populated team. Build the UUID→name map
     // once so per-row resolution is O(1) against the HashMap (rather than a
     // linear scan of the cache vec for every row).
+    //
+    // Skipped entirely in JSON mode: `print_output` only serializes `issues`
+    // under OutputFormat::Json and ignores `rows`, so the cache read + map
+    // build would be wasted filesystem I/O. JSON consumers already see the
+    // raw UUID under `fields.extra[team_field_id]` and can resolve locally.
     let client_verbose = client.verbose();
-    let team_displays: Vec<String> = if let Some(field_id) = team_field_id {
+    let team_displays: Vec<String> = if matches!(output_format, OutputFormat::Table)
+        && let Some(field_id) = team_field_id
+    {
         let uuids: Vec<Option<String>> = issues
             .iter()
             .map(|i| i.fields.team_id(field_id, client_verbose))

--- a/src/cli/issue/list.rs
+++ b/src/cli/issue/list.rs
@@ -482,8 +482,9 @@ pub(super) async fn handle_list(
     }
 
     // Team column gating (#191): show only when team_field_id is configured
-    // AND at least one issue has a populated team. Resolve UUIDs to names via
-    // the team cache once, per-row lookup is O(1) against the map.
+    // AND at least one issue has a populated team. Build the UUID→name map
+    // once so per-row resolution is O(1) against the HashMap (rather than a
+    // linear scan of the cache vec for every row).
     let client_verbose = client.verbose();
     let team_displays: Vec<String> = if let Some(field_id) = team_field_id {
         let uuids: Vec<Option<String>> = issues
@@ -494,15 +495,16 @@ pub(super) async fn handle_list(
             // Team cache read is best-effort for display — an Err or missing
             // entry falls back to the UUID. Cache population is not this
             // command's responsibility.
-            let cache = crate::cache::read_team_cache().ok().flatten();
+            let team_map: std::collections::HashMap<String, String> =
+                crate::cache::read_team_cache()
+                    .ok()
+                    .flatten()
+                    .map(|c| c.teams.into_iter().map(|t| (t.id, t.name)).collect())
+                    .unwrap_or_default();
             uuids
                 .iter()
                 .map(|u| match u {
-                    Some(uuid) => cache
-                        .as_ref()
-                        .and_then(|c| c.teams.iter().find(|t| t.id == *uuid))
-                        .map(|t| t.name.clone())
-                        .unwrap_or_else(|| uuid.clone()),
+                    Some(uuid) => team_map.get(uuid).cloned().unwrap_or_else(|| uuid.clone()),
                     None => "-".to_string(),
                 })
                 .collect()

--- a/src/cli/queue.rs
+++ b/src/cli/queue.rs
@@ -89,7 +89,7 @@ async fn handle_view(
         .await?;
 
     if keys.is_empty() {
-        let headers = issue_table_headers(false, false);
+        let headers = issue_table_headers(false, false, false);
         let empty: Vec<Vec<String>> = vec![];
         let empty_issues: Vec<crate::types::jira::Issue> = vec![];
         return output::print_output(output_format, &headers, &empty, &empty_issues);
@@ -105,7 +105,7 @@ async fn handle_view(
     let issues = reorder_by_queue_position(search_result.issues, &keys);
 
     // Step 4: Output
-    let headers = issue_table_headers(false, false);
+    let headers = issue_table_headers(false, false, false);
     let rows = format_issue_rows_public(&issues);
     output::print_output(output_format, &headers, &rows, &issues)
 }

--- a/src/cli/sprint.rs
+++ b/src/cli/sprint.rs
@@ -278,11 +278,11 @@ async fn handle_current(
 
             let rows: Vec<Vec<String>> = issues
                 .iter()
-                .map(|issue| super::issue::format_issue_row(issue, sp_field_id, None))
+                .map(|issue| super::issue::format_issue_row(issue, sp_field_id, None, None))
                 .collect();
             output::print_output(
                 output_format,
-                &super::issue::issue_table_headers(sp_field_id.is_some(), false),
+                &super::issue::issue_table_headers(sp_field_id.is_some(), false, false),
                 &rows,
                 &issues,
             )?;

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1940,7 +1940,7 @@ async fn test_list_shows_team_column_with_cached_name() {
 }
 
 /// When an issue's team UUID isn't in the cache, the Team column shows the
-/// raw UUID as a fallback. Cache population is out of scope for `jr list`.
+/// raw UUID as a fallback. Cache population is out of scope for `jr issue list`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_list_team_column_falls_back_to_uuid_when_cache_missing() {
     let server = MockServer::start().await;

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1903,13 +1903,17 @@ async fn test_edit_team_cold_cache_miss_avoids_stale_advice() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_list_shows_team_column_with_cached_name() {
     let server = MockServer::start().await;
+    // Summary is deliberately chosen to NOT contain the team name
+    // ("Platform") so the `contains("Platform")` assertion below can only
+    // pass via the resolved Team column cell — not a false match against
+    // the Summary column.
     Mock::given(method("POST"))
         .and(path("/rest/api/3/search/jql"))
         .respond_with(ResponseTemplate::new(200).set_body_json(
             common::fixtures::issue_search_response(vec![
                 common::fixtures::issue_response_with_team(
                     "HDL-800",
-                    "On Platform team",
+                    "Issue for backend work",
                     TEST_TEAM_FIELD_ID,
                     "team-uuid-abc",
                 ),
@@ -1927,8 +1931,12 @@ async fn test_list_shows_team_column_with_cached_name() {
         .args(["issue", "list", "--jql", "project = HDL"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Team")) // header
-        .stdout(predicate::str::contains("Platform")); // resolved name
+        .stdout(predicate::str::contains("Team")) // column header
+        .stdout(predicate::str::contains("Platform")) // resolved name (not in summary)
+        // Strong signal that resolution actually happened: the raw UUID
+        // must NOT appear in the output. If the cache lookup silently
+        // failed, we'd see "team-uuid-abc" in the Team cell instead.
+        .stdout(predicate::str::contains("team-uuid-abc").not());
 }
 
 /// When an issue's team UUID isn't in the cache, the Team column shows the
@@ -1936,13 +1944,15 @@ async fn test_list_shows_team_column_with_cached_name() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_list_team_column_falls_back_to_uuid_when_cache_missing() {
     let server = MockServer::start().await;
+    // Summary is chosen to NOT contain "Team" so the column-header
+    // assertion below can only match the real "Team" header.
     Mock::given(method("POST"))
         .and(path("/rest/api/3/search/jql"))
         .respond_with(ResponseTemplate::new(200).set_body_json(
             common::fixtures::issue_search_response(vec![
                 common::fixtures::issue_response_with_team(
                     "HDL-801",
-                    "Team not in cache",
+                    "Issue with unknown owner",
                     TEST_TEAM_FIELD_ID,
                     "team-uuid-unknown",
                 ),
@@ -1960,8 +1970,8 @@ async fn test_list_team_column_falls_back_to_uuid_when_cache_missing() {
         .args(["issue", "list", "--jql", "project = HDL"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Team"))
-        .stdout(predicate::str::contains("team-uuid-unknown"));
+        .stdout(predicate::str::contains("Team")) // column header (summary has no "Team")
+        .stdout(predicate::str::contains("team-uuid-unknown")); // raw UUID fallback
 }
 
 /// Team column is omitted when no issue in the result has a populated team,

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1894,3 +1894,107 @@ async fn test_edit_team_cold_cache_miss_avoids_stale_advice() {
         .stderr(predicate::str::contains("checked a fresh team list"))
         .stderr(predicate::str::contains("jr team list --refresh").not());
 }
+
+// ── Team column in `issue list` (#191) ──────────────────────────────
+
+/// When `team_field_id` is configured AND at least one issue in the result
+/// has a populated team, the list output includes a Team column with the
+/// cached team name (not the raw UUID).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_list_shows_team_column_with_cached_name() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/search/jql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            common::fixtures::issue_search_response(vec![
+                common::fixtures::issue_response_with_team(
+                    "HDL-800",
+                    "On Platform team",
+                    TEST_TEAM_FIELD_ID,
+                    "team-uuid-abc",
+                ),
+            ]),
+        ))
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    write_test_team_cache(cache_dir.path()); // "team-uuid-abc" → "Platform"
+    write_test_config_with_team_field(config_dir.path());
+
+    jr_cmd_with_xdg(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "list", "--jql", "project = HDL"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Team")) // header
+        .stdout(predicate::str::contains("Platform")); // resolved name
+}
+
+/// When an issue's team UUID isn't in the cache, the Team column shows the
+/// raw UUID as a fallback. Cache population is out of scope for `jr list`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_list_team_column_falls_back_to_uuid_when_cache_missing() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/search/jql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            common::fixtures::issue_search_response(vec![
+                common::fixtures::issue_response_with_team(
+                    "HDL-801",
+                    "Team not in cache",
+                    TEST_TEAM_FIELD_ID,
+                    "team-uuid-unknown",
+                ),
+            ]),
+        ))
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    write_test_team_cache(cache_dir.path()); // does NOT include team-uuid-unknown
+    write_test_config_with_team_field(config_dir.path());
+
+    jr_cmd_with_xdg(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "list", "--jql", "project = HDL"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Team"))
+        .stdout(predicate::str::contains("team-uuid-unknown"));
+}
+
+/// Team column is omitted when no issue in the result has a populated team,
+/// even if `team_field_id` is configured — mirrors the Points/Assets gating.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_list_omits_team_column_when_no_issue_has_team() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/search/jql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            common::fixtures::issue_search_response(vec![common::fixtures::issue_response(
+                "HDL-802",
+                "No team set",
+                "To Do",
+            )]),
+        ))
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    write_test_team_cache(cache_dir.path());
+    write_test_config_with_team_field(config_dir.path());
+
+    jr_cmd_with_xdg(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "list", "--jql", "project = HDL"])
+        .assert()
+        .success()
+        // Positive neighbour anchors the table shape — "Assignee" is always
+        // present in the header row. The negative on "Team" then asserts
+        // the column itself is absent without relying on box-drawing glyphs
+        // (which could change if comfy-table's default theme changes).
+        .stdout(predicate::str::contains("HDL-802"))
+        .stdout(predicate::str::contains("Assignee"))
+        .stdout(predicate::str::contains("Team").not());
+}


### PR DESCRIPTION
## Summary
Adds an optional Team column to \`jr issue list\` table output, gated the same way as Points and Assets:
- \`team_field_id\` configured in \`[fields]\`, **AND**
- at least one issue in the result set has a populated team UUID

UUID→name resolution uses the existing team cache (populated by \`jr team list --refresh\`). Cache misses fall back to the raw UUID — cache population is not this command's responsibility.

## Column position
\`Key | Type | Status | Priority | [Points] | Assignee | [Team] | [Assets] | Summary\`

Team sits between Assignee and Assets, grouping ownership metadata (who) separately from size metadata (Points) and attachment metadata (Assets). Matches the Jira board-card convention.

## Signature changes
- \`format_issue_row\` gains \`team: Option<&str>\`
- \`issue_table_headers\` gains \`show_team: bool\`
- All existing callers (\`queue.rs\`, \`sprint.rs\`, \`board.rs\`) pass \`None\` / \`false\` — backward-compatible default, no Team column in those outputs yet.

## Out-of-scope (filed as follow-up)
Sprint + board Team column parity tracked in **#246**. Thread the same resolution through \`sprint::handle_current\` and \`board\`.

## Test plan
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test\` — 817 passed, 0 failed
- [x] 3 new integration tests in \`tests/cli_handler.rs\`:
  - Cache-hit: shows resolved name "Platform"
  - Cache-miss: shows raw UUID fallback
  - Gating-off: no Team column when no issue has team (theme-robust assertion: checks for \`Assignee\` positive + \`Team\` absent)
- [x] Local code-reviewer: no critical/important findings

Closes #191