### PR TITLE
test: --all flag behavioral coverage for issue list + user search (#186)

### DIFF
--- a/tests/all_flag_behavior.rs
+++ b/tests/all_flag_behavior.rs
@@ -15,7 +15,7 @@ mod common;
 
 use assert_cmd::Command;
 use serde_json::Value;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{body_partial_json, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Build a `jr` command pre-configured for non-interactive JSON output
@@ -30,9 +30,10 @@ fn jr_cmd_json(server_uri: &str) -> Command {
 }
 
 /// `jr issue list --all` fetches beyond the default 30-row cap. Server
-/// returns 35 issues in one cursor-paginated response (`nextPageToken`
-/// absent) — client with `--all` passes `limit=None` → keeps all 35.
-/// Client without `--all` passes `limit=Some(30)` → truncates to 30.
+/// returns 35 issues in one cursor-paginated response (`nextPageToken:
+/// null`) — client with `--all` passes `limit=None`, so the API request
+/// body carries `maxResults=50` (the client's page size when no limit
+/// is set per src/api/jira/issues.rs:50) → keeps all 35.
 #[tokio::test]
 async fn issue_list_all_returns_more_than_default_cap() {
     let server = MockServer::start().await;
@@ -40,8 +41,17 @@ async fn issue_list_all_returns_more_than_default_cap() {
     let issues: Vec<Value> = (1..=35)
         .map(|i| common::fixtures::issue_response(&format!("ALL-{i}"), "Issue", "To Do"))
         .collect();
+    // Constrain the request body: the JQL must match what handle_list
+    // actually builds (wrapped parens + ORDER BY), and maxResults=50
+    // proves the client passed limit=None (i.e., --all took effect).
+    // Loose path-only matchers would silently pass even if the command
+    // sent the wrong JQL or cap.
     Mock::given(method("POST"))
         .and(path("/rest/api/3/search/jql"))
+        .and(body_partial_json(serde_json::json!({
+            "jql": "(project = ALL) ORDER BY updated DESC",
+            "maxResults": 50
+        })))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(common::fixtures::issue_search_response(issues)),
@@ -78,20 +88,31 @@ async fn issue_list_default_caps_at_thirty() {
     let issues: Vec<Value> = (1..=35)
         .map(|i| common::fixtures::issue_response(&format!("CAP-{i}"), "Issue", "To Do"))
         .collect();
+    // Constrain the request: maxResults=30 proves the default cap took
+    // effect (without --all, client passes limit=Some(30) →
+    // max_per_page=30 per src/api/jira/issues.rs:50).
     Mock::given(method("POST"))
         .and(path("/rest/api/3/search/jql"))
+        .and(body_partial_json(serde_json::json!({
+            "jql": "(project = CAP) ORDER BY updated DESC",
+            "maxResults": 30
+        })))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(common::fixtures::issue_search_response(issues)),
         )
         .mount(&server)
         .await;
-    // The cap hint needs an approximate-count response too — Jira-side, a
+    // The cap hint needs an approximate-count response — Jira-side, a
     // truncated result triggers a hint like "Showing 30 of ~42 results",
-    // which `handle_list` looks up via /search/approximate-count. Stub it
-    // so the command doesn't error on the secondary call.
+    // which `handle_list` looks up via /search/approximate-count with the
+    // ORDER BY-stripped JQL. Pinning the body ensures the secondary
+    // request shape is correct.
     Mock::given(method("POST"))
         .and(path("/rest/api/3/search/approximate-count"))
+        .and(body_partial_json(serde_json::json!({
+            "jql": "(project = CAP)"
+        })))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(common::fixtures::approximate_count_response(35)),
@@ -129,8 +150,11 @@ async fn user_search_all_returns_more_than_default_cap() {
     let users: Vec<(String, String, bool)> = (1..=35)
         .map(|i| (format!("acc-{i:03}"), format!("User {i:03}"), true))
         .collect();
+    // Constrain the `query` param so the test fails if `search_users`
+    // stops sending it (or renames the param).
     Mock::given(method("GET"))
         .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "User"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(common::fixtures::user_search_response(
                 users
@@ -170,8 +194,10 @@ async fn user_search_default_caps_at_thirty() {
     let users: Vec<(String, String, bool)> = (1..=35)
         .map(|i| (format!("acc-{i:03}"), format!("User {i:03}"), true))
         .collect();
+    // Same query_param constraint as the --all case above.
     Mock::given(method("GET"))
         .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "User"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(common::fixtures::user_search_response(
                 users

--- a/tests/all_flag_behavior.rs
+++ b/tests/all_flag_behavior.rs
@@ -18,10 +18,21 @@ use serde_json::Value;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+/// Build a `jr` command pre-configured for non-interactive JSON output
+/// against a mock server. Matches the pattern used in other integration
+/// test files so shared flags/env live in one place.
+fn jr_cmd_json(server_uri: &str) -> Command {
+    let mut cmd = Command::cargo_bin("jr").unwrap();
+    cmd.env("JR_BASE_URL", server_uri)
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["--no-input", "--output", "json"]);
+    cmd
+}
+
 /// `jr issue list --all` fetches beyond the default 30-row cap. Server
-/// returns 35 issues in one page (is_last=true) — client with `--all`
-/// passes `limit=None` → keeps all 35. Client without `--all` passes
-/// `limit=Some(30)` → truncates to 30.
+/// returns 35 issues in one cursor-paginated response (`nextPageToken`
+/// absent) — client with `--all` passes `limit=None` → keeps all 35.
+/// Client without `--all` passes `limit=Some(30)` → truncates to 30.
 #[tokio::test]
 async fn issue_list_all_returns_more_than_default_cap() {
     let server = MockServer::start().await;
@@ -39,20 +50,8 @@ async fn issue_list_all_returns_more_than_default_cap() {
         .await;
 
     // With --all: all 35 issues should appear in JSON output.
-    let output = Command::cargo_bin("jr")
-        .unwrap()
-        .env("JR_BASE_URL", server.uri())
-        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
-        .args([
-            "--no-input",
-            "--output",
-            "json",
-            "issue",
-            "list",
-            "--jql",
-            "project = ALL",
-            "--all",
-        ])
+    let output = jr_cmd_json(&server.uri())
+        .args(["issue", "list", "--jql", "project = ALL", "--all"])
         .output()
         .unwrap();
 
@@ -100,19 +99,8 @@ async fn issue_list_default_caps_at_thirty() {
         .mount(&server)
         .await;
 
-    let output = Command::cargo_bin("jr")
-        .unwrap()
-        .env("JR_BASE_URL", server.uri())
-        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
-        .args([
-            "--no-input",
-            "--output",
-            "json",
-            "issue",
-            "list",
-            "--jql",
-            "project = CAP",
-        ])
+    let output = jr_cmd_json(&server.uri())
+        .args(["issue", "list", "--jql", "project = CAP"])
         .output()
         .unwrap();
 
@@ -154,19 +142,8 @@ async fn user_search_all_returns_more_than_default_cap() {
         .mount(&server)
         .await;
 
-    let output = Command::cargo_bin("jr")
-        .unwrap()
-        .env("JR_BASE_URL", server.uri())
-        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
-        .args([
-            "--no-input",
-            "--output",
-            "json",
-            "user",
-            "search",
-            "User",
-            "--all",
-        ])
+    let output = jr_cmd_json(&server.uri())
+        .args(["user", "search", "User", "--all"])
         .output()
         .unwrap();
 
@@ -206,11 +183,8 @@ async fn user_search_default_caps_at_thirty() {
         .mount(&server)
         .await;
 
-    let output = Command::cargo_bin("jr")
-        .unwrap()
-        .env("JR_BASE_URL", server.uri())
-        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
-        .args(["--no-input", "--output", "json", "user", "search", "User"])
+    let output = jr_cmd_json(&server.uri())
+        .args(["user", "search", "User"])
         .output()
         .unwrap();
 

--- a/tests/all_flag_behavior.rs
+++ b/tests/all_flag_behavior.rs
@@ -1,0 +1,230 @@
+//! End-to-end coverage for `--all` disabling the default-limit cap (#186).
+//!
+//! `resolve_effective_limit` is unit-tested in `src/cli/mod.rs`, but without
+//! handler tests there's no regression guarantee that commands actually pass
+//! `None` down to their API layer when `--all` is set. Each test here stubs
+//! a response with more than `DEFAULT_LIMIT` (30) items and asserts the
+//! command returns the full set under `--all` and the 30-row cap without.
+//!
+//! Scope note: this PR covers `issue list` and `user search`. The other four
+//! `--all` commands (`user list`, `board view`, `sprint current`,
+//! `issue changelog`) are deferred to a follow-up issue.
+
+#[allow(dead_code)]
+mod common;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// `jr issue list --all` fetches beyond the default 30-row cap. Server
+/// returns 35 issues in one page (is_last=true) — client with `--all`
+/// passes `limit=None` → keeps all 35. Client without `--all` passes
+/// `limit=Some(30)` → truncates to 30.
+#[tokio::test]
+async fn issue_list_all_returns_more_than_default_cap() {
+    let server = MockServer::start().await;
+
+    let issues: Vec<Value> = (1..=35)
+        .map(|i| common::fixtures::issue_response(&format!("ALL-{i}"), "Issue", "To Do"))
+        .collect();
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/search/jql"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(common::fixtures::issue_search_response(issues)),
+        )
+        .mount(&server)
+        .await;
+
+    // With --all: all 35 issues should appear in JSON output.
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args([
+            "--no-input",
+            "--output",
+            "json",
+            "issue",
+            "list",
+            "--jql",
+            "project = ALL",
+            "--all",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let arr = json.as_array().expect("issue list JSON is an array");
+    assert_eq!(
+        arr.len(),
+        35,
+        "--all should return all 35 issues, got {}",
+        arr.len()
+    );
+}
+
+/// Without `--all`, `jr issue list` truncates to DEFAULT_LIMIT (30).
+#[tokio::test]
+async fn issue_list_default_caps_at_thirty() {
+    let server = MockServer::start().await;
+
+    let issues: Vec<Value> = (1..=35)
+        .map(|i| common::fixtures::issue_response(&format!("CAP-{i}"), "Issue", "To Do"))
+        .collect();
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/search/jql"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(common::fixtures::issue_search_response(issues)),
+        )
+        .mount(&server)
+        .await;
+    // The cap hint needs an approximate-count response too — Jira-side, a
+    // truncated result triggers a hint like "Showing 30 of ~42 results",
+    // which `handle_list` looks up via /search/approximate-count. Stub it
+    // so the command doesn't error on the secondary call.
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/search/approximate-count"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(common::fixtures::approximate_count_response(35)),
+        )
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args([
+            "--no-input",
+            "--output",
+            "json",
+            "issue",
+            "list",
+            "--jql",
+            "project = CAP",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let arr = json.as_array().expect("issue list JSON is an array");
+    assert_eq!(
+        arr.len(),
+        30,
+        "default limit should truncate to 30, got {}",
+        arr.len()
+    );
+}
+
+/// `jr user search --all` returns all users from a response that contains
+/// more than DEFAULT_LIMIT entries. `search_users` is flat (no pagination),
+/// so truncation is purely client-side.
+#[tokio::test]
+async fn user_search_all_returns_more_than_default_cap() {
+    let server = MockServer::start().await;
+
+    let users: Vec<(String, String, bool)> = (1..=35)
+        .map(|i| (format!("acc-{i:03}"), format!("User {i:03}"), true))
+        .collect();
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(common::fixtures::user_search_response(
+                users
+                    .iter()
+                    .map(|(a, d, t)| (a.as_str(), d.as_str(), *t))
+                    .collect(),
+            )),
+        )
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args([
+            "--no-input",
+            "--output",
+            "json",
+            "user",
+            "search",
+            "User",
+            "--all",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let arr = json.as_array().expect("user search JSON is an array");
+    assert_eq!(
+        arr.len(),
+        35,
+        "--all should return all 35 users, got {}",
+        arr.len()
+    );
+}
+
+/// Without `--all`, `jr user search` truncates to DEFAULT_LIMIT (30).
+#[tokio::test]
+async fn user_search_default_caps_at_thirty() {
+    let server = MockServer::start().await;
+
+    let users: Vec<(String, String, bool)> = (1..=35)
+        .map(|i| (format!("acc-{i:03}"), format!("User {i:03}"), true))
+        .collect();
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(common::fixtures::user_search_response(
+                users
+                    .iter()
+                    .map(|(a, d, t)| (a.as_str(), d.as_str(), *t))
+                    .collect(),
+            )),
+        )
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["--no-input", "--output", "json", "user", "search", "User"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let arr = json.as_array().expect("user search JSON is an array");
+    assert_eq!(
+        arr.len(),
+        30,
+        "default limit should truncate to 30, got {}",
+        arr.len()
+    );
+}


### PR DESCRIPTION
## Summary
Adds handler-level behavioral coverage for the `--all` flag on two commonly-used commands:
- `jr issue list --all` → fetches beyond the default 30-row cap
- `jr user search --all` → returns all matches (vs truncated to 30)

\`resolve_effective_limit\` was unit-tested in \`src/cli/mod.rs\`, but there was no regression guarantee that commands actually pass the flag down to their API layer. This PR closes that gap for the two highest-value commands.

## Tests
New file \`tests/all_flag_behavior.rs\` with 4 tests:

| Test | Stubs | Asserts |
|---|---|---|
| \`issue_list_all_returns_more_than_default_cap\` | 35 issues in search response | 35 in JSON output under \`--all\` |
| \`issue_list_default_caps_at_thirty\` | 35 issues + approximate-count | 30 in JSON output without \`--all\` |
| \`user_search_all_returns_more_than_default_cap\` | 35 users | 35 in JSON output under \`--all\` |
| \`user_search_default_caps_at_thirty\` | 35 users | 30 in JSON output without \`--all\` |

Each pair locks both the no-cap and capped behaviors — a regression that swaps them (or ignores \`--all\`) fails at least one test.

## Scope
The other four \`--all\` commands (\`user list\`, \`board view\`, \`sprint current\`, \`issue changelog\`) remain uncovered. Tracked as **#248** — the new test file's structure is ready for additive tests.

## Test plan
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test\` — 831 passed, 0 failed (baseline 827 + 4 new)
- [x] New tests verified in isolation

Refs #186