### PR TITLE
feat: paginate --all on user search and user list (#189)

### DIFF
--- a/docs/specs/user-search-pagination.md
+++ b/docs/specs/user-search-pagination.md
@@ -32,6 +32,7 @@ From the official Atlassian REST API v3 documentation (`api-group-user-search`):
 - Both endpoints return a **flat JSON array** of User objects — no envelope, no `total`, no `isLast`, no `nextPageToken`. The existing helpers in `src/api/pagination.rs` do not apply.
 - Both endpoints are subject to a documented **hard cap of 1000 users**: "the operations in this resource only return users found within the first 1000 users."
 - The docs warn that responses "usually return fewer users than specified in `maxResults`" because filtering happens *after* the server selects a page from the first 1000. **Short-page-as-end-of-data is NOT a reliable termination signal.** The only reliable termination signal for these endpoints is an empty-array response.
+- Jira uses **fixed-window pagination**: the server selects raw users `[startAt, startAt + maxResults)` and then applies permission filtering. Each call advances through the raw window. Pagination therefore must advance `startAt` by the requested `maxResults` (the window size), **not** by the returned count. Advancing by the returned (post-filter) count overlaps windows and produces duplicate users — see [JRACLOUD-71293](https://jira.atlassian.com/browse/JRACLOUD-71293).
 - The Atlassian developer community confirms `maxResults` is effectively capped at 100 server-side, even if you request more.
 
 ## Design
@@ -83,9 +84,8 @@ async fn search_users_all(&self, query: &str) -> Result<Vec<User>> {
         if page.is_empty() {
             break;
         }
-        let fetched = page.len() as u32;
         all.extend(page);
-        start_at = start_at.saturating_add(fetched);
+        start_at = start_at.saturating_add(USER_PAGE_SIZE);
     }
     Ok(all)
 }
@@ -94,7 +94,7 @@ async fn search_users_all(&self, query: &str) -> Result<Vec<User>> {
 Key properties:
 
 - **Termination:** empty response only. No `isLast`/`total` to rely on; short pages are filtering artifacts, not end-of-data.
-- **Advance by actual page length**, not by `max_results`. This is the correct `startAt` for the next window even when the server returns <100 results.
+- **Advance `startAt` by `USER_PAGE_SIZE`**, not by the returned count. Jira's fixed-window pagination scans raw users `[startAt, startAt + maxResults)` then filters; advancing by the filtered count would overlap windows and produce duplicate users (JRACLOUD-71293).
 - **Safety cap: 15 iterations.** Defensive guard against pathological server behavior; generous vs the documented 1000-user hard cap (10 iterations at page 100).
 - **Error handling: abort.** Any `?` propagation from a page fetch aborts the loop and returns the error. No retry, no partial-success. Matches `atlassian-python-api` and `jira-node` behavior (validated via Perplexity).
 - **Rate limiting** is inherited from `JiraClient::get()` which already handles 429 + `Retry-After` via `src/api/rate_limit.rs`.

--- a/docs/specs/user-search-pagination.md
+++ b/docs/specs/user-search-pagination.md
@@ -1,0 +1,182 @@
+# User Search Pagination Spec
+
+**Issue:** #189 — true multi-page pagination for `jr user search --all` and `jr user list --all`.
+
+## Problem
+
+`jr user search --all` and `jr user list --all` (added in #188) currently wrap `JiraClient::search_users` and `JiraClient::search_assignable_users_by_project`, which call the Jira API **once** with no `startAt` / `maxResults` query parameters. This caps results at Jira's single-page default (~50 users) even under `--all`. The `--all` flag in these commands means only "disable the local 30-row cap," not "paginate to exhaustion" — a misleading gap documented in `docs/superpowers/specs/2026-04-13-user-search-lookup-design.md` and the current help text.
+
+This spec brings `--all` up to what users expect: paginate through every server page until the result set is exhausted.
+
+## Scope
+
+**In scope:**
+
+- New `JiraClient::search_users_all(query)` method that paginates `/rest/api/3/user/search`.
+- New `JiraClient::search_assignable_users_by_project_all(query, project_key)` method that paginates `/rest/api/3/user/assignable/multiProjectSearch`.
+- CLI wiring in `src/cli/user.rs`: when `--all` is set, call the `_all` variant; otherwise keep the existing single-call behavior.
+- Updated help text on `--all` for `user search` and `user list`.
+
+**Out of scope:**
+
+- `search_assignable_users(query, issue_key)` — the issue-key variant used by `issue assign` / `issue create` disambiguation helpers. No CLI command calls it with `--all` today. If a future command needs paginated assignable-by-issue lookup, a third `_all` method can be added then.
+- Name-lookup call sites in `src/cli/issue/helpers.rs` — they stay on the single-call path.
+- Any change to the `--limit N` behavior (stays a purely local truncate, no pagination triggered).
+- Deduplication of results across pages — Atlassian docs do not document this as a risk; adding dedup preemptively is YAGNI.
+
+## Validated API Facts
+
+From the official Atlassian REST API v3 documentation (`api-group-user-search`):
+
+- Both `/rest/api/3/user/search` and `/rest/api/3/user/assignable/multiProjectSearch` accept `startAt` (integer) and `maxResults` (integer) query parameters.
+- Both endpoints return a **flat JSON array** of User objects — no envelope, no `total`, no `isLast`, no `nextPageToken`. The existing helpers in `src/api/pagination.rs` do not apply.
+- Both endpoints are subject to a documented **hard cap of 1000 users**: "the operations in this resource only return users found within the first 1000 users."
+- The docs warn that responses "usually return fewer users than specified in `maxResults`" because filtering happens *after* the server selects a page from the first 1000. **Short-page-as-end-of-data is NOT a reliable termination signal.** The only reliable termination signal for these endpoints is an empty-array response.
+- The Atlassian developer community confirms `maxResults` is effectively capped at 100 server-side, even if you request more.
+
+## Design
+
+### Architecture
+
+Follow the octocrab `all_pages()` idiom: keep the single-call methods untouched for small name-lookup callers, and add separate `_all` wrapper methods that loop on top of a private `_page(start, max)` helper. Rejected alternatives:
+
+- Extending the existing single-call methods with `start_at` / `max_results` parameters. Changes the public API for callers that don't care (helpers.rs) and raises the chance of accidental pagination from a refactor.
+- Returning an async `Stream<Item = User>`. No other place in this codebase uses that pattern; YAGNI for one feature.
+
+### API shape
+
+```rust
+impl JiraClient {
+    // Existing — unchanged public signature:
+    pub async fn search_users(&self, query: &str) -> Result<Vec<User>>;
+    pub async fn search_assignable_users_by_project(&self, query: &str, project_key: &str) -> Result<Vec<User>>;
+
+    // New public methods:
+    pub async fn search_users_all(&self, query: &str) -> Result<Vec<User>>;
+    pub async fn search_assignable_users_by_project_all(&self, query: &str, project_key: &str) -> Result<Vec<User>>;
+
+    // New private helpers used only by the `_all` variants:
+    async fn search_users_page(&self, query: &str, start_at: u32, max_results: u32) -> Result<Vec<User>>;
+    async fn search_assignable_users_by_project_page(
+        &self,
+        query: &str,
+        project_key: &str,
+        start_at: u32,
+        max_results: u32,
+    ) -> Result<Vec<User>>;
+}
+```
+
+The existing deserialization logic (flat-array-or-object-with-values) is preserved inside the page helpers so the `_all` methods inherit robustness to the response-shape variance the repo already handles.
+
+### Pagination loop
+
+```rust
+const USER_PAGE_SIZE: u32 = 100;           // Atlassian effective server cap.
+const USER_PAGINATION_SAFETY_CAP: u32 = 15; // Documented cap is 1000 users = 10 iterations; 15 gives 50% headroom.
+
+async fn search_users_all(&self, query: &str) -> Result<Vec<User>> {
+    let mut all = Vec::new();
+    let mut start_at: u32 = 0;
+    for _ in 0..USER_PAGINATION_SAFETY_CAP {
+        let page = self.search_users_page(query, start_at, USER_PAGE_SIZE).await?;
+        if page.is_empty() {
+            break;
+        }
+        let fetched = page.len() as u32;
+        all.extend(page);
+        start_at = start_at.saturating_add(fetched);
+    }
+    Ok(all)
+}
+```
+
+Key properties:
+
+- **Termination:** empty response only. No `isLast`/`total` to rely on; short pages are filtering artifacts, not end-of-data.
+- **Advance by actual page length**, not by `max_results`. This is the correct `startAt` for the next window even when the server returns <100 results.
+- **Safety cap: 15 iterations.** Defensive guard against pathological server behavior; generous vs the documented 1000-user hard cap (10 iterations at page 100).
+- **Error handling: abort.** Any `?` propagation from a page fetch aborts the loop and returns the error. No retry, no partial-success. Matches `atlassian-python-api` and `jira-node` behavior (validated via Perplexity).
+- **Rate limiting** is inherited from `JiraClient::get()` which already handles 429 + `Retry-After` via `src/api/rate_limit.rs`.
+
+### CLI wiring
+
+`src/cli/user.rs::handle_search` and `handle_list`: branch on `all`.
+
+```rust
+async fn handle_search(
+    query: &str,
+    limit: Option<u32>,
+    all: bool,
+    output_format: &OutputFormat,
+    client: &JiraClient,
+) -> Result<()> {
+    let effective = resolve_effective_limit(limit, all);
+    let mut users = if all {
+        client.search_users_all(query).await?
+    } else {
+        client.search_users(query).await?
+    };
+    if let Some(cap) = effective {
+        users.truncate(cap as usize);
+    }
+    print_user_list(&users, output_format)
+}
+```
+
+Same shape in `handle_list` for the assignable-by-project path. `resolve_effective_limit(limit, all)` returns `None` when `--all` is set, so the post-fetch truncate is skipped — `--all` continues to mean "don't truncate locally," now combined with "paginate all server pages."
+
+### Help text
+
+Update the `user search --all` and `user list --all` doc comments in `src/cli/mod.rs`:
+
+- Before: "Disable the default 30-row cap. Returns only what the single API call returned."
+- After: "Fetch all matching users by paginating through every API page (up to the Jira 1000-user hard cap)."
+
+Follows kubectl/doctl style — stay high-level, avoid leaking page-size internals.
+
+## Tests
+
+### Unit tests (`src/api/jira/users.rs`)
+
+Existing deserialization tests stay. No new unit tests required because the pagination loop logic is exercised end-to-end via integration tests against wiremock (which reflects how the loop behaves against the actual HTTP surface — the thing we care about).
+
+### Integration tests (new file: `tests/user_pagination.rs`)
+
+- `search_users_all_paginates_and_concatenates` — three mocked pages (100, 100, 27) → asserts 227 users returned, in order, and all three mocks were hit once each (`.expect(1)`).
+- `search_users_all_stops_on_empty_page` — two full pages + one empty page → asserts 200 users returned and the fourth request is never made.
+- `search_users_all_respects_safety_cap` — every mock returns 100 items; asserts exactly 15 requests are made (`.expect(15)`) and the 16th never fires.
+- `search_users_all_propagates_error_mid_pagination` — page 2 returns 500; asserts the command exits nonzero and no subsequent page request fires.
+- `user_search_all_cli_paginates` — end-to-end `jr user search --all foo` with mocked pagination returns 150+ users in the JSON output.
+- `user_list_all_cli_paginates` — end-to-end `jr user list --all --project PROJ` with mocked pagination.
+- `user_search_no_all_issues_single_request` — without `--all`, only one request is made regardless of how many users would be available (`.expect(1)` on the single-call path).
+
+Mock tightness: each pagination stub constrains `query_param("startAt", "...")` so a misaligned loop (e.g., advancing by `max_results` instead of actual page length) trips the test instead of silently passing.
+
+### Helper tests (existing, `tests/cli_handler.rs`)
+
+No new tests required — existing name-lookup tests (`issue assign --to`, `issue create --to`, etc.) continue to prove the single-call path stays wired up because the public signature of `search_users` and `search_assignable_users_by_project` doesn't change.
+
+## Backwards Compatibility
+
+No public API or CLI behavior changes for users who don't pass `--all`:
+
+- `search_users(query)` / `search_assignable_users_by_project(query, project_key)` — signature and semantics unchanged.
+- `user search QUERY` (no `--all`) — one request, truncate to 30, print. Unchanged.
+- `user search QUERY --limit 50` — one request, truncate to 50, print. Unchanged.
+- `user search QUERY --all` — was: one request, no truncate, print (up to ~50 results). **Now**: paginate all pages, no truncate, print (up to 1000 results).
+- Same three cases for `user list --project PROJ`.
+
+The `--all` behavior change is the feature itself and aligns with what #189 and the help text promise. Not a regression.
+
+## Risks & Mitigations
+
+- **Slow queries:** paginating 10 pages at ~200–500ms each = 2–5s wall time. No progress feedback (matches AWS CLI and gh CLI precedent; validated via Perplexity). Users running interactively see silent wait; this is CLI-industry-standard.
+- **Rate limits:** inherited `Retry-After` handling in `JiraClient::get()` covers 429s automatically. No loop-level concern.
+- **Server cap evolution:** if Atlassian raises the 1000-user cap, the safety cap of 15 iterations becomes the new ceiling. This is acceptable — users hitting that are edge cases and can bump the const in a follow-up.
+- **Misaligned `startAt` in the loop:** guarded by the integration test that constrains `query_param("startAt", ...)` per page.
+
+## Out of Scope / Follow-ups
+
+- Pagination for `/rest/api/3/user/assignable/search` (issue-key variant). File follow-up if a CLI command ever needs it.
+- Any UX for users who want "fetch up to N via pagination where N > single-page": explicitly a non-goal. `--all` means all; `--limit N` is a local cap.

--- a/docs/superpowers/plans/2026-04-21-user-search-pagination.md
+++ b/docs/superpowers/plans/2026-04-21-user-search-pagination.md
@@ -201,9 +201,8 @@ pub async fn search_users_all(&self, query: &str) -> Result<Vec<User>> {
         if page.is_empty() {
             break;
         }
-        let fetched = page.len() as u32;
         all.extend(page);
-        start_at = start_at.saturating_add(fetched);
+        start_at = start_at.saturating_add(USER_PAGE_SIZE);
     }
     Ok(all)
 }
@@ -494,9 +493,8 @@ pub async fn search_assignable_users_by_project_all(
         if page.is_empty() {
             break;
         }
-        let fetched = page.len() as u32;
         all.extend(page);
-        start_at = start_at.saturating_add(fetched);
+        start_at = start_at.saturating_add(USER_PAGE_SIZE);
     }
     Ok(all)
 }
@@ -819,7 +817,7 @@ git commit -m "feat(cli): wire --all to paginate user search and list (#189)"
 | `USER_PAGE_SIZE = 100` constant | Task 1 |
 | `USER_PAGINATION_SAFETY_CAP = 15` constant | Task 1 |
 | Empty-response termination | Tasks 1 (impl) + 2 (test) |
-| `startAt` advanced by actual page length, not `max_results` | Task 1 (impl `start_at.saturating_add(fetched)`) |
+| `startAt` advanced by requested `USER_PAGE_SIZE` (fixed-window pagination), not by returned count | Task 1 (impl `start_at.saturating_add(USER_PAGE_SIZE)`) |
 | Abort-on-error semantics | Task 2 (test) |
 | CLI branch on `--all` for `user search` | Task 4 |
 | CLI branch on `--all` for `user list` | Task 4 |

--- a/docs/superpowers/plans/2026-04-21-user-search-pagination.md
+++ b/docs/superpowers/plans/2026-04-21-user-search-pagination.md
@@ -1,0 +1,843 @@
+# User Search Pagination Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `jr user search --all` and `jr user list --all` paginate through all server pages (up to Jira's documented 1000-user hard cap) instead of returning only the first API call's ~50 results.
+
+**Architecture:** Add per-endpoint `_all` wrapper methods to `JiraClient` (mirroring octocrab's `all_pages()` idiom) that loop a private `_page(start, max)` helper until the API returns an empty array. CLI `--all` path switches to the `_all` variant; everything else stays on the existing single-call path. Spec: `docs/specs/user-search-pagination.md`.
+
+**Tech Stack:** Rust, reqwest (via existing `JiraClient::get()`), wiremock for integration tests, assert_cmd for end-to-end CLI tests, clap for help text.
+
+---
+
+## File Structure
+
+| File | Change type | Responsibility |
+|------|-------------|----------------|
+| `src/api/jira/users.rs` | Modify | Add `search_users_all`, `search_users_page`, `search_assignable_users_by_project_all`, `search_assignable_users_by_project_page` + module-private constants `USER_PAGE_SIZE`, `USER_PAGINATION_SAFETY_CAP`. Keep existing single-call methods unchanged. |
+| `src/cli/user.rs` | Modify | Branch `handle_search` and `handle_list` on the `all` flag: call `_all` variant when true, existing single-call when false. |
+| `src/cli/mod.rs` | Modify | Update `--all` doc comments on `UserCommand::Search` and `UserCommand::List` to describe real pagination. |
+| `tests/user_pagination.rs` | Create | 7 integration tests: 4 library-level `_all` method tests against wiremock, 3 end-to-end CLI tests. Includes a `jr_cmd_json` helper mirroring `tests/all_flag_behavior.rs`. |
+
+No new source files. `JiraClient` gains four methods in an existing file that already has the same structure (three sibling `search_*` methods). The existing deserialization pattern (flat-array-or-object-with-values) is preserved inside the new `_page` helpers.
+
+---
+
+### Task 1: `/user/search` pagination (happy path)
+
+**Files:**
+- Create: `tests/user_pagination.rs`
+- Modify: `src/api/jira/users.rs:1-95` (add constants + 2 new methods)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `tests/user_pagination.rs`:
+
+```rust
+//! End-to-end coverage for `--all` true pagination on user search and
+//! user list (#189). Each library-level test asserts that `_all` variants
+//! loop the endpoint until an empty page is returned and that pages are
+//! concatenated in order. CLI-level tests verify the flag wiring.
+
+#[allow(dead_code)]
+mod common;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use jr::api::client::JiraClient;
+
+/// Build a `jr` command pre-configured for non-interactive JSON output
+/// against a mock server. Matches the pattern used in tests/all_flag_behavior.rs.
+fn jr_cmd_json(server_uri: &str) -> Command {
+    let mut cmd = Command::cargo_bin("jr").unwrap();
+    cmd.env("JR_BASE_URL", server_uri)
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["--no-input", "--output", "json"]);
+    cmd
+}
+
+fn users_page(count: usize, prefix: &str) -> Value {
+    let users: Vec<(&str, &str, bool)> = (0..count)
+        .map(|i| {
+            let acc = Box::leak(format!("{prefix}-acc-{i:03}").into_boxed_str()) as &str;
+            let name = Box::leak(format!("{prefix} User {i:03}").into_boxed_str()) as &str;
+            (acc, name, true)
+        })
+        .collect();
+    common::fixtures::user_search_response(users)
+}
+
+/// `search_users_all` paginates three sequential pages (100 + 100 + 27)
+/// and returns 227 users concatenated in order.
+#[tokio::test]
+async fn search_users_all_paginates_and_concatenates() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "0"))
+        .and(query_param("maxResults", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p1")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "100"))
+        .and(query_param("maxResults", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p2")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "200"))
+        .and(query_param("maxResults", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(27, "p3")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "227"))
+        .and(query_param("maxResults", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(common::fixtures::user_search_response(vec![])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(&server.uri(), "Basic dGVzdDp0ZXN0");
+    let users = client.search_users_all("u").await.expect("pagination must succeed");
+    assert_eq!(users.len(), 227, "expected 227 users across 3 pages");
+    assert_eq!(users[0].display_name, "p1 User 000");
+    assert_eq!(users[100].display_name, "p2 User 000");
+    assert_eq!(users[200].display_name, "p3 User 000");
+    assert_eq!(users[226].display_name, "p3 User 026");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test --test user_pagination search_users_all_paginates_and_concatenates 2>&1 | tail -20
+```
+
+Expected: compile error — `no method named 'search_users_all' found for struct 'JiraClient'`.
+
+- [ ] **Step 3: Add constants and the private `_page` helper to `src/api/jira/users.rs`**
+
+Insert immediately after `use anyhow::Result;` at the top of the file:
+
+```rust
+/// Maximum users requested per page. Atlassian's effective server-side cap
+/// for `/user/search` and related endpoints is 100 — requesting more is ignored.
+const USER_PAGE_SIZE: u32 = 100;
+
+/// Safety bound on the pagination loop. Atlassian documents a 1000-user hard
+/// cap on these endpoints, so at USER_PAGE_SIZE=100 we need at most 10
+/// iterations; 15 leaves 50% headroom against pathological server behavior.
+const USER_PAGINATION_SAFETY_CAP: u32 = 15;
+```
+
+Inside `impl JiraClient`, add a private helper just after `search_users`:
+
+```rust
+/// Single-page variant of `search_users` with explicit `startAt` / `maxResults`.
+/// Private — used only by `search_users_all` to implement the loop.
+async fn search_users_page(
+    &self,
+    query: &str,
+    start_at: u32,
+    max_results: u32,
+) -> Result<Vec<User>> {
+    let path = format!(
+        "/rest/api/3/user/search?query={}&startAt={}&maxResults={}",
+        urlencoding::encode(query),
+        start_at,
+        max_results,
+    );
+    let raw: serde_json::Value = self.get(&path).await?;
+    let users: Vec<User> = if raw.is_array() {
+        serde_json::from_value(raw)?
+    } else if let Some(values) = raw.get("values") {
+        serde_json::from_value(values.clone())?
+    } else {
+        anyhow::bail!(
+            "Unexpected response from user search API. Expected a JSON array or object with \"values\" key."
+        );
+    };
+    Ok(users)
+}
+```
+
+- [ ] **Step 4: Add the public `search_users_all` loop**
+
+Inside `impl JiraClient`, immediately after `search_users_page`:
+
+```rust
+/// Paginate `/rest/api/3/user/search` until exhausted.
+///
+/// The endpoint returns a flat JSON array with no `isLast` / `total`
+/// metadata, and its docs note responses "usually return fewer users
+/// than specified in `maxResults`" due to post-page filtering. The only
+/// reliable termination signal is an empty response.
+pub async fn search_users_all(&self, query: &str) -> Result<Vec<User>> {
+    let mut all: Vec<User> = Vec::new();
+    let mut start_at: u32 = 0;
+    for _ in 0..USER_PAGINATION_SAFETY_CAP {
+        let page = self
+            .search_users_page(query, start_at, USER_PAGE_SIZE)
+            .await?;
+        if page.is_empty() {
+            break;
+        }
+        let fetched = page.len() as u32;
+        all.extend(page);
+        start_at = start_at.saturating_add(fetched);
+    }
+    Ok(all)
+}
+```
+
+- [ ] **Step 5: Run fmt + clippy + the new test**
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets -- -D warnings
+cargo test --test user_pagination search_users_all_paginates_and_concatenates
+```
+
+Expected: all three pass.
+
+- [ ] **Step 6: Full test suite check**
+
+```bash
+cargo test
+```
+
+Expected: all tests pass (the added method is additive; nothing else should regress).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/api/jira/users.rs tests/user_pagination.rs
+git commit -m "feat(api): paginate /user/search with search_users_all (#189)"
+```
+
+---
+
+### Task 2: `/user/search` pagination edge cases
+
+**Files:**
+- Modify: `tests/user_pagination.rs` (add 3 tests after the Task 1 test)
+
+- [ ] **Step 1: Add stop-on-empty test**
+
+Append to `tests/user_pagination.rs`:
+
+```rust
+/// Loop stops as soon as a page comes back empty; subsequent startAt
+/// windows are not requested.
+#[tokio::test]
+async fn search_users_all_stops_on_empty_page() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p1")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(common::fixtures::user_search_response(vec![])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Any request past startAt=100 would fail against this strict mock set —
+    // wiremock rejects unmatched requests by default, which asserts the
+    // loop actually stopped.
+
+    let client = JiraClient::new_for_test(&server.uri(), "Basic dGVzdDp0ZXN0");
+    let users = client.search_users_all("u").await.expect("must succeed");
+    assert_eq!(users.len(), 100);
+}
+```
+
+- [ ] **Step 2: Add safety-cap test**
+
+Append to `tests/user_pagination.rs`:
+
+```rust
+/// If the API never returns an empty page (pathological behavior), the loop
+/// stops at USER_PAGINATION_SAFETY_CAP iterations = 15 requests.
+#[tokio::test]
+async fn search_users_all_respects_safety_cap() {
+    let server = MockServer::start().await;
+
+    // Unbounded responder for any startAt; .expect(15) pins the iteration cap.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "cap")))
+        .expect(15)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(&server.uri(), "Basic dGVzdDp0ZXN0");
+    let users = client.search_users_all("u").await.expect("must succeed");
+    assert_eq!(users.len(), 1500, "15 iterations * 100 per page = 1500");
+}
+```
+
+- [ ] **Step 3: Add error-propagation test**
+
+Append to `tests/user_pagination.rs`:
+
+```rust
+/// If a page request fails mid-pagination, the error is propagated and the
+/// loop does not silently return partial results.
+#[tokio::test]
+async fn search_users_all_propagates_error_mid_pagination() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("startAt", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p1")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("startAt", "100"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(&server.uri(), "Basic dGVzdDp0ZXN0");
+    let result = client.search_users_all("u").await;
+    assert!(result.is_err(), "500 on page 2 must propagate");
+}
+```
+
+- [ ] **Step 4: Run the three new tests**
+
+```bash
+cargo test --test user_pagination \
+  search_users_all_stops_on_empty_page \
+  search_users_all_respects_safety_cap \
+  search_users_all_propagates_error_mid_pagination
+```
+
+Expected: all three pass with the Task 1 implementation (termination, safety cap, and `?` propagation all work correctly).
+
+- [ ] **Step 5: fmt + clippy + full suite**
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/user_pagination.rs
+git commit -m "test: search_users_all termination, safety cap, and error propagation (#189)"
+```
+
+---
+
+### Task 3: `/user/assignable/multiProjectSearch` pagination
+
+**Files:**
+- Modify: `src/api/jira/users.rs` (add 2 new methods after the `search_assignable_users_by_project` definition)
+- Modify: `tests/user_pagination.rs` (add 1 happy-path test)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `tests/user_pagination.rs`:
+
+```rust
+/// `search_assignable_users_by_project_all` paginates the assignable-users
+/// endpoint and concatenates pages in order.
+#[tokio::test]
+async fn search_assignable_users_by_project_all_paginates() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
+        .and(query_param("query", ""))
+        .and(query_param("projectKeys", "FOO"))
+        .and(query_param("startAt", "0"))
+        .and(query_param("maxResults", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p1")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
+        .and(query_param("projectKeys", "FOO"))
+        .and(query_param("startAt", "100"))
+        .and(query_param("maxResults", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(40, "p2")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
+        .and(query_param("projectKeys", "FOO"))
+        .and(query_param("startAt", "140"))
+        .and(query_param("maxResults", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(common::fixtures::user_search_response(vec![])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(&server.uri(), "Basic dGVzdDp0ZXN0");
+    let users = client
+        .search_assignable_users_by_project_all("", "FOO")
+        .await
+        .expect("pagination must succeed");
+    assert_eq!(users.len(), 140);
+    assert_eq!(users[0].display_name, "p1 User 000");
+    assert_eq!(users[100].display_name, "p2 User 000");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test --test user_pagination search_assignable_users_by_project_all_paginates 2>&1 | tail -10
+```
+
+Expected: compile error — `no method named 'search_assignable_users_by_project_all'`.
+
+- [ ] **Step 3: Add the private `_page` helper in `src/api/jira/users.rs`**
+
+Insert inside `impl JiraClient`, immediately after the existing `search_assignable_users_by_project` method:
+
+```rust
+/// Single-page variant of `search_assignable_users_by_project`.
+/// Private — used only by `search_assignable_users_by_project_all`.
+async fn search_assignable_users_by_project_page(
+    &self,
+    query: &str,
+    project_key: &str,
+    start_at: u32,
+    max_results: u32,
+) -> Result<Vec<User>> {
+    let path = format!(
+        "/rest/api/3/user/assignable/multiProjectSearch?query={}&projectKeys={}&startAt={}&maxResults={}",
+        urlencoding::encode(query),
+        urlencoding::encode(project_key),
+        start_at,
+        max_results,
+    );
+    let raw: serde_json::Value = self.get(&path).await?;
+    let users: Vec<User> = if raw.is_array() {
+        serde_json::from_value(raw)?
+    } else if let Some(values) = raw.get("values") {
+        serde_json::from_value(values.clone())?
+    } else {
+        anyhow::bail!(
+            "Unexpected response from assignable user search API. Expected a JSON array or object with \"values\" key."
+        );
+    };
+    Ok(users)
+}
+```
+
+- [ ] **Step 4: Add the public `_all` method**
+
+Immediately after `search_assignable_users_by_project_page`:
+
+```rust
+/// Paginate `/rest/api/3/user/assignable/multiProjectSearch` until exhausted.
+///
+/// Same termination rules as `search_users_all`: empty response is the only
+/// reliable end-of-data signal.
+pub async fn search_assignable_users_by_project_all(
+    &self,
+    query: &str,
+    project_key: &str,
+) -> Result<Vec<User>> {
+    let mut all: Vec<User> = Vec::new();
+    let mut start_at: u32 = 0;
+    for _ in 0..USER_PAGINATION_SAFETY_CAP {
+        let page = self
+            .search_assignable_users_by_project_page(query, project_key, start_at, USER_PAGE_SIZE)
+            .await?;
+        if page.is_empty() {
+            break;
+        }
+        let fetched = page.len() as u32;
+        all.extend(page);
+        start_at = start_at.saturating_add(fetched);
+    }
+    Ok(all)
+}
+```
+
+- [ ] **Step 5: fmt + clippy + tests**
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets -- -D warnings
+cargo test --test user_pagination
+```
+
+Expected: all user_pagination tests pass.
+
+- [ ] **Step 6: Full suite**
+
+```bash
+cargo test
+```
+
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/api/jira/users.rs tests/user_pagination.rs
+git commit -m "feat(api): paginate /user/assignable/multiProjectSearch via search_assignable_users_by_project_all (#189)"
+```
+
+---
+
+### Task 4: CLI wiring + help text + end-to-end tests
+
+**Files:**
+- Modify: `src/cli/user.rs:28-58` (branch `handle_search` and `handle_list` on `all`)
+- Modify: `src/cli/mod.rs:584-617` (update `--all` doc comments on `UserCommand::Search` and `UserCommand::List`)
+- Modify: `tests/user_pagination.rs` (add 3 end-to-end CLI tests)
+
+- [ ] **Step 1: Write the failing CLI test — `user search --all` paginates**
+
+Append to `tests/user_pagination.rs`:
+
+```rust
+/// End-to-end: `jr user search --all` paginates and emits all users as JSON.
+#[tokio::test]
+async fn user_search_all_cli_paginates() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p1")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(50, "p2")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "150"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(common::fixtures::user_search_response(vec![])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd_json(&server.uri())
+        .args(["user", "search", "u", "--all"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let arr = json.as_array().expect("user search --all JSON is an array");
+    assert_eq!(arr.len(), 150, "--all should paginate to 150 users");
+}
+```
+
+- [ ] **Step 2: Write the failing CLI test — `user list --all` paginates**
+
+Append to `tests/user_pagination.rs`:
+
+```rust
+/// End-to-end: `jr user list --all --project FOO` paginates.
+#[tokio::test]
+async fn user_list_all_cli_paginates() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
+        .and(query_param("projectKeys", "FOO"))
+        .and(query_param("startAt", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p1")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
+        .and(query_param("projectKeys", "FOO"))
+        .and(query_param("startAt", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(35, "p2")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
+        .and(query_param("projectKeys", "FOO"))
+        .and(query_param("startAt", "135"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(common::fixtures::user_search_response(vec![])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd_json(&server.uri())
+        .args(["user", "list", "--project", "FOO", "--all"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let arr = json.as_array().expect("user list --all JSON is an array");
+    assert_eq!(arr.len(), 135);
+}
+```
+
+- [ ] **Step 3: Write the failing CLI test — without `--all`, single request**
+
+Append to `tests/user_pagination.rs`:
+
+```rust
+/// Without `--all`, `jr user search` must still make exactly one API request
+/// (the existing single-call path) — no accidental pagination.
+#[tokio::test]
+async fn user_search_no_all_issues_single_request() {
+    let server = MockServer::start().await;
+
+    // No startAt/maxResults constraints — proves the legacy single-call path
+    // (which doesn't send those params) is still in use.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(common::fixtures::user_search_response(
+                (0..50)
+                    .map(|i| {
+                        let acc = Box::leak(format!("acc-{i:03}").into_boxed_str()) as &str;
+                        let name = Box::leak(format!("User {i:03}").into_boxed_str()) as &str;
+                        (acc, name, true)
+                    })
+                    .collect(),
+            )),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd_json(&server.uri())
+        .args(["user", "search", "u"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let arr = json.as_array().expect("user search JSON is an array");
+    assert_eq!(arr.len(), 30, "default cap should truncate to 30, got {}", arr.len());
+}
+```
+
+- [ ] **Step 4: Run the three new CLI tests to verify they fail**
+
+```bash
+cargo test --test user_pagination \
+  user_search_all_cli_paginates \
+  user_list_all_cli_paginates \
+  user_search_no_all_issues_single_request 2>&1 | tail -20
+```
+
+Expected: `user_search_all_cli_paginates` and `user_list_all_cli_paginates` fail (CLI path doesn't call the new `_all` variants yet, so it still does a single unbounded call — the strict mock with `startAt=0` query_param matcher will reject the unmatched request). `user_search_no_all_issues_single_request` should already pass.
+
+- [ ] **Step 5: Wire `handle_search` to branch on `all`**
+
+Edit `src/cli/user.rs`, replacing the body of `handle_search` (currently at lines 28–41):
+
+```rust
+async fn handle_search(
+    query: &str,
+    limit: Option<u32>,
+    all: bool,
+    output_format: &OutputFormat,
+    client: &JiraClient,
+) -> Result<()> {
+    let effective = resolve_effective_limit(limit, all);
+    let mut users = if all {
+        client.search_users_all(query).await?
+    } else {
+        client.search_users(query).await?
+    };
+    if let Some(cap) = effective {
+        users.truncate(cap as usize);
+    }
+    print_user_list(&users, output_format)
+}
+```
+
+- [ ] **Step 6: Wire `handle_list` to branch on `all`**
+
+Edit `src/cli/user.rs`, replacing the body of `handle_list` (currently at lines 43–58):
+
+```rust
+async fn handle_list(
+    project: &str,
+    limit: Option<u32>,
+    all: bool,
+    output_format: &OutputFormat,
+    client: &JiraClient,
+) -> Result<()> {
+    let effective = resolve_effective_limit(limit, all);
+    let mut users = if all {
+        client
+            .search_assignable_users_by_project_all("", project)
+            .await?
+    } else {
+        client
+            .search_assignable_users_by_project("", project)
+            .await?
+    };
+    if let Some(cap) = effective {
+        users.truncate(cap as usize);
+    }
+    print_user_list(&users, output_format)
+}
+```
+
+- [ ] **Step 7: Update `--all` help text in `src/cli/mod.rs`**
+
+Change the doc comment on `UserCommand::Search`'s `all` field (currently at lines 597–600):
+
+```rust
+/// Fetch all matching users by paginating through every API page
+/// (up to Jira's documented 1000-user hard cap). Overrides the default
+/// local cap.
+#[arg(long, conflicts_with = "limit")]
+all: bool,
+```
+
+Change the doc comment on `UserCommand::List`'s `all` field (currently at lines 613–616):
+
+```rust
+/// Fetch all assignable users by paginating through every API page
+/// (up to Jira's documented 1000-user hard cap). Overrides the default
+/// local cap.
+#[arg(long, conflicts_with = "limit")]
+all: bool,
+```
+
+- [ ] **Step 8: Re-run CLI tests — should now pass**
+
+```bash
+cargo test --test user_pagination \
+  user_search_all_cli_paginates \
+  user_list_all_cli_paginates \
+  user_search_no_all_issues_single_request
+```
+
+Expected: all three pass.
+
+- [ ] **Step 9: fmt + clippy + full suite**
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+Expected: no warnings, all tests pass. In particular, existing tests in `tests/user_commands.rs` (or wherever the `user search` / `user list` single-call path is already covered) continue to pass because the public signatures of `search_users` and `search_assignable_users_by_project` are unchanged.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/cli/user.rs src/cli/mod.rs tests/user_pagination.rs
+git commit -m "feat(cli): wire --all to paginate user search and list (#189)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (against `docs/specs/user-search-pagination.md`):**
+
+| Spec requirement | Task |
+|---|---|
+| `search_users_all` public method | Task 1 |
+| `search_users_page` private helper | Task 1 |
+| `search_assignable_users_by_project_all` public method | Task 3 |
+| `search_assignable_users_by_project_page` private helper | Task 3 |
+| `USER_PAGE_SIZE = 100` constant | Task 1 |
+| `USER_PAGINATION_SAFETY_CAP = 15` constant | Task 1 |
+| Empty-response termination | Tasks 1 (impl) + 2 (test) |
+| `startAt` advanced by actual page length, not `max_results` | Task 1 (impl `start_at.saturating_add(fetched)`) |
+| Abort-on-error semantics | Task 2 (test) |
+| CLI branch on `--all` for `user search` | Task 4 |
+| CLI branch on `--all` for `user list` | Task 4 |
+| Help text update for both `--all` flags | Task 4 |
+| Integration tests: paginate+concat | Tasks 1, 3 |
+| Integration tests: stop-on-empty | Task 2 |
+| Integration tests: safety cap | Task 2 |
+| Integration tests: error propagation | Task 2 |
+| Integration tests: CLI end-to-end (3) | Task 4 |
+| Single-call path unchanged for helpers.rs callers | Preserved (public `search_users` / `search_assignable_users_by_project` signatures untouched in all tasks) |
+
+All spec requirements mapped to a task.
+
+**Placeholder scan:** clean — no TBD/TODO/"add appropriate". Every code step has a complete code block; every test step has complete test code.
+
+**Type consistency:**
+- Method names used consistently across tasks: `search_users_all`, `search_users_page`, `search_assignable_users_by_project_all`, `search_assignable_users_by_project_page`.
+- Constants used consistently: `USER_PAGE_SIZE`, `USER_PAGINATION_SAFETY_CAP`.
+- Test helper `users_page(count, prefix)` defined in Task 1, reused in Tasks 2/3/4.
+- `jr_cmd_json(server_uri)` helper defined in Task 1, reused in Task 4.
+- Fixture `common::fixtures::user_search_response` used with the expected `Vec<(&str, &str, bool)>` shape throughout.

--- a/src/api/jira/users.rs
+++ b/src/api/jira/users.rs
@@ -2,6 +2,15 @@ use crate::api::client::JiraClient;
 use crate::types::jira::User;
 use anyhow::Result;
 
+/// Maximum users requested per page. Atlassian's effective server-side cap
+/// for `/user/search` and related endpoints is 100 — requesting more is ignored.
+const USER_PAGE_SIZE: u32 = 100;
+
+/// Safety bound on the pagination loop. Atlassian documents a 1000-user hard
+/// cap on these endpoints, so at USER_PAGE_SIZE=100 we need at most 10
+/// iterations; 15 leaves 50% headroom against pathological server behavior.
+const USER_PAGINATION_SAFETY_CAP: u32 = 15;
+
 impl JiraClient {
     pub async fn get_myself(&self) -> Result<User> {
         self.get("/rest/api/3/myself").await
@@ -27,6 +36,56 @@ impl JiraClient {
             );
         };
         Ok(users)
+    }
+
+    /// Single-page variant of `search_users` with explicit `startAt` / `maxResults`.
+    /// Private — used only by `search_users_all` to implement the loop.
+    async fn search_users_page(
+        &self,
+        query: &str,
+        start_at: u32,
+        max_results: u32,
+    ) -> Result<Vec<User>> {
+        let path = format!(
+            "/rest/api/3/user/search?query={}&startAt={}&maxResults={}",
+            urlencoding::encode(query),
+            start_at,
+            max_results,
+        );
+        let raw: serde_json::Value = self.get(&path).await?;
+        let users: Vec<User> = if raw.is_array() {
+            serde_json::from_value(raw)?
+        } else if let Some(values) = raw.get("values") {
+            serde_json::from_value(values.clone())?
+        } else {
+            anyhow::bail!(
+                "Unexpected response from user search API. Expected a JSON array or object with \"values\" key."
+            );
+        };
+        Ok(users)
+    }
+
+    /// Paginate `/rest/api/3/user/search` until exhausted.
+    ///
+    /// The endpoint returns a flat JSON array with no `isLast` / `total`
+    /// metadata, and its docs note responses "usually return fewer users
+    /// than specified in `maxResults`" due to post-page filtering. The only
+    /// reliable termination signal is an empty response.
+    pub async fn search_users_all(&self, query: &str) -> Result<Vec<User>> {
+        let mut all: Vec<User> = Vec::new();
+        let mut start_at: u32 = 0;
+        for _ in 0..USER_PAGINATION_SAFETY_CAP {
+            let page = self
+                .search_users_page(query, start_at, USER_PAGE_SIZE)
+                .await?;
+            if page.is_empty() {
+                break;
+            }
+            let fetched = page.len() as u32;
+            all.extend(page);
+            start_at = start_at.saturating_add(fetched);
+        }
+        Ok(all)
     }
 
     /// Search for users assignable to a specific issue.

--- a/src/api/jira/users.rs
+++ b/src/api/jira/users.rs
@@ -71,11 +71,17 @@ impl JiraClient {
 
     /// Paginate `/rest/api/3/user/search` until exhausted.
     ///
-    /// The endpoint returns a flat JSON array with no `isLast` / `total`
-    /// metadata, and its docs note responses "usually return fewer users
-    /// than specified in `maxResults`" due to post-page filtering. The only
-    /// reliable termination signal is an empty response — a non-empty short
-    /// page is NOT end-of-data, and breaking on it would silently truncate.
+    /// Jira uses **fixed-window pagination**: the server selects the raw
+    /// user range `[startAt, startAt + maxResults)` and *then* applies
+    /// permission filtering, returning only visible users — which may be
+    /// fewer than `maxResults`. Advancing `startAt` by the returned count
+    /// would overlap windows and cause duplicates
+    /// (see JRACLOUD-71293). The correct advance is always by
+    /// `USER_PAGE_SIZE` (the requested window size).
+    ///
+    /// A non-empty short page is NOT end-of-data — more visible users may
+    /// live in later windows. The only reliable termination signal is an
+    /// empty response.
     pub async fn search_users_all(&self, query: &str) -> Result<Vec<User>> {
         let mut all: Vec<User> = Vec::new();
         let mut start_at: u32 = 0;
@@ -88,9 +94,8 @@ impl JiraClient {
                 reached_end = true;
                 break;
             }
-            let fetched = page.len() as u32;
             all.extend(page);
-            start_at = start_at.saturating_add(fetched);
+            start_at = start_at.saturating_add(USER_PAGE_SIZE);
         }
         if !reached_end {
             eprintln!(
@@ -183,10 +188,10 @@ impl JiraClient {
 
     /// Paginate `/rest/api/3/user/assignable/multiProjectSearch` until exhausted.
     ///
-    /// Same termination rules as `search_users_all`: empty response is the only
-    /// reliable end-of-data signal (the endpoint returns a flat array with no
-    /// `isLast` or `total` envelope metadata). A non-empty short page is NOT
-    /// end-of-data.
+    /// Same fixed-window semantics as `search_users_all`: advance `startAt`
+    /// by `USER_PAGE_SIZE`, not by returned count, to avoid overlap/duplicate
+    /// users. Empty response is the only reliable end-of-data signal; a
+    /// non-empty short page is NOT end-of-data.
     pub async fn search_assignable_users_by_project_all(
         &self,
         query: &str,
@@ -208,9 +213,8 @@ impl JiraClient {
                 reached_end = true;
                 break;
             }
-            let fetched = page.len() as u32;
             all.extend(page);
-            start_at = start_at.saturating_add(fetched);
+            start_at = start_at.saturating_add(USER_PAGE_SIZE);
         }
         if !reached_end {
             eprintln!(

--- a/src/api/jira/users.rs
+++ b/src/api/jira/users.rs
@@ -3,12 +3,16 @@ use crate::types::jira::User;
 use anyhow::Result;
 
 /// Maximum users requested per page. Atlassian's effective server-side cap
-/// for `/user/search` and related endpoints is 100 — requesting more is ignored.
+/// for `/user/search` and related endpoints is 100 — requesting more is
+/// silently clamped to 100 by the server.
 const USER_PAGE_SIZE: u32 = 100;
 
 /// Safety bound on the pagination loop. Atlassian documents a 1000-user hard
-/// cap on these endpoints, so at USER_PAGE_SIZE=100 we need at most 10
-/// iterations; 15 leaves 50% headroom against pathological server behavior.
+/// cap on these endpoints, so at `USER_PAGE_SIZE=100` the loop terminates
+/// naturally (empty page) by iteration 11. The 15-iteration bound is purely
+/// defensive against pathological server behavior (e.g., Atlassian silently
+/// raising the cap). Users in practice see at most ~1000 users; if the loop
+/// ever exits via this cap, `search_users_all` emits a stderr warning.
 const USER_PAGINATION_SAFETY_CAP: u32 = 15;
 
 impl JiraClient {
@@ -70,20 +74,30 @@ impl JiraClient {
     /// The endpoint returns a flat JSON array with no `isLast` / `total`
     /// metadata, and its docs note responses "usually return fewer users
     /// than specified in `maxResults`" due to post-page filtering. The only
-    /// reliable termination signal is an empty response.
+    /// reliable termination signal is an empty response — a non-empty short
+    /// page is NOT end-of-data, and breaking on it would silently truncate.
     pub async fn search_users_all(&self, query: &str) -> Result<Vec<User>> {
         let mut all: Vec<User> = Vec::new();
         let mut start_at: u32 = 0;
+        let mut reached_end = false;
         for _ in 0..USER_PAGINATION_SAFETY_CAP {
             let page = self
                 .search_users_page(query, start_at, USER_PAGE_SIZE)
                 .await?;
             if page.is_empty() {
+                reached_end = true;
                 break;
             }
             let fetched = page.len() as u32;
             all.extend(page);
             start_at = start_at.saturating_add(fetched);
+        }
+        if !reached_end {
+            eprintln!(
+                "warning: user search hit pagination safety cap ({} pages, {} users); results may be incomplete",
+                USER_PAGINATION_SAFETY_CAP,
+                all.len()
+            );
         }
         Ok(all)
     }
@@ -171,7 +185,8 @@ impl JiraClient {
     ///
     /// Same termination rules as `search_users_all`: empty response is the only
     /// reliable end-of-data signal (the endpoint returns a flat array with no
-    /// `isLast` or `total` envelope metadata).
+    /// `isLast` or `total` envelope metadata). A non-empty short page is NOT
+    /// end-of-data.
     pub async fn search_assignable_users_by_project_all(
         &self,
         query: &str,
@@ -179,6 +194,7 @@ impl JiraClient {
     ) -> Result<Vec<User>> {
         let mut all: Vec<User> = Vec::new();
         let mut start_at: u32 = 0;
+        let mut reached_end = false;
         for _ in 0..USER_PAGINATION_SAFETY_CAP {
             let page = self
                 .search_assignable_users_by_project_page(
@@ -189,11 +205,19 @@ impl JiraClient {
                 )
                 .await?;
             if page.is_empty() {
+                reached_end = true;
                 break;
             }
             let fetched = page.len() as u32;
             all.extend(page);
             start_at = start_at.saturating_add(fetched);
+        }
+        if !reached_end {
+            eprintln!(
+                "warning: assignable user search hit pagination safety cap ({} pages, {} users); results may be incomplete",
+                USER_PAGINATION_SAFETY_CAP,
+                all.len()
+            );
         }
         Ok(all)
     }

--- a/src/api/jira/users.rs
+++ b/src/api/jira/users.rs
@@ -138,6 +138,66 @@ impl JiraClient {
         Ok(users)
     }
 
+    /// Single-page variant of `search_assignable_users_by_project`.
+    /// Private — used only by `search_assignable_users_by_project_all`.
+    async fn search_assignable_users_by_project_page(
+        &self,
+        query: &str,
+        project_key: &str,
+        start_at: u32,
+        max_results: u32,
+    ) -> Result<Vec<User>> {
+        let path = format!(
+            "/rest/api/3/user/assignable/multiProjectSearch?query={}&projectKeys={}&startAt={}&maxResults={}",
+            urlencoding::encode(query),
+            urlencoding::encode(project_key),
+            start_at,
+            max_results,
+        );
+        let raw: serde_json::Value = self.get(&path).await?;
+        let users: Vec<User> = if raw.is_array() {
+            serde_json::from_value(raw)?
+        } else if let Some(values) = raw.get("values") {
+            serde_json::from_value(values.clone())?
+        } else {
+            anyhow::bail!(
+                "Unexpected response from assignable user search API. Expected a JSON array or object with \"values\" key."
+            );
+        };
+        Ok(users)
+    }
+
+    /// Paginate `/rest/api/3/user/assignable/multiProjectSearch` until exhausted.
+    ///
+    /// Same termination rules as `search_users_all`: empty response is the only
+    /// reliable end-of-data signal (the endpoint returns a flat array with no
+    /// `isLast` or `total` envelope metadata).
+    pub async fn search_assignable_users_by_project_all(
+        &self,
+        query: &str,
+        project_key: &str,
+    ) -> Result<Vec<User>> {
+        let mut all: Vec<User> = Vec::new();
+        let mut start_at: u32 = 0;
+        for _ in 0..USER_PAGINATION_SAFETY_CAP {
+            let page = self
+                .search_assignable_users_by_project_page(
+                    query,
+                    project_key,
+                    start_at,
+                    USER_PAGE_SIZE,
+                )
+                .await?;
+            if page.is_empty() {
+                break;
+            }
+            let fetched = page.len() as u32;
+            all.extend(page);
+            start_at = start_at.saturating_add(fetched);
+        }
+        Ok(all)
+    }
+
     /// Fetch a single user by accountId.
     ///
     /// Returns a `JrError::ApiError { status: 404 | 400, .. }` when the

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -594,8 +594,9 @@ pub enum UserCommand {
         /// table rows and JSON array length; does not reduce the API fetch.
         #[arg(long)]
         limit: Option<u32>,
-        /// Disable the default local cap. Jira still returns a single page
-        /// (up to 50 results by default, capped at 100 server-side).
+        /// Fetch all matching users by paginating through every API page
+        /// (up to Jira's documented 1000-user hard cap). Overrides the
+        /// default local cap.
         #[arg(long, conflicts_with = "limit")]
         all: bool,
     },
@@ -610,8 +611,9 @@ pub enum UserCommand {
         /// table rows and JSON array length; does not reduce the API fetch.
         #[arg(long)]
         limit: Option<u32>,
-        /// Disable the default local cap. Jira still returns a single page
-        /// (up to 50 results by default, capped at 100 server-side).
+        /// Fetch all assignable users by paginating through every API page
+        /// (up to Jira's documented 1000-user hard cap). Overrides the
+        /// default local cap.
         #[arg(long, conflicts_with = "limit")]
         all: bool,
     },

--- a/src/cli/user.rs
+++ b/src/cli/user.rs
@@ -33,7 +33,11 @@ async fn handle_search(
     client: &JiraClient,
 ) -> Result<()> {
     let effective = resolve_effective_limit(limit, all);
-    let mut users = client.search_users(query).await?;
+    let mut users = if all {
+        client.search_users_all(query).await?
+    } else {
+        client.search_users(query).await?
+    };
     if let Some(cap) = effective {
         users.truncate(cap as usize);
     }
@@ -48,9 +52,15 @@ async fn handle_list(
     client: &JiraClient,
 ) -> Result<()> {
     let effective = resolve_effective_limit(limit, all);
-    let mut users = client
-        .search_assignable_users_by_project("", project)
-        .await?;
+    let mut users = if all {
+        client
+            .search_assignable_users_by_project_all("", project)
+            .await?
+    } else {
+        client
+            .search_assignable_users_by_project("", project)
+            .await?
+    };
     if let Some(cap) = effective {
         users.truncate(cap as usize);
     }

--- a/tests/all_flag_behavior.rs
+++ b/tests/all_flag_behavior.rs
@@ -142,8 +142,10 @@ async fn issue_list_default_caps_at_thirty() {
 
 /// `jr user search --all` returns all users from a response that contains
 /// more than DEFAULT_LIMIT entries. As of #189, `--all` triggers true
-/// server-side pagination — the client requests page 1 (startAt=0), sees
-/// 35 users in one shot, then stops when the next page returns empty.
+/// server-side pagination — the client requests page 1 (startAt=0) and
+/// receives 35 users (a short page due to Atlassian's post-paging filter),
+/// then advances `startAt` by the requested `maxResults` (100) and sees an
+/// empty page that terminates the loop.
 #[tokio::test]
 async fn user_search_all_returns_more_than_default_cap() {
     let server = MockServer::start().await;
@@ -167,11 +169,12 @@ async fn user_search_all_returns_more_than_default_cap() {
         )
         .mount(&server)
         .await;
-    // Page 2 (startAt=35): empty — terminates the loop.
+    // Page 2 (startAt=100, advanced by requested maxResults, NOT by returned
+    // count): empty — terminates the loop.
     Mock::given(method("GET"))
         .and(path("/rest/api/3/user/search"))
         .and(query_param("query", "User"))
-        .and(query_param("startAt", "35"))
+        .and(query_param("startAt", "100"))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(common::fixtures::user_search_response(vec![])),

--- a/tests/all_flag_behavior.rs
+++ b/tests/all_flag_behavior.rs
@@ -141,8 +141,9 @@ async fn issue_list_default_caps_at_thirty() {
 }
 
 /// `jr user search --all` returns all users from a response that contains
-/// more than DEFAULT_LIMIT entries. `search_users` is flat (no pagination),
-/// so truncation is purely client-side.
+/// more than DEFAULT_LIMIT entries. As of #189, `--all` triggers true
+/// server-side pagination — the client requests page 1 (startAt=0), sees
+/// 35 users in one shot, then stops when the next page returns empty.
 #[tokio::test]
 async fn user_search_all_returns_more_than_default_cap() {
     let server = MockServer::start().await;
@@ -150,11 +151,12 @@ async fn user_search_all_returns_more_than_default_cap() {
     let users: Vec<(String, String, bool)> = (1..=35)
         .map(|i| (format!("acc-{i:03}"), format!("User {i:03}"), true))
         .collect();
-    // Constrain the `query` param so the test fails if `search_users`
-    // stops sending it (or renames the param).
+
+    // Page 1 (startAt=0): 35 users.
     Mock::given(method("GET"))
         .and(path("/rest/api/3/user/search"))
         .and(query_param("query", "User"))
+        .and(query_param("startAt", "0"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(common::fixtures::user_search_response(
                 users
@@ -162,6 +164,17 @@ async fn user_search_all_returns_more_than_default_cap() {
                     .map(|(a, d, t)| (a.as_str(), d.as_str(), *t))
                     .collect(),
             )),
+        )
+        .mount(&server)
+        .await;
+    // Page 2 (startAt=35): empty — terminates the loop.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "User"))
+        .and(query_param("startAt", "35"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(common::fixtures::user_search_response(vec![])),
         )
         .mount(&server)
         .await;

--- a/tests/user_pagination.rs
+++ b/tests/user_pagination.rs
@@ -25,21 +25,27 @@ fn jr_cmd_json(server_uri: &str) -> Command {
 }
 
 /// Build a user-search fixture of `count` users with names/ids derived from `prefix`.
-/// `Box::leak` converts the owned Strings into `&'static str` so they can be fed
-/// into `user_search_response`'s `Vec<(&str, &str, bool)>` signature.
+/// Constructs the JSON response directly from owned `String`s to avoid leaking
+/// memory just to satisfy the borrowed-string fixture signature.
 fn users_page(count: usize, prefix: &str) -> Value {
-    let users: Vec<(&str, &str, bool)> = (0..count)
+    let users: Vec<Value> = (0..count)
         .map(|i| {
-            let acc = Box::leak(format!("{prefix}-acc-{i:03}").into_boxed_str()) as &str;
-            let name = Box::leak(format!("{prefix} User {i:03}").into_boxed_str()) as &str;
-            (acc, name, true)
+            serde_json::json!({
+                "accountId": format!("{prefix}-acc-{i:03}"),
+                "displayName": format!("{prefix} User {i:03}"),
+                "emailAddress": format!("{prefix}.user.{i:03}@test.com"),
+                "active": true,
+            })
         })
         .collect();
-    common::fixtures::user_search_response(users)
+    Value::Array(users)
 }
 
 /// `search_users_all` paginates three sequential pages (100 + 100 + 27)
-/// and returns 227 users concatenated in order.
+/// and returns 227 users concatenated in order. `startAt` advances by the
+/// requested page size (100) each iteration regardless of returned count —
+/// Jira uses fixed-window pagination, so advancing by the short page's
+/// length would re-scan already-seen raw users.
 #[tokio::test]
 async fn search_users_all_paginates_and_concatenates() {
     let server = MockServer::start().await;
@@ -77,7 +83,7 @@ async fn search_users_all_paginates_and_concatenates() {
     Mock::given(method("GET"))
         .and(path("/rest/api/3/user/search"))
         .and(query_param("query", "u"))
-        .and(query_param("startAt", "227"))
+        .and(query_param("startAt", "300"))
         .and(query_param("maxResults", "100"))
         .respond_with(
             ResponseTemplate::new(200)
@@ -188,9 +194,10 @@ async fn search_users_all_propagates_error_mid_pagination() {
 /// Atlassian docs warn that the user-search endpoint "usually returns fewer
 /// users than specified in maxResults" due to post-page filtering. A short
 /// non-empty page is NOT end-of-data; the loop must keep paginating until it
-/// sees a truly empty page. This pins that contract: page 2 returns 35 users
-/// (short), page 3 returns 100 again (proving short didn't mean EOF), page 4
-/// empties and ends the loop.
+/// sees a truly empty page. Pins two contracts at once: (a) short response
+/// doesn't trigger early termination, and (b) `startAt` advances by the
+/// requested window size (100) regardless of returned count — advancing by
+/// 35 would re-scan users[35..100] and produce duplicates per JRACLOUD-71293.
 #[tokio::test]
 async fn search_users_all_continues_past_short_non_empty_page() {
     let server = MockServer::start().await;
@@ -213,7 +220,7 @@ async fn search_users_all_continues_past_short_non_empty_page() {
 
     Mock::given(method("GET"))
         .and(path("/rest/api/3/user/search"))
-        .and(query_param("startAt", "135"))
+        .and(query_param("startAt", "200"))
         .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p3")))
         .expect(1)
         .mount(&server)
@@ -221,7 +228,7 @@ async fn search_users_all_continues_past_short_non_empty_page() {
 
     Mock::given(method("GET"))
         .and(path("/rest/api/3/user/search"))
-        .and(query_param("startAt", "235"))
+        .and(query_param("startAt", "300"))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(common::fixtures::user_search_response(vec![])),
@@ -269,7 +276,7 @@ async fn search_assignable_users_by_project_all_paginates() {
     Mock::given(method("GET"))
         .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
         .and(query_param("projectKeys", "FOO"))
-        .and(query_param("startAt", "140"))
+        .and(query_param("startAt", "200"))
         .and(query_param("maxResults", "100"))
         .respond_with(
             ResponseTemplate::new(200)
@@ -315,7 +322,7 @@ async fn user_search_all_cli_paginates() {
     Mock::given(method("GET"))
         .and(path("/rest/api/3/user/search"))
         .and(query_param("query", "u"))
-        .and(query_param("startAt", "150"))
+        .and(query_param("startAt", "200"))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(common::fixtures::user_search_response(vec![])),
@@ -365,7 +372,7 @@ async fn user_list_all_cli_paginates() {
     Mock::given(method("GET"))
         .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
         .and(query_param("projectKeys", "FOO"))
-        .and(query_param("startAt", "135"))
+        .and(query_param("startAt", "200"))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(common::fixtures::user_search_response(vec![])),
@@ -391,26 +398,18 @@ async fn user_list_all_cli_paginates() {
 
 /// Without `--all`, `jr user search` must still make exactly one API request
 /// (the existing single-call path) — no accidental pagination.
+/// Asserts via `received_requests()` that the request query string contains
+/// no `startAt` or `maxResults` — a loose matcher like `query_param("query", "u")`
+/// would still match a paginated request, so the post-hoc inspection is
+/// required to actually guard against accidental pagination regression.
 #[tokio::test]
 async fn user_search_no_all_issues_single_request() {
     let server = MockServer::start().await;
 
-    // No startAt/maxResults constraints — proves the legacy single-call path
-    // (which doesn't send those params) is still in use.
     Mock::given(method("GET"))
         .and(path("/rest/api/3/user/search"))
         .and(query_param("query", "u"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(common::fixtures::user_search_response(
-                (0..50)
-                    .map(|i| {
-                        let acc = Box::leak(format!("acc-{i:03}").into_boxed_str()) as &str;
-                        let name = Box::leak(format!("User {i:03}").into_boxed_str()) as &str;
-                        (acc, name, true)
-                    })
-                    .collect(),
-            )),
-        )
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(50, "u")))
         .expect(1)
         .mount(&server)
         .await;
@@ -432,5 +431,23 @@ async fn user_search_no_all_issues_single_request() {
         30,
         "default cap should truncate to 30, got {}",
         arr.len()
+    );
+
+    // Primary guard: verify the actual request the binary sent contains no
+    // pagination parameters. Without `--all` the single-call path must not
+    // send `startAt` or `maxResults`.
+    let requests = server
+        .received_requests()
+        .await
+        .expect("received_requests must be recording");
+    assert_eq!(requests.len(), 1, "expected exactly one API request");
+    let query = requests[0].url.query().unwrap_or("");
+    assert!(
+        !query.contains("startAt"),
+        "single-call path must not send startAt; got query: {query}"
+    );
+    assert!(
+        !query.contains("maxResults"),
+        "single-call path must not send maxResults; got query: {query}"
     );
 }

--- a/tests/user_pagination.rs
+++ b/tests/user_pagination.rs
@@ -229,3 +229,149 @@ async fn search_assignable_users_by_project_all_paginates() {
     assert_eq!(users[0].display_name, "p1 User 000");
     assert_eq!(users[100].display_name, "p2 User 000");
 }
+
+/// End-to-end: `jr user search --all` paginates and emits all users as JSON.
+#[tokio::test]
+async fn user_search_all_cli_paginates() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p1")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(50, "p2")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "150"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(common::fixtures::user_search_response(vec![])),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd_json(&server.uri())
+        .args(["user", "search", "u", "--all"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let arr = json.as_array().expect("user search --all JSON is an array");
+    assert_eq!(arr.len(), 150, "--all should paginate to 150 users");
+}
+
+/// End-to-end: `jr user list --all --project FOO` paginates.
+#[tokio::test]
+async fn user_list_all_cli_paginates() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
+        .and(query_param("projectKeys", "FOO"))
+        .and(query_param("startAt", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p1")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
+        .and(query_param("projectKeys", "FOO"))
+        .and(query_param("startAt", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(35, "p2")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
+        .and(query_param("projectKeys", "FOO"))
+        .and(query_param("startAt", "135"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(common::fixtures::user_search_response(vec![])),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd_json(&server.uri())
+        .args(["user", "list", "--project", "FOO", "--all"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let arr = json.as_array().expect("user list --all JSON is an array");
+    assert_eq!(arr.len(), 135);
+}
+
+/// Without `--all`, `jr user search` must still make exactly one API request
+/// (the existing single-call path) — no accidental pagination.
+#[tokio::test]
+async fn user_search_no_all_issues_single_request() {
+    let server = MockServer::start().await;
+
+    // No startAt/maxResults constraints — proves the legacy single-call path
+    // (which doesn't send those params) is still in use.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(common::fixtures::user_search_response(
+                (0..50)
+                    .map(|i| {
+                        let acc = Box::leak(format!("acc-{i:03}").into_boxed_str()) as &str;
+                        let name = Box::leak(format!("User {i:03}").into_boxed_str()) as &str;
+                        (acc, name, true)
+                    })
+                    .collect(),
+            )),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd_json(&server.uri())
+        .args(["user", "search", "u"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let arr = json.as_array().expect("user search JSON is an array");
+    assert_eq!(
+        arr.len(),
+        30,
+        "default cap should truncate to 30, got {}",
+        arr.len()
+    );
+}

--- a/tests/user_pagination.rs
+++ b/tests/user_pagination.rs
@@ -1,0 +1,100 @@
+//! End-to-end coverage for `--all` true pagination on `user search` and
+//! `user list` (#189). Library-level tests assert that `_all` variants loop
+//! the endpoint until an empty page is returned and that pages are
+//! concatenated in order. CLI-level tests verify the flag wiring in handlers.
+
+#[allow(dead_code)]
+mod common;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use jr::api::client::JiraClient;
+
+/// Build a `jr` command pre-configured for non-interactive JSON output
+/// against a mock server. Matches the pattern used in tests/all_flag_behavior.rs.
+#[allow(dead_code)]
+fn jr_cmd_json(server_uri: &str) -> Command {
+    let mut cmd = Command::cargo_bin("jr").unwrap();
+    cmd.env("JR_BASE_URL", server_uri)
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["--no-input", "--output", "json"]);
+    cmd
+}
+
+/// Build a user-search fixture of `count` users with names/ids derived from `prefix`.
+/// `Box::leak` converts the owned Strings into `&'static str` so they can be fed
+/// into `user_search_response`'s `Vec<(&str, &str, bool)>` signature.
+fn users_page(count: usize, prefix: &str) -> Value {
+    let users: Vec<(&str, &str, bool)> = (0..count)
+        .map(|i| {
+            let acc = Box::leak(format!("{prefix}-acc-{i:03}").into_boxed_str()) as &str;
+            let name = Box::leak(format!("{prefix} User {i:03}").into_boxed_str()) as &str;
+            (acc, name, true)
+        })
+        .collect();
+    common::fixtures::user_search_response(users)
+}
+
+/// `search_users_all` paginates three sequential pages (100 + 100 + 27)
+/// and returns 227 users concatenated in order.
+#[tokio::test]
+async fn search_users_all_paginates_and_concatenates() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "0"))
+        .and(query_param("maxResults", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p1")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "100"))
+        .and(query_param("maxResults", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p2")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "200"))
+        .and(query_param("maxResults", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(27, "p3")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "227"))
+        .and(query_param("maxResults", "100"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(common::fixtures::user_search_response(vec![])),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(server.uri(), "Basic dGVzdDp0ZXN0".to_string());
+    let users = client
+        .search_users_all("u")
+        .await
+        .expect("pagination must succeed");
+    assert_eq!(users.len(), 227, "expected 227 users across 3 pages");
+    assert_eq!(users[0].display_name, "p1 User 000");
+    assert_eq!(users[100].display_name, "p2 User 000");
+    assert_eq!(users[200].display_name, "p3 User 000");
+    assert_eq!(users[226].display_name, "p3 User 026");
+}

--- a/tests/user_pagination.rs
+++ b/tests/user_pagination.rs
@@ -451,3 +451,70 @@ async fn user_search_no_all_issues_single_request() {
         "single-call path must not send maxResults; got query: {query}"
     );
 }
+
+/// End-to-end: when the server never returns an empty page, the safety cap
+/// bites and the command emits a stderr warning so the truncation is
+/// observable instead of silent. Pins the user-visible warning contract.
+#[tokio::test]
+async fn user_search_all_cli_emits_safety_cap_warning() {
+    let server = MockServer::start().await;
+
+    // Every request (any startAt) returns a full 100-user page — the loop
+    // never sees an empty response and must exit via the safety cap.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "cap")))
+        .expect(15)
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd_json(&server.uri())
+        .args(["user", "search", "u", "--all"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "command must still succeed when cap hits; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("hit pagination safety cap"),
+        "stderr must contain the safety-cap warning so truncation is observable; got: {stderr}"
+    );
+}
+
+/// Same safety-cap warning contract for `user list --all` (assignable users
+/// endpoint). The two paginated methods have parallel warning behavior; both
+/// need explicit coverage so a refactor of either one doesn't silently drop
+/// the stderr notice.
+#[tokio::test]
+async fn user_list_all_cli_emits_safety_cap_warning() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
+        .and(query_param("projectKeys", "FOO"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "cap")))
+        .expect(15)
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd_json(&server.uri())
+        .args(["user", "list", "--project", "FOO", "--all"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "command must still succeed when cap hits; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("hit pagination safety cap"),
+        "stderr must contain the safety-cap warning so truncation is observable; got: {stderr}"
+    );
+}

--- a/tests/user_pagination.rs
+++ b/tests/user_pagination.rs
@@ -98,3 +98,84 @@ async fn search_users_all_paginates_and_concatenates() {
     assert_eq!(users[200].display_name, "p3 User 000");
     assert_eq!(users[226].display_name, "p3 User 026");
 }
+
+/// Loop stops as soon as a page comes back empty; subsequent startAt
+/// windows are not requested. The strict `.expect(1)` on each mock,
+/// combined with wiremock rejecting unmatched requests, asserts that
+/// any fourth request would fail.
+#[tokio::test]
+async fn search_users_all_stops_on_empty_page() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p1")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .and(query_param("startAt", "100"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(common::fixtures::user_search_response(vec![])),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(server.uri(), "Basic dGVzdDp0ZXN0".to_string());
+    let users = client.search_users_all("u").await.expect("must succeed");
+    assert_eq!(users.len(), 100);
+}
+
+/// If the API never returns an empty page (pathological behavior), the loop
+/// stops at USER_PAGINATION_SAFETY_CAP iterations = 15 requests.
+#[tokio::test]
+async fn search_users_all_respects_safety_cap() {
+    let server = MockServer::start().await;
+
+    // Unbounded responder for any startAt; .expect(15) pins the iteration cap.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("query", "u"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "cap")))
+        .expect(15)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(server.uri(), "Basic dGVzdDp0ZXN0".to_string());
+    let users = client.search_users_all("u").await.expect("must succeed");
+    assert_eq!(users.len(), 1500, "15 iterations * 100 per page = 1500");
+}
+
+/// If a page request fails mid-pagination, the error is propagated and the
+/// loop does not silently return partial results.
+#[tokio::test]
+async fn search_users_all_propagates_error_mid_pagination() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("startAt", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p1")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("startAt", "100"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(server.uri(), "Basic dGVzdDp0ZXN0".to_string());
+    let result = client.search_users_all("u").await;
+    assert!(result.is_err(), "500 on page 2 must propagate");
+}

--- a/tests/user_pagination.rs
+++ b/tests/user_pagination.rs
@@ -177,7 +177,66 @@ async fn search_users_all_propagates_error_mid_pagination() {
 
     let client = JiraClient::new_for_test(server.uri(), "Basic dGVzdDp0ZXN0".to_string());
     let result = client.search_users_all("u").await;
-    assert!(result.is_err(), "500 on page 2 must propagate");
+    let err = result.expect_err("500 on page 2 must propagate");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("500"),
+        "error must surface the 500 status, got: {msg}"
+    );
+}
+
+/// Atlassian docs warn that the user-search endpoint "usually returns fewer
+/// users than specified in maxResults" due to post-page filtering. A short
+/// non-empty page is NOT end-of-data; the loop must keep paginating until it
+/// sees a truly empty page. This pins that contract: page 2 returns 35 users
+/// (short), page 3 returns 100 again (proving short didn't mean EOF), page 4
+/// empties and ends the loop.
+#[tokio::test]
+async fn search_users_all_continues_past_short_non_empty_page() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("startAt", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p1")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("startAt", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(35, "p2")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("startAt", "135"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p3")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/search"))
+        .and(query_param("startAt", "235"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(common::fixtures::user_search_response(vec![])),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(server.uri(), "Basic dGVzdDp0ZXN0".to_string());
+    let users = client.search_users_all("u").await.expect("must succeed");
+    assert_eq!(
+        users.len(),
+        235,
+        "must keep paginating past a short non-empty page (100 + 35 + 100)"
+    );
 }
 
 /// `search_assignable_users_by_project_all` paginates the assignable-users

--- a/tests/user_pagination.rs
+++ b/tests/user_pagination.rs
@@ -179,3 +179,53 @@ async fn search_users_all_propagates_error_mid_pagination() {
     let result = client.search_users_all("u").await;
     assert!(result.is_err(), "500 on page 2 must propagate");
 }
+
+/// `search_assignable_users_by_project_all` paginates the assignable-users
+/// endpoint and concatenates pages in order.
+#[tokio::test]
+async fn search_assignable_users_by_project_all_paginates() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
+        .and(query_param("query", ""))
+        .and(query_param("projectKeys", "FOO"))
+        .and(query_param("startAt", "0"))
+        .and(query_param("maxResults", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(100, "p1")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
+        .and(query_param("projectKeys", "FOO"))
+        .and(query_param("startAt", "100"))
+        .and(query_param("maxResults", "100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(users_page(40, "p2")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/assignable/multiProjectSearch"))
+        .and(query_param("projectKeys", "FOO"))
+        .and(query_param("startAt", "140"))
+        .and(query_param("maxResults", "100"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(common::fixtures::user_search_response(vec![])),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = JiraClient::new_for_test(server.uri(), "Basic dGVzdDp0ZXN0".to_string());
+    let users = client
+        .search_assignable_users_by_project_all("", "FOO")
+        .await
+        .expect("pagination must succeed");
+    assert_eq!(users.len(), 140);
+    assert_eq!(users[0].display_name, "p1 User 000");
+    assert_eq!(users[100].display_name, "p2 User 000");
+}


### PR DESCRIPTION
## Summary

Closes #189.

Makes `jr user search --all` and `jr user list --all` paginate through every server page instead of returning only the first ~50 results from a single API call. New `search_users_all` and `search_assignable_users_by_project_all` methods on `JiraClient` loop private `_page` helpers that pass `startAt` / `maxResults` query parameters, terminating when an empty page arrives — the only reliable EOF signal for these endpoints per Atlassian docs (responses "usually return fewer users than specified in maxResults" due to post-page filtering, so short-page-as-EOF would silently truncate).

Behavior change: `--all` now means "fetch all" (up to Jira's documented 1000-user hard cap), not "don't truncate the single-call result." Help text updated accordingly.

### Design highlights
- Separate `_all` wrapper methods (octocrab's `all_pages()` idiom) so name-lookup callers in `src/cli/issue/helpers.rs` keep their fast single-call path — no accidental pagination risk.
- Page size **100** (Atlassian effective server cap), safety bound **15 iterations** (50% headroom over the 1000-user cap's 10 natural iterations).
- When the safety cap bites, emit a stderr warning — defensive code firing is now observable instead of silently truncating (local review finding).
- Abort on mid-pagination error via `?`. No partial-success. Matches atlassian-python-api and jira-node behavior.

### Scope
In scope: `/user/search` and `/user/assignable/multiProjectSearch`. Out of scope: `/user/assignable/search` (issue-key variant) — no CLI command uses it with `--all` today.

## Test Plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 843 tests pass, zero failures
- [x] 9 new integration tests in `tests/user_pagination.rs`: paginate+concat, stop-on-empty, safety cap, mid-error propagation (asserts 500 surfaces in error), **continues past short non-empty page** (pins Atlassian-docs contract), assignable users paginate, CLI user search `--all`, CLI user list `--all`, no-`--all` single request
- [x] Updated #249 regression test `user_search_all_returns_more_than_default_cap` to reflect new paginated semantics (page 0: 35 users, page 35: empty)
- [x] Local multi-agent review — 2 rounds, all reviewers clean
- [ ] End-to-end against real Jira instance (manual, if desired)