### PR TITLE
feat: configurable OAuth scopes via config.toml (#184)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,9 +1805,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ jr init
 jr auth login
 
 # Or authenticate with OAuth 2.0 (requires your own OAuth app)
+# Scopes default to Atlassian's recommended classic set; override via
+# [instance].oauth_scopes in config.toml — see Configuration below.
 jr auth login --oauth
 
 # Non-interactive (CI / agents): flags or env vars, no TTY required.
@@ -214,6 +216,12 @@ jr issue comment KEY-123 "Deployed to staging"
 [instance]
 url = "https://yourorg.atlassian.net"
 auth_method = "api_token"  # or "oauth"
+# Optional: override the OAuth 2.0 scope list when auth_method = "oauth".
+# Must match what your app in the Atlassian Developer Console has
+# configured. Classic and granular scopes CANNOT mix in one request, and
+# "offline_access" is required for refresh tokens to be issued. If unset,
+# jr uses Atlassian's recommended classic scopes.
+# oauth_scopes = "read:issue:jira write:issue:jira write:comment:jira read:jira-user offline_access"
 
 [defaults]
 output = "table"

--- a/docs/specs/oauth-scopes-configurable.md
+++ b/docs/specs/oauth-scopes-configurable.md
@@ -1,0 +1,135 @@
+# OAuth Scopes Configurable via `config.toml`
+
+**Issue:** [#184](https://github.com/Zious11/jira-cli/issues/184)
+
+## Problem
+
+`jr`'s OAuth 2.0 (3LO) flow at `src/api/auth.rs:27` hardcodes a classic scope string:
+
+```rust
+const SCOPES: &str = "read:jira-work write:jira-work read:jira-user offline_access";
+```
+
+Users who configure an OAuth app in the Atlassian Developer Console with a different scope set — typically granular scopes for least-privilege agent use, e.g. `read:issue:jira write:comment:jira` — cannot make `jr auth login --oauth` request those scopes. The authorize URL always asks for the hardcoded classic string regardless of what the Developer Console app actually has.
+
+## Atlassian constraints (validated)
+
+Confirmed against Atlassian's own developer docs via Perplexity:
+
+1. **Classic scopes remain recommended.** Atlassian's docs state: *"use classic scopes to the maximum extent possible"*; granular scopes are for cases *"when you can't use classic scopes."* No end-of-life has been announced for classic scopes in Jira Platform, Service Management, or Confluence. Exception: Jira **Software**-specific scopes are granular-only.
+2. **Classic and granular scopes cannot be mixed in one `/authorize` request.** The scope parameter must only contain scopes already added to the app in the Developer Console, and apps configure one model or the other — not both.
+3. **`offline_access` is required** for a refresh token to be issued, in both classic and granular scope modes.
+
+Implication: the current hardcoded default is a safe, recommended default for classic apps. The fix is simply to let users override it when their Developer Console app uses a different scope set. `jr` performs no scope-mix validation — Atlassian returns an actionable error on invalid combinations, and maintaining a client-side allowlist of scope names would be brittle as Atlassian revises the list.
+
+## Design
+
+### Config shape
+
+Add one optional field to `InstanceConfig` (`src/config.rs`):
+
+```rust
+#[derive(Debug, Deserialize, Serialize, Default)]
+pub struct InstanceConfig {
+    pub url: Option<String>,
+    pub cloud_id: Option<String>,
+    pub org_id: Option<String>,
+    pub auth_method: Option<String>,
+    pub oauth_scopes: Option<String>, // new
+}
+```
+
+TOML usage:
+
+```toml
+[instance]
+auth_method = "oauth"
+oauth_scopes = "read:issue:jira write:issue:jira write:comment:jira read:jira-user offline_access"
+```
+
+Env override comes free from the existing `Env::prefixed("JR_")` merge in `Config::load()`: `JR_INSTANCE_OAUTH_SCOPES` sets or overrides the value. Empirically confirmed by the existing `JR_INSTANCE_AUTH_METHOD` usage in `tests/auth_refresh.rs:71`.
+
+### Default
+
+The existing classic string stays as the fallback when `oauth_scopes` is unset. Renamed for clarity:
+
+```rust
+// src/api/auth.rs
+pub const DEFAULT_OAUTH_SCOPES: &str =
+    "read:jira-work write:jira-work read:jira-user offline_access";
+```
+
+Zero behavior change for any user who doesn't set the new config field.
+
+### Data flow
+
+```
+Config::load() → cli::auth::handle_login()
+  → resolve_oauth_scopes(&config)?
+  → api::auth::oauth_login(client_id, client_secret, scopes)
+    → urlencoding::encode(scopes) in the authorize URL
+```
+
+- `oauth_login` gains a third parameter `scopes: &str`, replacing the `SCOPES` constant at the existing use site (`src/api/auth.rs:168`).
+- `refresh_oauth_token` is **unchanged**. The OAuth `refresh_token` grant does not accept a `scope` parameter at Atlassian's token endpoint; scopes for refreshed access tokens inherit from the original authorization.
+
+### Scope-resolution helper
+
+A small private helper in `src/cli/auth.rs` owns the selection and validation:
+
+```rust
+// src/cli/auth.rs (module-private)
+fn resolve_oauth_scopes(config: &Config) -> Result<String> {
+    match config.global.instance.oauth_scopes.as_deref() {
+        None => Ok(crate::api::auth::DEFAULT_OAUTH_SCOPES.to_string()),
+        Some(raw) => {
+            let trimmed = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+            if trimmed.is_empty() {
+                Err(JrError::ConfigError(
+                    "oauth_scopes is empty; remove the setting to use defaults \
+                     or list at least one scope".into(),
+                ).into())
+            } else {
+                Ok(trimmed)
+            }
+        }
+    }
+}
+```
+
+Trimming collapses arbitrary whitespace (TOML multi-line literals, trailing newlines, stray tabs) into single spaces, matching how `urlencoding::encode` will render the string to Atlassian. `split_whitespace().collect::<Vec<_>>().join(" ")` is the idiomatic way to do this in Rust.
+
+### Errors
+
+| Condition | Behavior |
+|---|---|
+| `oauth_scopes` unset | Use `DEFAULT_OAUTH_SCOPES`, no warning |
+| `oauth_scopes = "..."` with at least one token after trim | Pass through trimmed value |
+| `oauth_scopes = ""` or whitespace-only | `JrError::ConfigError`, actionable message, exit 78 |
+| Invalid scope combination (e.g. mix, unknown scope) | Atlassian returns `invalid_scope` at token exchange; existing `anyhow::bail!("Token exchange failed: {body}")` path surfaces it |
+
+No client-side mix detection. No warning for missing `offline_access`. Both are documented caveats, not enforcement.
+
+### Documentation
+
+- `docs/specs/oauth-scopes-configurable.md` (this file)
+- README section on OAuth configuration: call out that the scope string must match what the Developer Console app has configured, that classic and granular cannot mix, and that `offline_access` is required for unattended re-authentication
+- Existing `jr auth login --oauth` help text: reference the config key so users discover it without reading the README
+
+## Testing strategy
+
+All unit tests in the affected modules. No integration test for the OAuth flow itself — `oauth_login` hits `auth.atlassian.com` and the value of mocking the authorization-code dance is low compared to the risk of the mock diverging from Atlassian's actual behavior.
+
+- `src/config.rs` (`#[cfg(test)]` module): `oauth_scopes` parses from TOML; missing field yields `None`; env var `JR_INSTANCE_OAUTH_SCOPES` overrides
+- `src/cli/auth.rs` (`#[cfg(test)]` module): `resolve_oauth_scopes` — None path returns default, Some(valid) returns trimmed, Some(empty/whitespace) returns `ConfigError`, Some with internal whitespace is collapsed
+
+## Out of scope
+
+- Validating scope mix (classic vs granular) or token shape client-side — let Atlassian return `invalid_scope`; our error path already surfaces it
+- Warning when `offline_access` is absent — docs-only caveat
+- Migrating the default to granular — Atlassian still recommends classic for Jira Platform; Jira Software users who need granular will simply set the config
+- Per-project `oauth_scopes` in `.jr.toml` — global-only, matches how `auth_method`, `cloud_id`, and `url` are scoped today
+
+## Non-breaking
+
+Every existing user continues to see the same authorize URL until they opt in by setting `oauth_scopes`. No migration, no deprecation notice.

--- a/docs/specs/oauth-scopes-configurable.md
+++ b/docs/specs/oauth-scopes-configurable.md
@@ -66,7 +66,7 @@ Zero behavior change for any user who doesn't set the new config field.
 ### Data flow
 
 ```
-Config::load() → cli::auth::handle_login()
+Config::load() → cli::auth::login_oauth()
   → resolve_oauth_scopes(&config)?
   → api::auth::oauth_login(client_id, client_secret, scopes)
     → urlencoding::encode(scopes) in the authorize URL
@@ -116,7 +116,7 @@ No client-side mix detection. No warning for missing `offline_access`. Both are 
 
 - `docs/specs/oauth-scopes-configurable.md` (this file)
 - README section on OAuth configuration: call out that the scope string must match what the Developer Console app has configured, that classic and granular cannot mix, and that `offline_access` is required for unattended re-authentication
-- Existing `jr auth login --oauth` help text: reference the config key so users discover it without reading the README
+- `jr auth login --oauth` help text in `src/cli/mod.rs`: reference the config key so users discover it from `jr auth login --help` without having to read the README
 
 ## Testing strategy
 

--- a/docs/specs/oauth-scopes-configurable.md
+++ b/docs/specs/oauth-scopes-configurable.md
@@ -4,11 +4,13 @@
 
 ## Problem
 
-`jr`'s OAuth 2.0 (3LO) flow at `src/api/auth.rs:27` hardcodes a classic scope string:
+`jr`'s OAuth 2.0 (3LO) flow previously hardcoded a classic scope string in `src/api/auth.rs`:
 
 ```rust
 const SCOPES: &str = "read:jira-work write:jira-work read:jira-user offline_access";
 ```
+
+(As part of this change, the constant is renamed to `pub const DEFAULT_OAUTH_SCOPES` so the CLI handler can fall back to it when no override is configured — see the Default section below.)
 
 Users who configure an OAuth app in the Atlassian Developer Console with a different scope set — typically granular scopes for least-privilege agent use, e.g. `read:issue:jira write:comment:jira` — cannot make `jr auth login --oauth` request those scopes. The authorize URL always asks for the hardcoded classic string regardless of what the Developer Console app actually has.
 

--- a/docs/specs/oauth-scopes-configurable.md
+++ b/docs/specs/oauth-scopes-configurable.md
@@ -47,7 +47,7 @@ auth_method = "oauth"
 oauth_scopes = "read:issue:jira write:issue:jira write:comment:jira read:jira-user offline_access"
 ```
 
-Env override comes free from the existing `Env::prefixed("JR_")` merge in `Config::load()`: `JR_INSTANCE_OAUTH_SCOPES` sets or overrides the value. Empirically confirmed by the existing `JR_INSTANCE_AUTH_METHOD` usage in `tests/auth_refresh.rs:71`.
+**Env-var override is out of scope for this PR.** Figment's default `Env::prefixed("JR_")` layer in `Config::load()` cannot reach nested struct fields without a `.split(...)` separator, and neither `.split("_")` (would split `oauth_scopes` itself) nor `.split("__")` (changes convention for the whole app) is a one-file change. The earlier `tests/auth_refresh.rs:71` reference was defensive env-clearing, not proof that `JR_INSTANCE_AUTH_METHOD` actually propagates through figment. A dedicated follow-up issue tracks adding proper nested-env-var support for `JR_INSTANCE_*` and `JR_FIELDS_*` across the config.
 
 ### Default
 
@@ -71,7 +71,7 @@ Config::load() → cli::auth::handle_login()
 ```
 
 - `oauth_login` gains a third parameter `scopes: &str`, replacing the `SCOPES` constant at the existing use site (`src/api/auth.rs:168`).
-- `refresh_oauth_token` is **unchanged**. The OAuth `refresh_token` grant does not accept a `scope` parameter at Atlassian's token endpoint; scopes for refreshed access tokens inherit from the original authorization.
+- `refresh_oauth_token` is **unchanged**. The OAuth `refresh_token` grant does not accept a `scope` parameter at Atlassian's token endpoint; scopes for refreshed access tokens inherit from the original authorization (RFC 6749 §6). **Consequence:** changing `oauth_scopes` in config.toml does not take effect until the user re-runs `jr auth login --oauth`. `jr auth refresh` alone will keep the old scope set.
 
 ### Scope-resolution helper
 
@@ -120,8 +120,8 @@ No client-side mix detection. No warning for missing `offline_access`. Both are 
 
 All unit tests in the affected modules. No integration test for the OAuth flow itself — `oauth_login` hits `auth.atlassian.com` and the value of mocking the authorization-code dance is low compared to the risk of the mock diverging from Atlassian's actual behavior.
 
-- `src/config.rs` (`#[cfg(test)]` module): `oauth_scopes` parses from TOML; missing field yields `None`; env var `JR_INSTANCE_OAUTH_SCOPES` overrides
-- `src/cli/auth.rs` (`#[cfg(test)]` module): `resolve_oauth_scopes` — None path returns default, Some(valid) returns trimmed, Some(empty/whitespace) returns `ConfigError`, Some with internal whitespace is collapsed
+- `src/config.rs` (`#[cfg(test)]` module): `oauth_scopes` parses from TOML; missing field yields `None`. (Env-var override deferred — see Data flow note above.)
+- `src/cli/auth.rs` (`#[cfg(test)]` module): `resolve_oauth_scopes` — None path returns default, Some(valid) returns trimmed, Some(empty/whitespace) returns `ConfigError`, Some with internal whitespace is collapsed. Plus two lock-in tests: `DEFAULT_OAUTH_SCOPES` content is pinned to `"read:jira-work write:jira-work read:jira-user offline_access"`, and `resolve_oauth_scopes_does_not_validate_scope_shape` guards against future client-side validation creep (classic+granular mix, unknown scopes, missing `offline_access` all pass through unchanged).
 
 ## Out of scope
 

--- a/docs/superpowers/plans/2026-04-22-oauth-scopes-configurable.md
+++ b/docs/superpowers/plans/2026-04-22-oauth-scopes-configurable.md
@@ -1,0 +1,436 @@
+# OAuth Scopes Configurable via `config.toml` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users override `jr`'s hardcoded OAuth 2.0 scopes via `config.toml`, falling back to the existing classic scopes when the key is unset.
+
+**Architecture:** Add one field to `InstanceConfig`. Rename the existing `SCOPES` constant to `pub const DEFAULT_OAUTH_SCOPES` so callers can use it as a fallback. A small private helper in `src/cli/auth.rs` picks config-over-default, trims whitespace, and errors on empty input. The helper's result is passed as a new `scopes: &str` parameter to `oauth_login`, replacing the use of the constant inside the authorize-URL builder.
+
+**Tech Stack:** Rust, figment (already used for config), serde, anyhow, `urlencoding` (already used in authorize URL).
+
+**Spec:** `docs/specs/oauth-scopes-configurable.md`
+
+---
+
+## File map
+
+| Path | Change |
+|---|---|
+| `src/config.rs` | Add `oauth_scopes: Option<String>` to `InstanceConfig`; add unit tests for TOML parse, None default, env override |
+| `src/api/auth.rs` | Rename `const SCOPES` → `pub const DEFAULT_OAUTH_SCOPES`; add `scopes: &str` parameter to `oauth_login`; use the parameter in the authorize URL |
+| `src/cli/auth.rs` | Add module-private `resolve_oauth_scopes(&Config) -> Result<String>`; call it in `login_oauth` and pass the result into `oauth_login`; add unit tests covering four cases |
+| `README.md` | Add `oauth_scopes` to the global config example and a short note on classic-vs-granular + `offline_access` |
+
+No files created. No integration test file needed — `oauth_login` hits `auth.atlassian.com` directly and is out of scope for unit-testable mocking.
+
+---
+
+## Task 1: Add `oauth_scopes` to `InstanceConfig`
+
+**Files:**
+- Modify: `src/config.rs`
+- Test: `src/config.rs` (inline `#[cfg(test)]` module)
+
+### Step 1: Write the failing test
+
+- [ ] Append to the existing `#[cfg(test)] mod tests` in `src/config.rs`:
+
+```rust
+#[test]
+fn instance_config_parses_oauth_scopes_from_toml() {
+    use figment::{Figment, providers::{Format, Toml}};
+
+    let toml = r#"
+        [instance]
+        url = "https://example.atlassian.net"
+        auth_method = "oauth"
+        oauth_scopes = "read:issue:jira write:issue:jira offline_access"
+    "#;
+
+    let config: GlobalConfig = Figment::new()
+        .merge(Toml::string(toml))
+        .extract()
+        .unwrap();
+
+    assert_eq!(
+        config.instance.oauth_scopes.as_deref(),
+        Some("read:issue:jira write:issue:jira offline_access")
+    );
+}
+
+#[test]
+fn instance_config_oauth_scopes_missing_is_none() {
+    use figment::{Figment, providers::{Format, Toml}};
+
+    let toml = r#"
+        [instance]
+        url = "https://example.atlassian.net"
+        auth_method = "oauth"
+    "#;
+
+    let config: GlobalConfig = Figment::new()
+        .merge(Toml::string(toml))
+        .extract()
+        .unwrap();
+
+    assert!(config.instance.oauth_scopes.is_none());
+}
+```
+
+### Step 2: Run test to verify it fails
+
+- [ ] `cargo test --lib instance_config_parses_oauth_scopes_from_toml` — expect FAIL with "no field `oauth_scopes`" or similar serde/figment error.
+
+### Step 3: Write minimal implementation
+
+- [ ] Modify `InstanceConfig` in `src/config.rs`:
+
+```rust
+#[derive(Debug, Deserialize, Serialize, Default)]
+pub struct InstanceConfig {
+    pub url: Option<String>,
+    pub cloud_id: Option<String>,
+    pub org_id: Option<String>,
+    pub auth_method: Option<String>,
+    pub oauth_scopes: Option<String>,
+}
+```
+
+No other changes required — `Deserialize`, `Default`, and the existing `Env::prefixed("JR_")` merge pick this up automatically (empirically confirmed: `tests/auth_refresh.rs:71` already uses `JR_INSTANCE_AUTH_METHOD` against the same struct).
+
+### Step 4: Run tests to verify they pass
+
+- [ ] `cargo test --lib instance_config_parses_oauth_scopes_from_toml instance_config_oauth_scopes_missing_is_none` — expect PASS.
+
+### Step 5: Checks + commit
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --all-targets -- -D warnings`
+- [ ] `cargo test`
+
+```bash
+git add src/config.rs
+git commit -m "feat(config): add oauth_scopes to InstanceConfig (#184)
+
+Adds Option<String> field so users can override the hardcoded OAuth 2.0
+scope list via config.toml or the JR_INSTANCE_OAUTH_SCOPES env var. No
+behavior change yet — the field is unused until Task 3 wires it into
+oauth_login. Spec: docs/specs/oauth-scopes-configurable.md."
+```
+
+---
+
+## Task 2: Add `resolve_oauth_scopes` helper + expose `DEFAULT_OAUTH_SCOPES`
+
+**Files:**
+- Modify: `src/api/auth.rs` (rename `SCOPES` → `pub const DEFAULT_OAUTH_SCOPES`)
+- Modify: `src/cli/auth.rs` (add helper + unit tests)
+
+### Step 1: Write the failing tests
+
+- [ ] Add a `#[cfg(test)] mod tests` block at the bottom of `src/cli/auth.rs` (creating one if it doesn't exist). Use explicit crate paths for `Config`, `GlobalConfig`, `InstanceConfig`, and the constant:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::auth::DEFAULT_OAUTH_SCOPES;
+    use crate::config::{Config, GlobalConfig, InstanceConfig};
+
+    fn config_with_scopes(scopes: Option<&str>) -> Config {
+        Config {
+            global: GlobalConfig {
+                instance: InstanceConfig {
+                    oauth_scopes: scopes.map(String::from),
+                    ..InstanceConfig::default()
+                },
+                ..GlobalConfig::default()
+            },
+            project: Default::default(),
+        }
+    }
+
+    #[test]
+    fn resolve_oauth_scopes_none_returns_default() {
+        let config = config_with_scopes(None);
+        assert_eq!(resolve_oauth_scopes(&config).unwrap(), DEFAULT_OAUTH_SCOPES);
+    }
+
+    #[test]
+    fn resolve_oauth_scopes_trims_and_collapses_whitespace() {
+        let config = config_with_scopes(Some("  read:issue:jira   write:comment:jira\n\toffline_access  "));
+        assert_eq!(
+            resolve_oauth_scopes(&config).unwrap(),
+            "read:issue:jira write:comment:jira offline_access"
+        );
+    }
+
+    #[test]
+    fn resolve_oauth_scopes_empty_string_is_config_error() {
+        let config = config_with_scopes(Some(""));
+        let err = resolve_oauth_scopes(&config).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("oauth_scopes is empty"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn resolve_oauth_scopes_whitespace_only_is_config_error() {
+        let config = config_with_scopes(Some("   \n\t  "));
+        let err = resolve_oauth_scopes(&config).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("oauth_scopes is empty"), "unexpected error: {msg}");
+    }
+}
+```
+
+### Step 2: Run tests to verify they fail
+
+- [ ] `cargo test --lib resolve_oauth_scopes` — expect FAIL with "cannot find value `resolve_oauth_scopes`" and "cannot find value `DEFAULT_OAUTH_SCOPES`".
+
+### Step 3: Rename the constant
+
+- [ ] In `src/api/auth.rs`, change:
+
+```rust
+const SCOPES: &str = "read:jira-work write:jira-work read:jira-user offline_access";
+```
+
+to:
+
+```rust
+/// Default OAuth 2.0 scopes used when `oauth_scopes` is not set in
+/// config.toml. Matches Atlassian's "classic" scope recommendation for
+/// Jira Platform apps. Users who configured their Developer Console app
+/// with granular scopes (e.g., for least-privilege agent use) should
+/// override via `[instance].oauth_scopes` in config.toml.
+pub const DEFAULT_OAUTH_SCOPES: &str =
+    "read:jira-work write:jira-work read:jira-user offline_access";
+```
+
+Update the reference at `src/api/auth.rs:168` (the only in-module use):
+
+```rust
+urlencoding::encode(DEFAULT_OAUTH_SCOPES),
+```
+
+(This reference will be replaced again in Task 3 — leaving the rename standalone keeps this task self-contained.)
+
+### Step 4: Add the helper
+
+- [ ] At the top of `src/cli/auth.rs`, ensure the following imports are present (reuse existing ones where possible):
+
+```rust
+use anyhow::Result;
+use crate::config::Config;
+use crate::error::JrError;
+```
+
+- [ ] Add near the other module-private helpers in `src/cli/auth.rs`:
+
+```rust
+/// Pick the OAuth scope string: user override from `[instance].oauth_scopes`
+/// if set, else the compiled-in default. Trims and collapses interior
+/// whitespace so multi-line TOML strings encode cleanly. Empty or
+/// whitespace-only overrides are a configuration error.
+fn resolve_oauth_scopes(config: &Config) -> Result<String> {
+    match config.global.instance.oauth_scopes.as_deref() {
+        None => Ok(crate::api::auth::DEFAULT_OAUTH_SCOPES.to_string()),
+        Some(raw) => {
+            let collapsed: String = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+            if collapsed.is_empty() {
+                Err(JrError::ConfigError(
+                    "oauth_scopes is empty; remove the setting to use defaults \
+                     or list at least one scope"
+                        .into(),
+                )
+                .into())
+            } else {
+                Ok(collapsed)
+            }
+        }
+    }
+}
+```
+
+### Step 5: Run tests to verify they pass
+
+- [ ] `cargo test --lib resolve_oauth_scopes` — expect 4/4 PASS.
+
+### Step 6: Checks + commit
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --all-targets -- -D warnings` — note: `resolve_oauth_scopes` is unused outside tests until Task 3; clippy should not warn thanks to `#[cfg(test)]` referencing it, but if it does, add `#[allow(dead_code)]` to the helper with a comment pointing at Task 3.
+- [ ] `cargo test`
+
+```bash
+git add src/api/auth.rs src/cli/auth.rs
+git commit -m "feat(auth): add resolve_oauth_scopes helper + expose DEFAULT_OAUTH_SCOPES (#184)
+
+Renames the private SCOPES constant to pub const DEFAULT_OAUTH_SCOPES so
+the CLI handler can fall back to it when no override is configured.
+Introduces resolve_oauth_scopes(&Config) -> Result<String> with four-case
+coverage: None → default, valid → trimmed + whitespace-collapsed, empty
+and whitespace-only → JrError::ConfigError. Not yet wired into the
+login flow — Task 3 threads it through oauth_login."
+```
+
+---
+
+## Task 3: Thread scopes into `oauth_login` and wire the call site
+
+**Files:**
+- Modify: `src/api/auth.rs` (add `scopes: &str` parameter, remove direct use of `DEFAULT_OAUTH_SCOPES` inside `oauth_login`)
+- Modify: `src/cli/auth.rs` (`login_oauth` calls `resolve_oauth_scopes` and passes the result)
+
+No new tests — the helper (Task 2) covers the selection logic, and the OAuth flow itself isn't unit-tested in the current codebase.
+
+### Step 1: Update the API signature
+
+- [ ] Change `oauth_login` at `src/api/auth.rs:150` from:
+
+```rust
+pub async fn oauth_login(client_id: &str, client_secret: &str) -> Result<OAuthResult> {
+```
+
+to:
+
+```rust
+pub async fn oauth_login(
+    client_id: &str,
+    client_secret: &str,
+    scopes: &str,
+) -> Result<OAuthResult> {
+```
+
+- [ ] Replace the single internal reference (the line currently `urlencoding::encode(DEFAULT_OAUTH_SCOPES),` after Task 2) with:
+
+```rust
+urlencoding::encode(scopes),
+```
+
+Update the function's doc comment to note the new parameter:
+
+```rust
+/// Run the full OAuth 2.0 (3LO) authorization code flow:
+/// 1. Open browser to Atlassian authorization page requesting `scopes`
+/// 2. Listen on a local port for the callback
+/// 3. Exchange the authorization code for tokens
+/// 4. Fetch accessible resources to get the cloud ID
+/// 5. Store tokens in the system keychain
+///
+/// `scopes` is a space-separated scope string (URL-encoded internally).
+/// Callers should use `DEFAULT_OAUTH_SCOPES` when no user override is set.
+/// Note: `refresh_oauth_token` does NOT take a scope parameter — the
+/// refresh_token grant inherits scopes from the original authorization.
+```
+
+### Step 2: Update the call site
+
+- [ ] In `src/cli/auth.rs`, replace the call at line 182:
+
+```rust
+let result = crate::api::auth::oauth_login(&client_id, &client_secret).await?;
+```
+
+with:
+
+```rust
+let scopes = resolve_oauth_scopes(&Config::load().unwrap_or_default())?;
+let result =
+    crate::api::auth::oauth_login(&client_id, &client_secret, &scopes).await?;
+```
+
+Note: `Config::load()` is called twice in `login_oauth` now (once here, once at line 184 for saving). That's fine — config load is cheap and the second load picks up the state already present on disk. If clippy complains about `needless_late_init` or similar, hoist the `Config::load().unwrap_or_default()` into a single `let mut config = ...` at the top of the function and reuse it.
+
+### Step 3: Build + checks
+
+- [ ] `cargo build` — expect success; the three-arg `oauth_login` signature is consistent across the one call site.
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --all-targets -- -D warnings`
+- [ ] `cargo test` — all tests (including the four from Task 2) pass.
+
+### Step 4: Commit
+
+- [ ] 
+
+```bash
+git add src/api/auth.rs src/cli/auth.rs
+git commit -m "feat(auth): thread configurable OAuth scopes through authorize URL (#184)
+
+oauth_login now accepts scopes as a parameter and the CLI login handler
+passes resolve_oauth_scopes(&config)?. Users with an Atlassian Developer
+Console app configured with granular scopes (e.g., write:issue:jira for
+least-privilege LLM/agent use) can now opt in by setting
+
+    [instance]
+    oauth_scopes = \"read:issue:jira write:issue:jira offline_access\"
+
+in config.toml. Unset keeps the existing classic default — zero behavior
+change for everyone else. refresh_oauth_token is unchanged; the
+refresh_token grant doesn't take a scope parameter. Closes #184."
+```
+
+---
+
+## Task 4: Documentation
+
+**Files:**
+- Modify: `README.md`
+
+### Step 1: Update the global config example
+
+- [ ] Edit README.md line 216 context (the `[instance]` block in the Configuration section) to include `oauth_scopes`:
+
+```toml
+[instance]
+url = "https://yourorg.atlassian.net"
+auth_method = "api_token"  # or "oauth"
+# Optional: override the OAuth 2.0 scope list when auth_method = "oauth".
+# Must match what the OAuth app configured in the Atlassian Developer
+# Console actually has. Classic and granular scopes CANNOT mix in one
+# request, and "offline_access" is required for refresh tokens to be
+# issued. If unset, jr uses Atlassian's recommended classic scopes.
+# oauth_scopes = "read:issue:jira write:issue:jira write:comment:jira read:jira-user offline_access"
+```
+
+### Step 2: Add one-sentence reference in the OAuth login section
+
+- [ ] In the OAuth section of the README (near line 90, where `jr auth login --oauth` is shown), add a note after the command:
+
+```markdown
+To override the default scope list — for example, to request granular
+scopes for least-privilege agent access — set `[instance].oauth_scopes`
+in `~/.config/jr/config.toml`. See the Configuration section below.
+```
+
+### Step 3: Checks + commit
+
+- [ ] `cargo fmt --all -- --check` (no-op for docs but keeps the habit)
+- [ ] `cargo clippy --all-targets -- -D warnings`
+- [ ] `cargo test`
+
+```bash
+git add README.md
+git commit -m "docs: document oauth_scopes config key (#184)
+
+Adds an example of oauth_scopes to the global config block and a short
+note near jr auth login --oauth pointing users at the override. Includes
+the two constraints Perplexity-validated against Atlassian's docs:
+classic and granular scopes cannot mix, and offline_access is required
+for refresh tokens. Spec: docs/specs/oauth-scopes-configurable.md."
+```
+
+---
+
+## Self-review
+
+**Spec coverage:** every requirement from `docs/specs/oauth-scopes-configurable.md` maps to a task:
+- Config shape → Task 1
+- `DEFAULT_OAUTH_SCOPES` + `resolve_oauth_scopes` helper + four-case error handling → Task 2
+- Data flow + `oauth_login` signature change → Task 3
+- README docs → Task 4
+- "No integration test for the OAuth flow itself" — respected (none planned)
+
+**Placeholder scan:** none. Every code block is complete; every command is runnable as written.
+
+**Type consistency:** `resolve_oauth_scopes` signature is the same everywhere it appears (`fn resolve_oauth_scopes(config: &Config) -> Result<String>`). `DEFAULT_OAUTH_SCOPES` is the same constant name everywhere. `oauth_login` parameter order `(client_id, client_secret, scopes)` matches the signature change in Task 3 and the call site update.

--- a/docs/superpowers/plans/2026-04-22-oauth-scopes-configurable.md
+++ b/docs/superpowers/plans/2026-04-22-oauth-scopes-configurable.md
@@ -16,12 +16,12 @@
 
 | Path | Change |
 |---|---|
-| `src/config.rs` | Add `oauth_scopes: Option<String>` to `InstanceConfig`; add unit tests for TOML parse, None default, env override |
+| `src/config.rs` | Add `oauth_scopes: Option<String>` to `InstanceConfig`; add unit tests for TOML parse and missing-key default-to-`None` behavior |
 | `src/api/auth.rs` | Rename `const SCOPES` → `pub const DEFAULT_OAUTH_SCOPES`; add `scopes: &str` parameter to `oauth_login`; use the parameter in the authorize URL |
 | `src/cli/auth.rs` | Add module-private `resolve_oauth_scopes(&Config) -> Result<String>`; call it in `login_oauth` and pass the result into `oauth_login`; add unit tests covering four cases |
 | `README.md` | Add `oauth_scopes` to the global config example and a short note on classic-vs-granular + `offline_access` |
 
-No files created. No integration test file needed — `oauth_login` hits `auth.atlassian.com` directly and is out of scope for unit-testable mocking.
+No additional implementation or test files are created by the plan. The spec (`docs/specs/oauth-scopes-configurable.md`) and this plan itself are new in this PR but are documentation, not implementation. No integration test file is needed — `oauth_login` hits `auth.atlassian.com` directly and is out of scope for unit-testable mocking. Env-var override is likewise out of scope (see spec Data flow section).
 
 ---
 

--- a/docs/superpowers/plans/2026-04-22-oauth-scopes-configurable.md
+++ b/docs/superpowers/plans/2026-04-22-oauth-scopes-configurable.md
@@ -96,7 +96,7 @@ pub struct InstanceConfig {
 }
 ```
 
-No other changes required — `Deserialize`, `Default`, and the existing `Env::prefixed("JR_")` merge pick this up automatically (empirically confirmed: `tests/auth_refresh.rs:71` already uses `JR_INSTANCE_AUTH_METHOD` against the same struct).
+No other changes required — the `Deserialize` and `Default` derives pick this up automatically from the TOML layer. **Do not** assume `JR_INSTANCE_OAUTH_SCOPES` works via the current `Env::prefixed("JR_")` merge; figment's default env provider can't reach nested struct fields without a `.split(...)` configuration, and the spec at `docs/specs/oauth-scopes-configurable.md:50` scopes nested env-var support out of this PR. The `tests/auth_refresh.rs:71` reference in earlier drafts was defensive env-clearing, not proof that `JR_INSTANCE_AUTH_METHOD` actually propagates through figment.
 
 ### Step 4: Run tests to verify they pass
 
@@ -113,9 +113,10 @@ git add src/config.rs
 git commit -m "feat(config): add oauth_scopes to InstanceConfig (#184)
 
 Adds Option<String> field so users can override the hardcoded OAuth 2.0
-scope list via config.toml or the JR_INSTANCE_OAUTH_SCOPES env var. No
-behavior change yet — the field is unused until Task 3 wires it into
-oauth_login. Spec: docs/specs/oauth-scopes-configurable.md."
+scope list via config.toml. Env-var override via JR_INSTANCE_OAUTH_SCOPES
+is out of scope for this PR — see spec data-flow note. No behavior change
+yet — the field is unused until Task 3 wires it into oauth_login.
+Spec: docs/specs/oauth-scopes-configurable.md."
 ```
 
 ---

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -270,6 +270,12 @@ pub async fn oauth_login(
 
 /// Refresh the OAuth 2.0 access token using the stored refresh token.
 /// Returns the new access token on success.
+///
+/// Intentionally takes no `scopes` parameter: the `refresh_token` grant
+/// inherits scopes from the original authorization per RFC 6749 §6. To
+/// pick up a changed `[instance].oauth_scopes` in config.toml, the user
+/// must re-run `jr auth login --oauth` (refresh alone will keep the old
+/// scope set).
 pub async fn refresh_oauth_token(client_id: &str, client_secret: &str) -> Result<String> {
     let (_, refresh_token) = load_oauth_tokens()?;
 

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -24,7 +24,13 @@ const KEY_API_TOKEN: &str = "api-token";
 const KEY_OAUTH_ACCESS: &str = "oauth-access-token";
 const KEY_OAUTH_REFRESH: &str = "oauth-refresh-token";
 
-const SCOPES: &str = "read:jira-work write:jira-work read:jira-user offline_access";
+/// Default OAuth 2.0 scopes used when `oauth_scopes` is not set in
+/// config.toml. Matches Atlassian's "classic" scope recommendation for
+/// Jira Platform apps. Users who configured their Developer Console app
+/// with granular scopes (e.g., for least-privilege agent use) should
+/// override via `[instance].oauth_scopes` in config.toml.
+pub const DEFAULT_OAUTH_SCOPES: &str =
+    "read:jira-work write:jira-work read:jira-user offline_access";
 
 fn entry(key: &str) -> Result<Entry> {
     Entry::new(&service_name(), key).context("Failed to access keychain")
@@ -142,12 +148,21 @@ pub struct OAuthResult {
 }
 
 /// Run the full OAuth 2.0 (3LO) authorization code flow:
-/// 1. Open browser to Atlassian authorization page
+/// 1. Open browser to Atlassian authorization page requesting `scopes`
 /// 2. Listen on a local port for the callback
 /// 3. Exchange the authorization code for tokens
 /// 4. Fetch accessible resources to get the cloud ID
 /// 5. Store tokens in the system keychain
-pub async fn oauth_login(client_id: &str, client_secret: &str) -> Result<OAuthResult> {
+///
+/// `scopes` is a space-separated scope string (URL-encoded internally).
+/// Callers should use [`DEFAULT_OAUTH_SCOPES`] when no user override is set.
+/// Note: [`refresh_oauth_token`] does NOT take a scope parameter — the
+/// `refresh_token` grant inherits scopes from the original authorization.
+pub async fn oauth_login(
+    client_id: &str,
+    client_secret: &str,
+    scopes: &str,
+) -> Result<OAuthResult> {
     // 1. Find an available port for the local callback server.
     let listener = TcpListener::bind("127.0.0.1:0")?;
     let port = listener.local_addr()?.port();
@@ -165,7 +180,7 @@ pub async fn oauth_login(client_id: &str, client_secret: &str) -> Result<OAuthRe
          &state={state}\
          &response_type=code\
          &prompt=consent",
-        urlencoding::encode(SCOPES),
+        urlencoding::encode(scopes),
     );
 
     eprintln!("Opening browser for authorization...");

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -199,11 +199,16 @@ pub async fn login_oauth(
         Some(OAUTH_APP_HINT),
     )?;
 
-    // Store OAuth app credentials in keychain
-    crate::api::auth::store_oauth_app_credentials(&client_id, &client_secret)?;
-
+    // Resolve config and scopes BEFORE persisting credentials — a bad
+    // [instance].oauth_scopes (empty/whitespace-only) must fail fast, not
+    // leave new client_id/client_secret in the keychain alongside a login
+    // that never succeeded.
     let mut config = Config::load().unwrap_or_default();
     let scopes = resolve_oauth_scopes(&config)?;
+
+    // Store OAuth app credentials in keychain (only after scopes validate)
+    crate::api::auth::store_oauth_app_credentials(&client_id, &client_secret)?;
+
     let result = crate::api::auth::oauth_login(&client_id, &client_secret, &scopes).await?;
 
     config.global.instance.url = Some(result.site_url);

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -586,4 +586,37 @@ mod tests {
             "unexpected error: {msg}"
         );
     }
+
+    /// The default scope literal is a backward-compatibility contract for
+    /// every user who hasn't opted into `oauth_scopes`. A typo that drops
+    /// `offline_access` would silently break refresh tokens for everyone.
+    #[test]
+    fn default_oauth_scopes_is_the_classic_set_with_offline_access() {
+        assert_eq!(
+            auth::DEFAULT_OAUTH_SCOPES,
+            "read:jira-work write:jira-work read:jira-user offline_access"
+        );
+    }
+
+    /// `jr` deliberately does NOT reject mixed classic+granular scopes,
+    /// unknown scope names, or missing `offline_access` — Atlassian returns
+    /// `invalid_scope` at token exchange per the spec's "Out of scope"
+    /// section. Locks this so a future refactor that starts "helping" with
+    /// client-side validation fails visibly.
+    #[test]
+    fn resolve_oauth_scopes_does_not_validate_scope_shape() {
+        let inputs = [
+            "read:jira-work read:issue:jira",           // classic + granular mix
+            "read:issue:jira write:issue:jira",         // no offline_access
+            "totally-made-up-scope another-fake-scope", // unknown scopes
+            "offline_access",                           // only offline_access
+        ];
+        for raw in inputs {
+            let config = config_with_oauth_scopes(Some(raw));
+            let result = resolve_oauth_scopes(&config).unwrap_or_else(|e| {
+                panic!("resolve_oauth_scopes must pass {raw:?} through unchanged, got error: {e:#}")
+            });
+            assert_eq!(result, raw, "input {raw:?} must pass through unchanged");
+        }
+    }
 }

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -113,6 +113,29 @@ fn chosen_flow(config: &Config, oauth_override: bool) -> AuthFlow {
     }
 }
 
+/// Pick the OAuth scope string: user override from `[instance].oauth_scopes`
+/// if set, else the compiled-in default. Trims and collapses interior
+/// whitespace so multi-line TOML strings encode cleanly. Empty or
+/// whitespace-only overrides are a configuration error.
+fn resolve_oauth_scopes(config: &Config) -> Result<String> {
+    match config.global.instance.oauth_scopes.as_deref() {
+        None => Ok(auth::DEFAULT_OAUTH_SCOPES.to_string()),
+        Some(raw) => {
+            let collapsed: String = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+            if collapsed.is_empty() {
+                Err(JrError::ConfigError(
+                    "oauth_scopes is empty; remove the setting to use defaults \
+                     or list at least one scope"
+                        .into(),
+                )
+                .into())
+            } else {
+                Ok(collapsed)
+            }
+        }
+    }
+}
+
 /// Resolve email and API token (flag → env → prompt), then store in keychain.
 pub async fn login_token(
     email: Option<String>,
@@ -179,9 +202,10 @@ pub async fn login_oauth(
     // Store OAuth app credentials in keychain
     crate::api::auth::store_oauth_app_credentials(&client_id, &client_secret)?;
 
-    let result = crate::api::auth::oauth_login(&client_id, &client_secret).await?;
-
     let mut config = Config::load().unwrap_or_default();
+    let scopes = resolve_oauth_scopes(&config)?;
+    let result = crate::api::auth::oauth_login(&client_id, &client_secret, &scopes).await?;
+
     config.global.instance.url = Some(result.site_url);
     config.global.instance.cloud_id = Some(result.cloud_id);
     config.global.instance.auth_method = Some("oauth".into());
@@ -505,6 +529,61 @@ mod tests {
         assert!(
             msg.contains("developer.atlassian.com/console/myapps"),
             "OAuth error should cite dev console URL: {msg}"
+        );
+    }
+
+    fn config_with_oauth_scopes(scopes: Option<&str>) -> Config {
+        Config {
+            global: GlobalConfig {
+                instance: InstanceConfig {
+                    oauth_scopes: scopes.map(String::from),
+                    ..InstanceConfig::default()
+                },
+                ..GlobalConfig::default()
+            },
+            project: Default::default(),
+        }
+    }
+
+    #[test]
+    fn resolve_oauth_scopes_none_returns_default() {
+        let config = config_with_oauth_scopes(None);
+        assert_eq!(
+            resolve_oauth_scopes(&config).unwrap(),
+            auth::DEFAULT_OAUTH_SCOPES
+        );
+    }
+
+    #[test]
+    fn resolve_oauth_scopes_trims_and_collapses_whitespace() {
+        let config = config_with_oauth_scopes(Some(
+            "  read:issue:jira   write:comment:jira\n\toffline_access  ",
+        ));
+        assert_eq!(
+            resolve_oauth_scopes(&config).unwrap(),
+            "read:issue:jira write:comment:jira offline_access"
+        );
+    }
+
+    #[test]
+    fn resolve_oauth_scopes_empty_string_is_config_error() {
+        let config = config_with_oauth_scopes(Some(""));
+        let err = resolve_oauth_scopes(&config).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("oauth_scopes is empty"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_oauth_scopes_whitespace_only_is_config_error() {
+        let config = config_with_oauth_scopes(Some("   \n\t  "));
+        let err = resolve_oauth_scopes(&config).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("oauth_scopes is empty"),
+            "unexpected error: {msg}"
         );
     }
 }

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -306,9 +306,8 @@ mod tests {
             global: GlobalConfig {
                 instance: InstanceConfig {
                     url: Some("https://example.atlassian.net".into()),
-                    cloud_id: None,
-                    org_id: None,
                     auth_method: method.map(str::to_string),
+                    ..InstanceConfig::default()
                 },
                 ..Default::default()
             },

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -28,9 +28,7 @@ pub async fn handle() -> Result<()> {
     let global = GlobalConfig {
         instance: InstanceConfig {
             url: Some(url.clone()),
-            cloud_id: None,
-            org_id: None,
-            auth_method: None,
+            ..InstanceConfig::default()
         },
         defaults: DefaultsConfig::default(),
         fields: FieldsConfig::default(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -185,7 +185,9 @@ pub enum AssetsCommand {
 pub enum AuthCommand {
     /// Authenticate with Jira
     Login {
-        /// Use OAuth 2.0 instead of API token (requires your own OAuth app)
+        /// Use OAuth 2.0 instead of API token (requires your own OAuth app).
+        /// Scope list is Atlassian's recommended classic set by default;
+        /// override via `[instance].oauth_scopes` in config.toml.
         #[arg(long)]
         oauth: bool,
         /// Jira email (API token flow). Prefer $JR_EMAIL over this flag.

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ pub struct InstanceConfig {
     pub cloud_id: Option<String>,
     pub org_id: Option<String>,
     pub auth_method: Option<String>,
+    pub oauth_scopes: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -184,9 +185,8 @@ mod tests {
             global: GlobalConfig {
                 instance: InstanceConfig {
                     url: Some("https://myorg.atlassian.net".into()),
-                    cloud_id: None,
-                    org_id: None,
                     auth_method: Some("api_token".into()),
+                    ..InstanceConfig::default()
                 },
                 defaults: DefaultsConfig::default(),
                 ..Default::default()
@@ -204,8 +204,8 @@ mod tests {
                 instance: InstanceConfig {
                     url: Some("https://myorg.atlassian.net".into()),
                     cloud_id: Some("abc-123".into()),
-                    org_id: None,
                     auth_method: Some("oauth".into()),
+                    ..InstanceConfig::default()
                 },
                 defaults: DefaultsConfig::default(),
                 ..Default::default()
@@ -276,9 +276,8 @@ mod tests {
             global: GlobalConfig {
                 instance: InstanceConfig {
                     url: Some("https://myorg.atlassian.net/".into()),
-                    cloud_id: None,
-                    org_id: None,
                     auth_method: Some("api_token".into()),
+                    ..InstanceConfig::default()
                 },
                 defaults: DefaultsConfig::default(),
                 ..Default::default()
@@ -297,9 +296,8 @@ mod tests {
             global: GlobalConfig {
                 instance: InstanceConfig {
                     url: Some("https://test.atlassian.net".into()),
-                    cloud_id: None,
-                    org_id: None,
                     auth_method: Some("api_token".into()),
+                    ..InstanceConfig::default()
                 },
                 defaults: DefaultsConfig::default(),
                 ..Default::default()
@@ -322,5 +320,35 @@ mod tests {
             Some("https://test.atlassian.net")
         );
         assert_eq!(loaded.instance.auth_method.as_deref(), Some("api_token"));
+    }
+
+    #[test]
+    fn instance_config_parses_oauth_scopes_from_toml() {
+        let toml = r#"
+            [instance]
+            url = "https://example.atlassian.net"
+            auth_method = "oauth"
+            oauth_scopes = "read:issue:jira write:issue:jira offline_access"
+        "#;
+
+        let config: GlobalConfig = Figment::new().merge(Toml::string(toml)).extract().unwrap();
+
+        assert_eq!(
+            config.instance.oauth_scopes.as_deref(),
+            Some("read:issue:jira write:issue:jira offline_access")
+        );
+    }
+
+    #[test]
+    fn instance_config_oauth_scopes_missing_is_none() {
+        let toml = r#"
+            [instance]
+            url = "https://example.atlassian.net"
+            auth_method = "oauth"
+        "#;
+
+        let config: GlobalConfig = Figment::new().merge(Toml::string(toml)).extract().unwrap();
+
+        assert!(config.instance.oauth_scopes.is_none());
     }
 }


### PR DESCRIPTION
## Summary

Makes OAuth 2.0 scopes configurable via `[instance].oauth_scopes` in `config.toml`, falling back to the existing hardcoded classic scope set when unset. Unlocks granular / least-privilege OAuth apps for LLM and agent use cases (Atlassian Developer Console apps configured with scopes like `write:issue:jira` instead of the broader `write:jira-work`).

Zero behavior change for users who don't set the new key.

## Scope-model constraints (validated with Perplexity against Atlassian's developer docs)

- Classic scopes remain Atlassian-recommended for Jira Platform apps; granular is for cases "when you can't use classic scopes." Jira Software is the exception (granular-only).
- Classic and granular scopes **cannot mix** in one `/authorize` request — the scope list must match what the Developer Console app has configured.
- `offline_access` is required in both modes for a refresh token to be issued.

## Key design decisions

- Pure passthrough — no client-side scope-mix detection. Atlassian returns `invalid_scope` at token exchange if the user's config is wrong; maintaining a client-side allowlist of valid scope combinations would be brittle as Atlassian revises the list.
- `refresh_oauth_token` is unchanged — the `refresh_token` grant inherits scopes from the original authorization per RFC 6749 §6. Users must re-run `jr auth login --oauth` for changed scopes to take effect (documented on the function).
- Env-var override (`JR_INSTANCE_OAUTH_SCOPES`) is out of scope for this PR — figment's default `Env::prefixed("JR_")` can't reach nested struct fields, and the separator fix (`.split("_")` or `.split("__")`) is orthogonal scope. Follow-up issue to track proper nested-env support.

## Changes

- `src/config.rs`: add `InstanceConfig.oauth_scopes: Option<String>` + 2 TOML-parsing unit tests
- `src/api/auth.rs`: rename `const SCOPES` → `pub const DEFAULT_OAUTH_SCOPES`; add `scopes: &str` parameter to `oauth_login`; document scope-inheritance on `refresh_oauth_token`
- `src/cli/auth.rs`: module-private `resolve_oauth_scopes(&Config) -> Result<String>` (None → default, valid → trimmed + whitespace-collapsed, empty / whitespace-only → `ConfigError` exit 78); `login_oauth` threads it into `oauth_login`; 6 unit tests including a content pin on `DEFAULT_OAUTH_SCOPES` and a passthrough lock-in covering classic+granular mix / missing `offline_access` / unknown scopes
- `README.md`: document the new key with the three constraints users need to know
- `docs/specs/oauth-scopes-configurable.md` + `docs/superpowers/plans/2026-04-22-oauth-scopes-configurable.md`: spec + TDD plan

## Deferred to follow-up issues

- #255 — OAuth `state` parameter uses wall-clock nanoseconds instead of CSPRNG (pre-existing, not introduced by this PR)
- #256 — `client_id` / `redirect_uri` / `state` not URL-encoded in authorize URL; only `scope` is (defense-in-depth)

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — full suite passes; 8 new unit tests (2 in `config.rs`, 6 in `cli/auth.rs`) all green
- [x] Local multi-agent review (code / security / architecture / test) — 2 rounds, all clean on round 2
- [ ] Copilot review iterate-until-clean

Closes #184.