### PR TITLE
fix: use CSPRNG for OAuth state parameter (#255)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,6 +1133,7 @@ dependencies = [
  "predicates",
  "proptest",
  "pulldown-cmark",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,9 +1586,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ toml = "1"
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 futures = { version = "0.3", default-features = false, features = ["async-await"] }
+rand = "0.9"
 urlencoding = "2"
 pulldown-cmark = { version = "0.13", default-features = false }
 

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -169,7 +169,7 @@ pub async fn oauth_login(
     drop(listener);
 
     let redirect_uri = format!("http://localhost:{port}/callback");
-    let state = generate_state();
+    let state = generate_state()?;
 
     let auth_url = format!(
         "https://auth.atlassian.com/authorize\
@@ -317,17 +317,26 @@ pub async fn refresh_oauth_token(client_id: &str, client_secret: &str) -> Result
 /// closing the attack window where an attacker with local access could
 /// observe the authorize URL and race the 127.0.0.1 callback listener
 /// with a forged code.
-fn generate_state() -> String {
+///
+/// Returns `Err` when the OS CSPRNG is unavailable — a rare but non-
+/// panicking failure mode (sandboxed environments without `/dev/urandom`,
+/// early-boot situations, or OS-level seccomp denials). The caller
+/// bubbles this up through `oauth_login` so `jr auth login` fails with
+/// an actionable error rather than aborting the process (the release
+/// profile uses `panic = "abort"`).
+fn generate_state() -> Result<String> {
     use rand::TryRngCore;
     let mut bytes = [0u8; 32];
-    rand::rngs::OsRng
-        .try_fill_bytes(&mut bytes)
-        .expect("OS CSPRNG should always succeed for 32-byte reads");
-    bytes.iter().fold(String::with_capacity(64), |mut s, b| {
+    rand::rngs::OsRng.try_fill_bytes(&mut bytes).context(
+        "Failed to read from OS CSPRNG when generating OAuth state. \
+         Check OS entropy availability or sandbox/seccomp restrictions \
+         that may block getrandom(2) / BCryptGenRandom.",
+    )?;
+    Ok(bytes.iter().fold(String::with_capacity(64), |mut s, b| {
         use std::fmt::Write;
         let _ = write!(s, "{b:02x}");
         s
-    })
+    }))
 }
 
 /// Extract a query parameter value from a raw HTTP request string.
@@ -380,7 +389,7 @@ mod tests {
 
     #[test]
     fn test_generate_state_is_hex() {
-        let state = generate_state();
+        let state = generate_state().expect("OS CSPRNG available in tests");
         assert!(!state.is_empty());
         assert!(state.chars().all(|c| c.is_ascii_hexdigit()));
     }
@@ -391,7 +400,7 @@ mod tests {
     /// the is_hex check.
     #[test]
     fn test_generate_state_is_64_hex_chars() {
-        let state = generate_state();
+        let state = generate_state().expect("OS CSPRNG available in tests");
         assert_eq!(
             state.len(),
             64,
@@ -399,20 +408,22 @@ mod tests {
         );
     }
 
-    /// Sanity check that `generate_state` is not obviously deterministic:
-    /// generate 8 values and assert at least 7 are distinct. A deterministic
-    /// or low-entropy regression (e.g., a reintroduction of `as_nanos`-style
-    /// state, or a constant) will collapse all 8 outputs to the same value
-    /// and trip this check. With 256 bits of true entropy the probability of
-    /// any collision across 8 samples is ~2^-253 (birthday bound, C(8,2) /
-    /// 2^256), so the test is not a CI flake risk.
+    /// `generate_state` must produce 8 distinct values across 8 calls. A
+    /// deterministic or low-entropy regression (reintroduced `as_nanos`
+    /// state, a constant, etc.) collapses outputs and trips this check.
+    /// With 256 bits of true entropy the birthday-bound collision
+    /// probability across 8 samples is C(8,2) / 2^256 ≈ 2^-253, so
+    /// requiring all 8 to be distinct is rigorously not a flake source.
     #[test]
     fn test_generate_state_is_not_deterministic() {
-        let samples: std::collections::HashSet<String> = (0..8).map(|_| generate_state()).collect();
-        assert!(
-            samples.len() >= 7,
-            "expected >=7 distinct values from 8 generate_state() calls, \
-             got {} distinct out of 8: {samples:?}",
+        let samples: std::collections::HashSet<String> = (0..8)
+            .map(|_| generate_state().expect("OS CSPRNG available in tests"))
+            .collect();
+        assert_eq!(
+            samples.len(),
+            8,
+            "expected 8 distinct values from 8 generate_state() calls, \
+             got {} distinct: {samples:?}",
             samples.len()
         );
     }

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -308,16 +308,21 @@ pub async fn refresh_oauth_token(client_id: &str, client_secret: &str) -> Result
 /// Generate a cryptographically random state parameter for CSRF protection
 /// of the OAuth 2.0 authorization-code flow (RFC 6749 §10.12).
 ///
-/// 32 random bytes from the OS CSPRNG (via `rand` 0.9 — which delegates to
-/// `getrandom` on the target platform) rendered as 64 hex characters. 256
-/// bits of entropy far exceeds the ~30 bits offered by the previous
-/// wall-clock-nanosecond implementation, closing the attack window where
-/// an attacker with local access could observe the authorize URL and race
-/// the 127.0.0.1 callback listener with a forged code.
+/// 32 random bytes read directly from the operating system CSPRNG via
+/// `rand::rngs::OsRng` (which is a thin wrapper over the `getrandom` crate
+/// and calls `getrandom(2)` / `BCryptGenRandom` on each invocation — no
+/// user-space reseeding state, unlike `rand::rng()` / `ThreadRng`).
+/// Rendered as 64 hex characters. 256 bits of entropy far exceeds the
+/// ~30 bits offered by the previous wall-clock-nanosecond implementation,
+/// closing the attack window where an attacker with local access could
+/// observe the authorize URL and race the 127.0.0.1 callback listener
+/// with a forged code.
 fn generate_state() -> String {
-    use rand::RngCore;
+    use rand::TryRngCore;
     let mut bytes = [0u8; 32];
-    rand::rng().fill_bytes(&mut bytes);
+    rand::rngs::OsRng
+        .try_fill_bytes(&mut bytes)
+        .expect("OS CSPRNG should always succeed for 32-byte reads");
     bytes.iter().fold(String::with_capacity(64), |mut s, b| {
         use std::fmt::Write;
         let _ = write!(s, "{b:02x}");
@@ -394,14 +399,21 @@ mod tests {
         );
     }
 
-    /// Two calls must produce different values. With 256 bits of entropy
-    /// the collision probability is cryptographically negligible (~2^-128
-    /// per pair), so a collision here means the CSPRNG source is broken or
-    /// the function fell back to something deterministic.
+    /// Sanity check that `generate_state` is not obviously deterministic:
+    /// generate 8 values and assert at least 7 are distinct. A deterministic
+    /// or low-entropy regression (e.g., a reintroduction of `as_nanos`-style
+    /// state, or a constant) will collapse all 8 outputs to the same value
+    /// and trip this check. With 256 bits of true entropy the probability of
+    /// any collision across 8 samples is ~2^-253 (birthday bound, C(8,2) /
+    /// 2^256), so the test is not a CI flake risk.
     #[test]
-    fn test_generate_state_is_unpredictable() {
-        let a = generate_state();
-        let b = generate_state();
-        assert_ne!(a, b, "two consecutive calls returned identical state: {a}");
+    fn test_generate_state_is_not_deterministic() {
+        let samples: std::collections::HashSet<String> = (0..8).map(|_| generate_state()).collect();
+        assert!(
+            samples.len() >= 7,
+            "expected >=7 distinct values from 8 generate_state() calls, \
+             got {} distinct out of 8: {samples:?}",
+            samples.len()
+        );
     }
 }

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -305,11 +305,24 @@ pub async fn refresh_oauth_token(client_id: &str, client_secret: &str) -> Result
     Ok(tokens.access_token)
 }
 
-/// Generate a unique state parameter for CSRF protection.
+/// Generate a cryptographically random state parameter for CSRF protection
+/// of the OAuth 2.0 authorization-code flow (RFC 6749 §10.12).
+///
+/// 32 random bytes from the OS CSPRNG (via `rand` 0.9 — which delegates to
+/// `getrandom` on the target platform) rendered as 64 hex characters. 256
+/// bits of entropy far exceeds the ~30 bits offered by the previous
+/// wall-clock-nanosecond implementation, closing the attack window where
+/// an attacker with local access could observe the authorize URL and race
+/// the 127.0.0.1 callback listener with a forged code.
 fn generate_state() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let t = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-    format!("{:x}", t.as_nanos())
+    use rand::RngCore;
+    let mut bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut bytes);
+    bytes.iter().fold(String::with_capacity(64), |mut s, b| {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+        s
+    })
 }
 
 /// Extract a query parameter value from a raw HTTP request string.
@@ -365,5 +378,30 @@ mod tests {
         let state = generate_state();
         assert!(!state.is_empty());
         assert!(state.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    /// 256-bit CSPRNG output rendered as hex must always be 64 characters.
+    /// Pinning the length guards against a regression to any lower-entropy
+    /// source (e.g., timestamp-hex, truncated UUIDs) that would still pass
+    /// the is_hex check.
+    #[test]
+    fn test_generate_state_is_64_hex_chars() {
+        let state = generate_state();
+        assert_eq!(
+            state.len(),
+            64,
+            "expected 32 bytes = 64 hex chars, got: {state}"
+        );
+    }
+
+    /// Two calls must produce different values. With 256 bits of entropy
+    /// the collision probability is cryptographically negligible (~2^-128
+    /// per pair), so a collision here means the CSPRNG source is broken or
+    /// the function fell back to something deterministic.
+    #[test]
+    fn test_generate_state_is_unpredictable() {
+        let a = generate_state();
+        let b = generate_state();
+        assert_ne!(a, b, "two consecutive calls returned identical state: {a}");
     }
 }


### PR DESCRIPTION
## Summary

Replaces the wall-clock-nanosecond `generate_state()` in `src/api/auth.rs` with 32 random bytes from the OS CSPRNG (via `rand 0.9`), hex-encoded to 64 characters.

## Why

RFC 6749 §10.12 and §10.14 require the OAuth 2.0 state parameter to be cryptographically random. The previous implementation was a monotonically-growing hex timestamp with ~30 bits of observable entropy (nanoseconds within a narrow attacker window). An attacker with local access who could observe the authorize URL (process listing, `/proc/*/cmdline`, or the `open::that` shell invocation) could race the `127.0.0.1` callback listener with a forged code.

256 bits of entropy closes that window.

Surfaced as a suggestion during the security review of PR #257 (merged). Filed as #255 and picked up as the immediate follow-up.

## Changes

- `src/api/auth.rs`: `generate_state()` rewritten using `rand::rng().fill_bytes()` + a small in-place hex encoder. Doc comment expanded with the threat model and the entropy upgrade rationale.
- `Cargo.toml`: `rand = "0.9"` added as a direct dep. It was already transitively present via proptest (dev-dep), so this is zero graph impact — just makes the import declared.
- Two new tests: `test_generate_state_is_64_hex_chars` (regression guard against lower-entropy sources that would pass the existing is_hex check), `test_generate_state_is_unpredictable` (two calls must differ — collision probability is ~2⁻¹²⁸, so failure means the CSPRNG is broken).

No API surface change — `generate_state` is module-private.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — full suite passes; 3 tests on `generate_state` (existing + 2 new) all green
- [x] Local review (security + code) — clean on round 1
- [ ] Copilot review

Closes #255.