### PR TITLE
docs: document --internal flag for JSM comment visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,11 @@ jr issue move KEY-123 "In Progress"
 # Log time
 jr worklog add KEY-123 2h -m "Fixed the auth bug"
 
-# Add a comment
+# Add a comment (public reply by default)
 jr issue comment KEY-123 "Deployed to staging"
+
+# Add an internal-only comment on a JSM issue (agents see it, customers don't)
+jr issue comment JSM-42 "customer is on the paid plan — prioritizing" --internal
 ```
 
 ## Commands
@@ -157,8 +160,8 @@ jr issue comment KEY-123 "Deployed to staging"
 | `jr issue move KEY [STATUS]` | Transition issue (partial match on status name) |
 | `jr issue transitions KEY` | List available transitions |
 | `jr issue assign KEY` | Assign to self (or `--to USER`, `--unassign`) |
-| `jr issue comment KEY "msg"` | Add a comment (`--stdin`, `--file`, `--markdown`) |
-| `jr issue comments KEY` | List comments (`--limit N`) |
+| `jr issue comment KEY "msg"` | Add a comment (`--stdin`, `--file`, `--markdown`, `--internal` for JSM agent-only notes) |
+| `jr issue comments KEY` | List comments (`--limit N`; JSM issues show a Visibility column: External / Internal) |
 | `jr issue open KEY` | Open in browser (`--url-only` for scripts) |
 | `jr issue link KEY1 KEY2` | Link two issues (`--type blocks`, defaults to Relates) |
 | `jr issue unlink KEY1 KEY2` | Remove link(s) between issues (`--type` to filter) |

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -414,7 +414,9 @@ pub enum IssueCommand {
         /// Read comment from stdin (for piping)
         #[arg(long)]
         stdin: bool,
-        /// Mark comment as internal (agent-only, not visible to customers on JSM projects)
+        /// Mark comment as internal — agent-only, not visible to the customer on the JSM
+        /// portal. Without this flag the comment is a public reply (the default). No-op on
+        /// standard (non-JSM) projects, where Jira ignores the `sd.public.comment` property.
         #[arg(long)]
         internal: bool,
     },


### PR DESCRIPTION
## Summary

Docs-only follow-up after finding that #259 (a feature request for JSM comment visibility) was already satisfied by #170 — merged 2026-04-06, closed #103. The `--internal` flag on `jr issue comment` and the Visibility column on `jr issue comments` both already work; they just weren't discoverable from the README or from `jr issue comment --help`.

#259 was closed as a duplicate. This PR makes sure users can actually find the feature without re-opening it.

## Changes

- **README quickstart:** second comment example shows `--internal` on a JSM issue, with a clarifying comment that the default is a public reply.
- **README command table:**
  - `jr issue comment` row now lists `--internal` (agent-only for JSM).
  - `jr issue comments` row mentions the Visibility column (External / Internal) that renders on JSM issues.
- **`src/cli/mod.rs`:** rewrote the clap doc comment on `--internal` to spell out (a) the default (public reply), and (b) that the flag is a no-op on standard (non-JSM) projects where Jira ignores `sd.public.comment`.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — full suite passes (510 unit tests, 0 behavioral change)
- [x] Verified the updated `--help` output via `./target/debug/jr issue comment --help`
- [x] Local code-reviewer pass — clean
- [ ] Copilot review