### PR TITLE
fix(issue): issue create --output json returns full Issue shape (#253)

### DIFF
--- a/docs/specs/issue-create-json-full-shape.md
+++ b/docs/specs/issue-create-json-full-shape.md
@@ -1,0 +1,92 @@
+# `jr issue create --output json` — return full issue shape
+
+**Issue:** [#253](https://github.com/Zious11/jira-cli/issues/253)
+
+## Problem
+
+`jr issue create --output json` returns a minimal body with only `key` and `url`. `jr issue view --output json` on the same key returns a full `Issue` payload with `fields` (summary, status, assignee, labels, parent, description, story points, team, CMDB fields). Scripts that pipe `create` output into `jq '.fields.summary'` silently get empty strings.
+
+The user-reported impact: "empty summary appeared in a status report we generated."
+
+## Root cause
+
+Validated against Atlassian REST API v3 docs (Perplexity + `developer.atlassian.com/cloud/jira/platform/rest/v3`):
+
+- `POST /rest/api/3/issue` returns only `{id, key, self}` — the full issue is **not** included in the POST response.
+- There is **no `expand` or `fields` query parameter** on POST. The only way to get the full shape is a follow-up `GET /rest/api/3/issue/{key}`.
+
+`src/cli/issue/create.rs:138-156` currently serializes only `CreateIssueResponse { key }` and tacks on `url`. It does not follow up with a GET.
+
+## Design
+
+After a successful POST, perform a follow-up GET that mirrors `handle_view`'s behaviour, then merge `url` into the resulting JSON and print.
+
+### User-visible change
+
+Before (create):
+```json
+{ "key": "PROJ-123", "url": "https://…/browse/PROJ-123" }
+```
+
+After (create):
+```json
+{
+  "id": "…", "key": "PROJ-123", "self": "…/rest/api/3/issue/…",
+  "fields": { "summary": "…", "status": {…}, "assignee": {…}, … },
+  "url": "https://…/browse/PROJ-123"
+}
+```
+
+### Which extra fields to fetch
+
+The follow-up GET uses the same `extra_fields` composition as `handle_view` (`src/cli/issue/list.rs:759-770`):
+- `config.global.fields.story_points_field_id`
+- `config.global.fields.team_field_id`
+- discovered CMDB fields (via cached `get_or_fetch_cmdb_fields`)
+
+### CMDB linked-asset enrichment
+
+**Out of scope.** `handle_view` also enriches linked CMDB assets via a batch lookup after the GET. For create, skip enrichment — the user just issued a create, the asset fields are rarely populated at creation time, and enrichment would double the latency of every `create` call. The raw CMDB field IDs in the response are enough for scripts that need them. If a future issue wants enriched assets on create, that's additive.
+
+### Degraded path: GET fails after POST succeeds
+
+The issue has already been created when the follow-up GET runs — we must **not** treat a GET failure as a create failure. Behaviour:
+
+- Emit a stderr warning: `[warn] issue created ({key}) but follow-up fetch failed: {err}`
+- Fall back to the old minimal shape: `{ "key": "...", "url": "..." }`
+- Exit 0 (the create succeeded; the user's automation still gets the key)
+
+### Table output
+
+Unchanged. Table already prints only `Created issue PROJ-123` + browse URL on stderr. No extra GET is performed on the table path (saves a round trip when the user is reading on a terminal).
+
+### Command: `edit`
+
+Out of scope. `edit` already has its own `edit_response` shape; this issue is specifically about `create`.
+
+## Testing
+
+All tests use wiremock (`JR_BASE_URL` override, existing pattern in `tests/`):
+
+1. **Happy path** — POST returns `{id, key, self}`, GET returns full `Issue`. Assert stdout JSON has `.fields.summary`, `.key`, `.url`, and `.fields.status.name`.
+2. **Degraded path** — POST returns 201, GET returns 500. Assert stdout JSON is the minimal `{key, url}` shape, stderr contains `[warn]`, exit code 0.
+3. **Table path** — POST returns 201, no GET is made (wiremock expectation: zero GET requests). Assert stdout/stderr match existing table output.
+
+Unit tests: none needed — the handler already has integration coverage; the change is purely orchestration.
+
+Snapshot: none — JSON output is already matched by integration tests, no insta snapshot change needed.
+
+## Files touched
+
+| Path | Change |
+|---|---|
+| `src/cli/issue/create.rs` | `handle_create` JSON branch: after POST, call `get_issue(&key, &extra)`, merge `url`, print. On GET failure, warn + fall back. |
+| `src/cli/issue/create.rs` or `helpers.rs` | Factor `extra_fields_for_view(config, cmdb_fields)` helper shared with `handle_view` (light refactor). |
+| `src/cli/issue/list.rs` | `handle_view` uses the new shared helper for extra_fields composition. |
+| `tests/issue_create_json.rs` | New file: 3 wiremock tests (happy, degraded, table-unchanged). |
+
+## Out of scope
+
+- Asset enrichment on create (future issue if needed).
+- `issue edit` JSON shape.
+- `expand=renderedFields` on the follow-up GET (not part of `handle_view` either; keep parity).

--- a/docs/specs/issue-create-json-full-shape.md
+++ b/docs/specs/issue-create-json-full-shape.md
@@ -52,7 +52,7 @@ The follow-up GET uses the same `extra_fields` composition as `handle_view` (`sr
 
 The issue has already been created when the follow-up GET runs — we must **not** treat a GET failure as a create failure. Behaviour:
 
-- Emit a stderr warning: `[warn] issue created ({key}) but follow-up fetch failed: {err}`
+- Emit a stderr warning: `warning: issue created ({key}) but follow-up fetch failed: {err}`
 - Fall back to the old minimal shape: `{ "key": "...", "url": "..." }`
 - Exit 0 (the create succeeded; the user's automation still gets the key)
 
@@ -69,7 +69,7 @@ Out of scope. `edit` already has its own `edit_response` shape; this issue is sp
 All tests use wiremock (`JR_BASE_URL` override, existing pattern in `tests/`):
 
 1. **Happy path** — POST returns `{id, key, self}`, GET returns full `Issue`. Assert stdout JSON has `.fields.summary`, `.key`, `.url`, and `.fields.status.name`.
-2. **Degraded path** — POST returns 201, GET returns 500. Assert stdout JSON is the minimal `{key, url}` shape, stderr contains `[warn]`, exit code 0.
+2. **Degraded path** — POST returns 201, GET returns 500. Assert stdout JSON is the minimal `{key, url}` shape, stderr contains `warning:`, exit code 0.
 3. **Table path** — POST returns 201, no GET is made (wiremock expectation: zero GET requests). Assert stdout/stderr match existing table output.
 
 Unit tests: none needed — the handler already has integration coverage; the change is purely orchestration.

--- a/docs/specs/issue-create-json-full-shape.md
+++ b/docs/specs/issue-create-json-full-shape.md
@@ -31,11 +31,29 @@ Before (create):
 After (create):
 ```json
 {
-  "id": "…", "key": "PROJ-123", "self": "…/rest/api/3/issue/…",
+  "key": "PROJ-123",
   "fields": { "summary": "…", "status": {…}, "assignee": {…}, … },
   "url": "https://…/browse/PROJ-123"
 }
 ```
+
+Shape matches `serde_json::to_value(&Issue { key, fields })` from
+`src/types/jira/issue.rs` — the `Issue` struct only carries `key` and
+`fields`, so `id` and `self` from the raw API response don't appear in
+the serialized output.
+
+If the follow-up GET fails, the fallback shape is:
+```json
+{
+  "key": "PROJ-123",
+  "url": "https://…/browse/PROJ-123",
+  "fetch_error": "…error message…"
+}
+```
+
+The top-level `fetch_error` string is a machine-readable sentinel so
+scripts piping through `jq` can distinguish a degraded fallback from
+success without parsing stderr.
 
 ### Which extra fields to fetch
 

--- a/docs/superpowers/plans/2026-04-23-issue-create-json-full-shape.md
+++ b/docs/superpowers/plans/2026-04-23-issue-create-json-full-shape.md
@@ -262,7 +262,7 @@ match output_format {
             }
             Err(err) => {
                 eprintln!(
-                    "[warn] issue created ({}) but follow-up fetch failed: {err}",
+                    "warning: issue created ({}) but follow-up fetch failed: {err}",
                     response.key
                 );
                 let mut json_response = serde_json::to_value(&response)?;
@@ -361,7 +361,7 @@ async fn issue_create_json_degrades_when_follow_up_get_fails() {
     assert!(parsed["url"].as_str().unwrap().ends_with("/browse/PROJ-124"));
     assert!(parsed.get("fields").is_none(), "fallback shape must not include fields");
 
-    assert!(stderr.contains("[warn]"), "expected warning on stderr, got: {stderr}");
+    assert!(stderr.contains("warning:"), "expected warning on stderr, got: {stderr}");
     assert!(stderr.contains("PROJ-124"), "warning should mention key");
 }
 ```

--- a/docs/superpowers/plans/2026-04-23-issue-create-json-full-shape.md
+++ b/docs/superpowers/plans/2026-04-23-issue-create-json-full-shape.md
@@ -1,0 +1,483 @@
+# `jr issue create --output json` full-shape Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `jr issue create --output json` return the same full `Issue` payload as `jr issue view --output json`, plus `url`. On follow-up GET failure, degrade gracefully to `{key, url}` with a stderr warning.
+
+**Architecture:** After successful POST, call `get_issue(&key, &extra)` using the same `extra_fields` composition as `handle_view`. Extract the composition into a shared helper. Table output path is unchanged (no extra GET).
+
+**Tech Stack:** reqwest (existing `JiraClient`), serde_json, wiremock for integration tests.
+
+**Spec:** `docs/specs/issue-create-json-full-shape.md`
+
+**Known collision check:** `handle_view` already does this composition at `src/cli/issue/list.rs:759-770`. The helper must be reusable by both handlers without cyclic imports. Put the helper in `src/cli/issue/helpers.rs` alongside the existing team/points/user resolvers.
+
+---
+
+## Task 1: Extract shared `extra_fields_for_issue` helper
+
+**Files:**
+- Modify: `src/cli/issue/helpers.rs` — add `pub(super) async fn extra_fields_for_issue(client: &JiraClient, config: &Config) -> (Vec<String>, Vec<(String,String)>)`. Returns owned `Vec<String>` (story-points + cmdb ids + team) AND the raw `cmdb_fields` `Vec<(id, name)>` so the view path can still do per-field asset enrichment.
+- Modify: `src/cli/issue/list.rs:759-770` — replace inline composition in `handle_view` with a call to the helper.
+- Test: `src/cli/issue/helpers.rs` — inline `#[cfg(test)]` unit test exercising the composition with mocked inputs (no network — drive via a `Config` fixture and a stub cmdb list).
+
+**Rationale:** DRY — both `handle_view` (existing) and `handle_create` (new) need the exact same extra-fields list.
+
+- [ ] **Step 1: Write the failing unit test**
+
+File: `src/cli/issue/helpers.rs` (append to existing `#[cfg(test)] mod tests`):
+
+```rust
+#[test]
+fn extra_fields_for_issue_composes_sp_team_and_cmdb() {
+    use crate::config::{Config, Fields, GlobalConfig};
+
+    let mut config = Config::default();
+    config.global.fields.story_points_field_id = Some("customfield_10016".into());
+    config.global.fields.team_field_id = Some("customfield_10001".into());
+    let cmdb_fields = vec![
+        ("customfield_12345".to_string(), "Affected Services".to_string()),
+        ("customfield_67890".to_string(), "Deployed To".to_string()),
+    ];
+
+    let extra = compose_extra_fields(&config, &cmdb_fields);
+
+    assert!(extra.contains(&"customfield_10016".to_string()), "sp present");
+    assert!(extra.contains(&"customfield_10001".to_string()), "team present");
+    assert!(extra.contains(&"customfield_12345".to_string()), "cmdb 1 present");
+    assert!(extra.contains(&"customfield_67890".to_string()), "cmdb 2 present");
+    assert_eq!(extra.len(), 4);
+}
+
+#[test]
+fn extra_fields_for_issue_omits_unset_optionals() {
+    use crate::config::Config;
+
+    let config = Config::default();
+    let cmdb_fields: Vec<(String, String)> = vec![];
+
+    let extra = compose_extra_fields(&config, &cmdb_fields);
+    assert!(extra.is_empty());
+}
+```
+
+Run: `cargo test -p jr --lib issue::helpers::tests::extra_fields_for_issue -- --nocapture`
+Expected: FAIL — `compose_extra_fields` not yet defined.
+
+- [ ] **Step 2: Write minimal implementation**
+
+Add to `src/cli/issue/helpers.rs`:
+
+```rust
+/// Compose the `extra` fields list that both `handle_view` and `handle_create`
+/// pass to `JiraClient::get_issue`. Order is: story-points, cmdb ids, team.
+pub(super) fn compose_extra_fields(
+    config: &Config,
+    cmdb_fields: &[(String, String)],
+) -> Vec<String> {
+    let mut extra: Vec<String> = Vec::new();
+    if let Some(sp) = config.global.fields.story_points_field_id.as_deref() {
+        extra.push(sp.to_string());
+    }
+    for (id, _) in cmdb_fields {
+        extra.push(id.clone());
+    }
+    if let Some(t) = config.global.fields.team_field_id.as_deref() {
+        extra.push(t.to_string());
+    }
+    extra
+}
+```
+
+Add the import `use crate::config::Config;` at the top of the file if missing.
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `cargo test -p jr --lib issue::helpers::tests::extra_fields_for_issue -- --nocapture`
+Expected: PASS (2/2).
+
+- [ ] **Step 4: Replace inline composition in handle_view**
+
+Edit `src/cli/issue/list.rs` around lines 759–770. Old code:
+
+```rust
+let sp_field_id = config.global.fields.story_points_field_id.as_deref();
+let team_field_id: Option<&str> = config.global.fields.team_field_id.as_deref();
+let cmdb_fields = get_or_fetch_cmdb_fields(client).await.unwrap_or_default();
+let cmdb_field_id_list = cmdb_field_ids(&cmdb_fields);
+let mut extra: Vec<&str> = sp_field_id.iter().copied().collect();
+for f in &cmdb_field_id_list {
+    extra.push(f.as_str());
+}
+if let Some(t) = team_field_id {
+    extra.push(t);
+}
+let mut issue = client.get_issue(&key, &extra).await?;
+```
+
+New code:
+
+```rust
+let cmdb_fields = get_or_fetch_cmdb_fields(client).await.unwrap_or_default();
+let extra_owned = super::helpers::compose_extra_fields(config, &cmdb_fields);
+let extra: Vec<&str> = extra_owned.iter().map(String::as_str).collect();
+let mut issue = client.get_issue(&key, &extra).await?;
+```
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `cargo fmt --all -- --check && cargo clippy --all-targets -- -D warnings && cargo test`
+Expected: all green. handle_view tests/snapshots unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/issue/helpers.rs src/cli/issue/list.rs
+git commit -m "refactor(issue): extract compose_extra_fields helper"
+```
+
+---
+
+## Task 2: Integration test — happy path (full shape)
+
+**Files:**
+- Create: `tests/issue_create_json.rs` — new wiremock integration test file.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `tests/issue_create_json.rs`:
+
+```rust
+mod common;
+
+use assert_cmd::Command;
+use common::fixtures;
+use serde_json::Value;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn issue_create_json_returns_full_shape() {
+    let server = MockServer::start().await;
+
+    // POST returns minimal Atlassian shape: {id, key, self}
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": "10001",
+            "key": "PROJ-123",
+            "self": format!("{}/rest/api/3/issue/10001", server.uri()),
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Follow-up GET returns full issue
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/PROJ-123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "10001",
+            "key": "PROJ-123",
+            "self": format!("{}/rest/api/3/issue/10001", server.uri()),
+            "fields": {
+                "summary": "test summary",
+                "status": { "name": "To Do", "statusCategory": { "name": "To Do", "key": "new" } },
+                "issuetype": { "name": "Task" },
+                "project": { "key": "PROJ" }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // List fields (find_* helpers) — minimal stub
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/field"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Value::Array(vec![])))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_EMAIL", "test@example.com")
+        .env("JR_AUTH_TOKEN", "fake-token")
+        .env("JR_CACHE_DIR", fixtures::temp_cache_dir())
+        .env("JR_CONFIG_DIR", fixtures::temp_config_dir())
+        .args([
+            "issue", "create",
+            "--project", "PROJ",
+            "--issue-type", "Task",
+            "--summary", "test summary",
+            "--output", "json",
+            "--no-input",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "expected success: stderr={}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: Value = serde_json::from_str(&stdout).expect("valid JSON");
+
+    assert_eq!(parsed["key"], "PROJ-123");
+    assert!(parsed["url"].as_str().unwrap().ends_with("/browse/PROJ-123"));
+    assert_eq!(parsed["fields"]["summary"], "test summary");
+    assert_eq!(parsed["fields"]["status"]["name"], "To Do");
+}
+```
+
+**Note:** Before writing this, check `tests/common/fixtures.rs` for existing helpers (`temp_cache_dir`, `temp_config_dir`, env setup). If names differ, use the existing helpers — don't fabricate.
+
+Run: `cargo test --test issue_create_json issue_create_json_returns_full_shape -- --nocapture`
+Expected: FAIL — output has only `{key, url}`, missing `.fields`.
+
+- [ ] **Step 2: Implement JSON path in handle_create**
+
+Edit `src/cli/issue/create.rs` around lines 138–156:
+
+```rust
+let response = client.create_issue(fields).await?;
+
+let browse_url = format!(
+    "{}/browse/{}",
+    client.instance_url().trim_end_matches('/'),
+    response.key
+);
+
+match output_format {
+    OutputFormat::Json => {
+        let cmdb_fields = crate::cli::issue::assets::get_or_fetch_cmdb_fields(client)
+            .await
+            .unwrap_or_default();
+        let extra_owned = helpers::compose_extra_fields(config, &cmdb_fields);
+        let extra: Vec<&str> = extra_owned.iter().map(String::as_str).collect();
+
+        match client.get_issue(&response.key, &extra).await {
+            Ok(issue) => {
+                let mut issue_json = serde_json::to_value(&issue)?;
+                if let Some(obj) = issue_json.as_object_mut() {
+                    obj.insert("url".into(), serde_json::Value::String(browse_url.clone()));
+                }
+                println!("{}", serde_json::to_string_pretty(&issue_json)?);
+            }
+            Err(err) => {
+                eprintln!(
+                    "[warn] issue created ({}) but follow-up fetch failed: {err}",
+                    response.key
+                );
+                let mut json_response = serde_json::to_value(&response)?;
+                json_response["url"] = json!(browse_url);
+                println!("{}", serde_json::to_string_pretty(&json_response)?);
+            }
+        }
+    }
+    OutputFormat::Table => {
+        output::print_success(&format!("Created issue {}", response.key));
+        eprintln!("{}", browse_url);
+    }
+}
+```
+
+Adjust the `get_or_fetch_cmdb_fields` import path: it lives in `src/cli/issue/assets.rs`. Check the existing `use` block at the top of `create.rs` — may need to add the import.
+
+- [ ] **Step 3: Run the integration test**
+
+Run: `cargo test --test issue_create_json issue_create_json_returns_full_shape`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/cli/issue/create.rs tests/issue_create_json.rs
+git commit -m "feat(issue): issue create --output json returns full shape"
+```
+
+---
+
+## Task 3: Integration test — degraded path (GET fails after POST)
+
+**Files:**
+- Modify: `tests/issue_create_json.rs` — add second test.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/issue_create_json.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread")]
+async fn issue_create_json_degrades_when_follow_up_get_fails() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": "10001",
+            "key": "PROJ-124",
+            "self": format!("{}/rest/api/3/issue/10001", server.uri()),
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/PROJ-124"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/field"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Value::Array(vec![])))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_EMAIL", "test@example.com")
+        .env("JR_AUTH_TOKEN", "fake-token")
+        .env("JR_CACHE_DIR", fixtures::temp_cache_dir())
+        .env("JR_CONFIG_DIR", fixtures::temp_config_dir())
+        .args([
+            "issue", "create",
+            "--project", "PROJ",
+            "--issue-type", "Task",
+            "--summary", "degraded test",
+            "--output", "json",
+            "--no-input",
+        ])
+        .output()
+        .unwrap();
+
+    // Create succeeded even though follow-up GET failed → exit 0.
+    assert!(output.status.success(), "expected success (create did succeed): stderr={}", String::from_utf8_lossy(&output.stderr));
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("valid JSON on fallback");
+    assert_eq!(parsed["key"], "PROJ-124");
+    assert!(parsed["url"].as_str().unwrap().ends_with("/browse/PROJ-124"));
+    assert!(parsed.get("fields").is_none(), "fallback shape must not include fields");
+
+    assert!(stderr.contains("[warn]"), "expected warning on stderr, got: {stderr}");
+    assert!(stderr.contains("PROJ-124"), "warning should mention key");
+}
+```
+
+Run: `cargo test --test issue_create_json issue_create_json_degrades_when_follow_up_get_fails`
+Expected: PASS (the previous implementation already handles this via the `Err(err)` arm). If it fails, iterate the fallback code in Task 2 Step 2 until green.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add tests/issue_create_json.rs
+git commit -m "test(issue): cover follow-up GET failure on create --output json"
+```
+
+---
+
+## Task 4: Integration test — table output path unchanged (no extra GET)
+
+**Files:**
+- Modify: `tests/issue_create_json.rs` — add third test.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/issue_create_json.rs`:
+
+```rust
+#[tokio::test(flavor = "multi_thread")]
+async fn issue_create_table_does_not_trigger_follow_up_get() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": "10001",
+            "key": "PROJ-125",
+            "self": format!("{}/rest/api/3/issue/10001", server.uri()),
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // A GET on the issue MUST NOT be made on the table path.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/PROJ-125"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("should not be called"))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/field"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Value::Array(vec![])))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_EMAIL", "test@example.com")
+        .env("JR_AUTH_TOKEN", "fake-token")
+        .env("JR_CACHE_DIR", fixtures::temp_cache_dir())
+        .env("JR_CONFIG_DIR", fixtures::temp_config_dir())
+        .args([
+            "issue", "create",
+            "--project", "PROJ",
+            "--issue-type", "Task",
+            "--summary", "table test",
+            "--no-input",
+        ]) // no --output json → defaults to table
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Created issue PROJ-125"), "stdout: {stdout}");
+    // wiremock's .expect(0) will fail the test on drop if the GET was called.
+}
+```
+
+Run: `cargo test --test issue_create_json issue_create_table_does_not_trigger_follow_up_get`
+Expected: PASS.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add tests/issue_create_json.rs
+git commit -m "test(issue): verify table path does not trigger follow-up GET"
+```
+
+---
+
+## Task 5: Final checks + doc touch-up
+
+- [ ] **Step 1: Run the full CI-equivalent check set**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+Every check must pass.
+
+- [ ] **Step 2: Verify README / help text accuracy**
+
+`grep -n "create" README.md` to find any place documenting `issue create --output json` shape. If the README shows the old `{key, url}` output shape as an example, update it to the new full-shape example. If no such example exists, skip.
+
+`cargo run -- issue create --help` should still work (flag list is unchanged). Verify.
+
+- [ ] **Step 3: Commit any doc changes (only if README was updated)**
+
+```bash
+git add README.md
+git commit -m "docs: update issue create JSON example to full shape"
+```
+
+- [ ] **Step 4: Declare done**
+
+All 4 previous tasks complete + this final check = ready for local review pass.

--- a/src/cli/issue/create.rs
+++ b/src/cli/issue/create.rs
@@ -2,6 +2,7 @@ use anyhow::{Result, bail};
 use serde_json::json;
 
 use crate::adf;
+use crate::api::assets::linked::get_or_fetch_cmdb_fields;
 use crate::api::client::JiraClient;
 use crate::cli::{IssueCommand, OutputFormat};
 use crate::config::Config;
@@ -149,9 +150,7 @@ pub(super) async fn handle_create(
             // (full Issue shape), plus `url`. On GET failure we keep the create
             // succeeding — warn on stderr and fall back to the old `{key, url}`
             // shape so downstream consumers always get at least the key + URL.
-            let cmdb_fields = crate::api::assets::linked::get_or_fetch_cmdb_fields(client)
-                .await
-                .unwrap_or_default();
+            let cmdb_fields = get_or_fetch_cmdb_fields(client).await.unwrap_or_default();
             let extra_owned = helpers::compose_extra_fields(config, &cmdb_fields);
             let extra: Vec<&str> = extra_owned.iter().map(String::as_str).collect();
 
@@ -165,7 +164,7 @@ pub(super) async fn handle_create(
                 }
                 Err(err) => {
                     eprintln!(
-                        "[warn] issue created ({}) but follow-up fetch failed: {err}",
+                        "warning: issue created ({}) but follow-up fetch failed: {err}",
                         response.key
                     );
                     let mut json_response = serde_json::to_value(&response)?;

--- a/src/cli/issue/create.rs
+++ b/src/cli/issue/create.rs
@@ -145,9 +145,34 @@ pub(super) async fn handle_create(
 
     match output_format {
         OutputFormat::Json => {
-            let mut json_response = serde_json::to_value(&response)?;
-            json_response["url"] = json!(browse_url);
-            println!("{}", serde_json::to_string_pretty(&json_response)?);
+            // Follow-up GET so the JSON output matches `issue view --output json`
+            // (full Issue shape), plus `url`. On GET failure we keep the create
+            // succeeding — warn on stderr and fall back to the old `{key, url}`
+            // shape so downstream consumers always get at least the key + URL.
+            let cmdb_fields = crate::api::assets::linked::get_or_fetch_cmdb_fields(client)
+                .await
+                .unwrap_or_default();
+            let extra_owned = helpers::compose_extra_fields(config, &cmdb_fields);
+            let extra: Vec<&str> = extra_owned.iter().map(String::as_str).collect();
+
+            match client.get_issue(&response.key, &extra).await {
+                Ok(issue) => {
+                    let mut issue_json = serde_json::to_value(&issue)?;
+                    if let Some(obj) = issue_json.as_object_mut() {
+                        obj.insert("url".into(), serde_json::Value::String(browse_url.clone()));
+                    }
+                    println!("{}", serde_json::to_string_pretty(&issue_json)?);
+                }
+                Err(err) => {
+                    eprintln!(
+                        "[warn] issue created ({}) but follow-up fetch failed: {err}",
+                        response.key
+                    );
+                    let mut json_response = serde_json::to_value(&response)?;
+                    json_response["url"] = json!(browse_url);
+                    println!("{}", serde_json::to_string_pretty(&json_response)?);
+                }
+            }
         }
         OutputFormat::Table => {
             output::print_success(&format!("Created issue {}", response.key));

--- a/src/cli/issue/create.rs
+++ b/src/cli/issue/create.rs
@@ -150,6 +150,11 @@ pub(super) async fn handle_create(
             // (full Issue shape), plus `url`. On GET failure we keep the create
             // succeeding — warn on stderr and fall back to the old `{key, url}`
             // shape so downstream consumers always get at least the key + URL.
+            //
+            // Pre-existing pattern (same as handle_view, handle_list, project): a CMDB
+            // discovery error silently degrades to an empty field list. Tracked as a
+            // separate cleanup in the follow-up concerns documented on PR #253 — will
+            // be addressed codebase-wide, not per-call-site.
             let cmdb_fields = get_or_fetch_cmdb_fields(client).await.unwrap_or_default();
             let extra_owned = helpers::compose_extra_fields(config, &cmdb_fields);
             let extra: Vec<&str> = extra_owned.iter().map(String::as_str).collect();
@@ -163,12 +168,19 @@ pub(super) async fn handle_create(
                     println!("{}", serde_json::to_string_pretty(&issue_json)?);
                 }
                 Err(err) => {
+                    // Fallback JSON carries a top-level `fetch_error` string so
+                    // scripts using `jq '.fields.status.name'` can tell this
+                    // shape apart from success without parsing stderr. Recovery
+                    // hint points users at `jr issue view` for the full payload.
+                    let err_msg = format!("{err}");
                     eprintln!(
-                        "warning: issue created ({}) but follow-up fetch failed: {err}",
-                        response.key
+                        "warning: issue created ({}) but follow-up fetch failed: {err_msg}. \
+                         Run `jr issue view {} --output json` to retrieve the full payload.",
+                        response.key, response.key
                     );
                     let mut json_response = serde_json::to_value(&response)?;
                     json_response["url"] = json!(browse_url);
+                    json_response["fetch_error"] = json!(err_msg);
                     println!("{}", serde_json::to_string_pretty(&json_response)?);
                 }
             }

--- a/src/cli/issue/helpers.rs
+++ b/src/cli/issue/helpers.rs
@@ -179,6 +179,25 @@ pub(super) async fn resolve_team_field(
     }
 }
 
+/// Compose the `extra` fields list that both `handle_view` and `handle_create`
+/// pass to `JiraClient::get_issue`. Order: story-points, cmdb ids, team.
+pub(super) fn compose_extra_fields(
+    config: &Config,
+    cmdb_fields: &[(String, String)],
+) -> Vec<String> {
+    let mut extra: Vec<String> = Vec::new();
+    if let Some(sp) = config.global.fields.story_points_field_id.as_deref() {
+        extra.push(sp.to_string());
+    }
+    for (id, _) in cmdb_fields {
+        extra.push(id.clone());
+    }
+    if let Some(t) = config.global.fields.team_field_id.as_deref() {
+        extra.push(t.to_string());
+    }
+    extra
+}
+
 pub(super) fn resolve_story_points_field_id(config: &Config) -> Result<String> {
     Ok(config
         .global
@@ -735,5 +754,52 @@ mod tests {
         assert!(msg.contains("No match. Found:"));
         assert!(msg.contains("Alice"));
         assert!(msg.contains("Bob"));
+    }
+
+    // ── compose_extra_fields tests ────────────────────────────────────
+
+    #[test]
+    fn extra_fields_for_issue_composes_sp_team_and_cmdb() {
+        use crate::config::Config;
+
+        let mut config = Config::default();
+        config.global.fields.story_points_field_id = Some("customfield_10016".into());
+        config.global.fields.team_field_id = Some("customfield_10001".into());
+        let cmdb_fields = vec![
+            (
+                "customfield_12345".to_string(),
+                "Affected Services".to_string(),
+            ),
+            ("customfield_67890".to_string(), "Deployed To".to_string()),
+        ];
+
+        let extra = compose_extra_fields(&config, &cmdb_fields);
+
+        assert!(
+            extra.contains(&"customfield_10016".to_string()),
+            "sp present"
+        );
+        assert!(
+            extra.contains(&"customfield_10001".to_string()),
+            "team present"
+        );
+        assert!(
+            extra.contains(&"customfield_12345".to_string()),
+            "cmdb 1 present"
+        );
+        assert!(
+            extra.contains(&"customfield_67890".to_string()),
+            "cmdb 2 present"
+        );
+        assert_eq!(extra.len(), 4);
+    }
+
+    #[test]
+    fn extra_fields_for_issue_omits_unset_optionals() {
+        use crate::config::Config;
+        let config = Config::default();
+        let cmdb_fields: Vec<(String, String)> = vec![];
+        let extra = compose_extra_fields(&config, &cmdb_fields);
+        assert!(extra.is_empty());
     }
 }

--- a/src/cli/issue/helpers.rs
+++ b/src/cli/issue/helpers.rs
@@ -775,23 +775,20 @@ mod tests {
 
         let extra = compose_extra_fields(&config, &cmdb_fields);
 
-        assert!(
-            extra.contains(&"customfield_10016".to_string()),
-            "sp present"
+        // compose_extra_fields documents the order: story-points first, CMDB
+        // ids preserved in slice order, team last. Asserting the full vector
+        // (not just membership) pins that contract so a refactor that changes
+        // order — which could break downstream callers relying on it — trips
+        // this test instead of escaping into production.
+        assert_eq!(
+            extra,
+            vec![
+                "customfield_10016".to_string(), // SP first
+                "customfield_12345".to_string(), // CMDB preserved in slice order
+                "customfield_67890".to_string(), // CMDB preserved in slice order
+                "customfield_10001".to_string(), // team last
+            ],
         );
-        assert!(
-            extra.contains(&"customfield_10001".to_string()),
-            "team present"
-        );
-        assert!(
-            extra.contains(&"customfield_12345".to_string()),
-            "cmdb 1 present"
-        );
-        assert!(
-            extra.contains(&"customfield_67890".to_string()),
-            "cmdb 2 present"
-        );
-        assert_eq!(extra.len(), 4);
     }
 
     #[test]

--- a/src/cli/issue/list.rs
+++ b/src/cli/issue/list.rs
@@ -759,14 +759,8 @@ pub(super) async fn handle_view(
     let sp_field_id = config.global.fields.story_points_field_id.as_deref();
     let team_field_id: Option<&str> = config.global.fields.team_field_id.as_deref();
     let cmdb_fields = get_or_fetch_cmdb_fields(client).await.unwrap_or_default();
-    let cmdb_field_id_list = cmdb_field_ids(&cmdb_fields);
-    let mut extra: Vec<&str> = sp_field_id.iter().copied().collect();
-    for f in &cmdb_field_id_list {
-        extra.push(f.as_str());
-    }
-    if let Some(t) = team_field_id {
-        extra.push(t);
-    }
+    let extra_owned = super::helpers::compose_extra_fields(config, &cmdb_fields);
+    let extra: Vec<&str> = extra_owned.iter().map(String::as_str).collect();
     let mut issue = client.get_issue(&key, &extra).await?;
 
     // Extract and enrich assets per-field (shared by both JSON and table paths).

--- a/tests/issue_create_json.rs
+++ b/tests/issue_create_json.rs
@@ -113,6 +113,11 @@ async fn issue_create_json_returns_full_shape() {
     );
     assert_eq!(parsed["fields"]["issuetype"]["name"], "Task");
     assert_eq!(parsed["fields"]["project"]["key"], "PROJ");
+
+    assert!(
+        !stderr.to_lowercase().contains("warning") && !stderr.to_lowercase().contains("error"),
+        "expected clean stderr on happy path, got: {stderr}"
+    );
 }
 
 /// If the follow-up GET fails, the handler warns on stderr and falls back to

--- a/tests/issue_create_json.rs
+++ b/tests/issue_create_json.rs
@@ -1,0 +1,201 @@
+//! Integration tests for `jr issue create --output json` — issue #253.
+//!
+//! The JSON output of `issue create` must return the same full Issue payload
+//! shape as `issue view --output json`, plus a top-level `url` field. After a
+//! successful POST /rest/api/3/issue, the handler does a follow-up GET
+//! /rest/api/3/issue/{key} and merges `url` into the result. On GET failure it
+//! warns on stderr and falls back to the old `{key, url}` shape (exit 0).
+
+#[allow(dead_code)]
+mod common;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn issue_create_json_returns_full_shape() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    // POST /rest/api/3/issue — minimal Atlassian create response.
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": "10001",
+            "key": "PROJ-123",
+            "self": format!("{}/rest/api/3/issue/10001", server.uri()),
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // GET /rest/api/3/issue/PROJ-123 — full issue payload the handler fetches
+    // after a successful create.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/PROJ-123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "10001",
+            "key": "PROJ-123",
+            "self": format!("{}/rest/api/3/issue/10001", server.uri()),
+            "fields": {
+                "summary": "test summary",
+                "status": {
+                    "name": "To Do",
+                    "statusCategory": {"name": "To Do", "key": "new"}
+                },
+                "issuetype": {"name": "Task"},
+                "project": {"key": "PROJ"}
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // GET /rest/api/3/field — fetched by `get_or_fetch_cmdb_fields` on a cold
+    // cache. An empty array means "no CMDB fields" and keeps the test focused
+    // on the shape guarantee.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/field"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Value::Array(vec![])))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .args([
+            "--no-input",
+            "issue",
+            "create",
+            "--project",
+            "PROJ",
+            "--type",
+            "Task",
+            "--summary",
+            "test summary",
+            "--output",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {stderr}, stdout: {stdout}"
+    );
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+
+    assert_eq!(parsed["key"], "PROJ-123");
+    assert!(
+        parsed["url"]
+            .as_str()
+            .expect("url must be a string")
+            .ends_with("/browse/PROJ-123"),
+        "url must end with /browse/PROJ-123, got: {}",
+        parsed["url"]
+    );
+    assert_eq!(
+        parsed["fields"]["summary"], "test summary",
+        "fields.summary must be present in the full shape"
+    );
+    assert_eq!(
+        parsed["fields"]["status"]["name"], "To Do",
+        "fields.status.name must be present in the full shape"
+    );
+    assert_eq!(parsed["fields"]["issuetype"]["name"], "Task");
+    assert_eq!(parsed["fields"]["project"]["key"], "PROJ");
+}
+
+/// If the follow-up GET fails, the handler warns on stderr and falls back to
+/// the old minimal `{key, url}` shape. The command still exits 0 — the create
+/// succeeded, only the enrichment didn't.
+#[tokio::test]
+async fn issue_create_json_falls_back_on_get_failure() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": "10002",
+            "key": "PROJ-456",
+            "self": format!("{}/rest/api/3/issue/10002", server.uri()),
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Follow-up GET fails with 500.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/PROJ-456"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
+            "errorMessages": ["boom"],
+            "errors": {}
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/field"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Value::Array(vec![])))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .args([
+            "--no-input",
+            "issue",
+            "create",
+            "--project",
+            "PROJ",
+            "--type",
+            "Task",
+            "--summary",
+            "fallback summary",
+            "--output",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    assert!(
+        output.status.success(),
+        "create must still succeed when the follow-up GET fails, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("PROJ-456") && stderr.to_lowercase().contains("warn"),
+        "expected a stderr warning mentioning the new key, got: {stderr}"
+    );
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(parsed["key"], "PROJ-456");
+    assert!(
+        parsed["url"]
+            .as_str()
+            .expect("url must be a string")
+            .ends_with("/browse/PROJ-456")
+    );
+    // The fallback shape is the old minimal `{key, url}` — no `fields` object.
+    assert!(
+        parsed.get("fields").is_none(),
+        "fallback shape must not contain `fields`, got: {parsed}"
+    );
+}

--- a/tests/issue_create_json.rs
+++ b/tests/issue_create_json.rs
@@ -197,6 +197,10 @@ async fn issue_create_json_falls_back_on_get_failure() {
         stderr.contains("PROJ-456") && stderr.to_lowercase().contains("warn"),
         "expected a stderr warning mentioning the new key, got: {stderr}"
     );
+    assert!(
+        stderr.contains("jr issue view PROJ-456"),
+        "expected recovery hint pointing at `jr issue view`, got: {stderr}"
+    );
 
     let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
     assert_eq!(parsed["key"], "PROJ-456");

--- a/tests/issue_create_json.rs
+++ b/tests/issue_create_json.rs
@@ -118,6 +118,14 @@ async fn issue_create_json_returns_full_shape() {
         !stderr.to_lowercase().contains("warning") && !stderr.to_lowercase().contains("error"),
         "expected clean stderr on happy path, got: {stderr}"
     );
+
+    // The `fetch_error` sentinel must only appear on the fallback path —
+    // asserting its absence here pins the happy-path/fallback distinction so
+    // a regression that always emits the sentinel is caught.
+    assert!(
+        parsed.get("fetch_error").is_none(),
+        "happy path must not include fetch_error sentinel: {parsed}"
+    );
 }
 
 /// If the follow-up GET fails, the handler warns on stderr and falls back to
@@ -203,6 +211,14 @@ async fn issue_create_json_falls_back_on_get_failure() {
         parsed.get("fields").is_none(),
         "fallback shape must not contain `fields`, got: {parsed}"
     );
+    // Machine-readable sentinel so scripts using `jq '.fields.status.name'`
+    // can detect degraded output without parsing stderr. The value is the
+    // error message for diagnostics — we only require that it's present and
+    // a string.
+    assert!(
+        parsed["fetch_error"].is_string(),
+        "fallback must include fetch_error sentinel: {parsed}"
+    );
 }
 
 /// The table output path must not trigger a follow-up GET after a successful
@@ -234,9 +250,15 @@ async fn issue_create_table_does_not_trigger_follow_up_get() {
         .mount(&server)
         .await;
 
+    // Also pin .expect(0) on /rest/api/3/field: the table path currently
+    // doesn't call `get_or_fetch_cmdb_fields` at all, and a future refactor
+    // that hoists CMDB discovery above the match in `handle_create` would
+    // start hitting /field on the table path — a wasted round trip on every
+    // table-mode create. This assertion catches that regression.
     Mock::given(method("GET"))
         .and(path("/rest/api/3/field"))
         .respond_with(ResponseTemplate::new(200).set_body_json(Value::Array(vec![])))
+        .expect(0)
         .mount(&server)
         .await;
 
@@ -274,4 +296,130 @@ async fn issue_create_table_does_not_trigger_follow_up_get() {
         combined.contains("Created issue PROJ-125"),
         "output must announce the created key, stdout: {stdout}, stderr: {stderr}"
     );
+}
+
+/// The follow-up GET on the JSON path must pass the configured SP + team +
+/// CMDB field IDs in `?fields=...`. This pins the `compose_extra_fields`
+/// wire-through, so a refactor that accidentally calls `get_issue(&[])`
+/// trips this test instead of silently dropping custom fields.
+#[tokio::test]
+async fn issue_create_json_follow_up_get_passes_configured_extra_fields() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    // Write a global config at $XDG_CONFIG_HOME/jr/config.toml with SP + team
+    // field IDs, matching the shape defined in `src/config.rs` (`FieldsConfig`
+    // under `[fields]`).
+    let jr_config_dir = config_dir.path().join("jr");
+    std::fs::create_dir_all(&jr_config_dir).unwrap();
+    std::fs::write(
+        jr_config_dir.join("config.toml"),
+        "[fields]\nstory_points_field_id = \"customfield_10016\"\nteam_field_id = \"customfield_10001\"\n",
+    )
+    .unwrap();
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": "10003",
+            "key": "PROJ-789",
+            "self": format!("{}/rest/api/3/issue/10003", server.uri()),
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Happy-path GET so we exercise the success branch. `fields` content is
+    // asserted out-of-band via `received_requests()` below.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/PROJ-789"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "10003",
+            "key": "PROJ-789",
+            "fields": { "summary": "extra-fields test" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // GET /rest/api/3/field — returns one CMDB field so
+    // `compose_extra_fields` includes a discovered id in addition to the
+    // configured SP + team. Schema string matches
+    // `CMDB_SCHEMA_TYPE` in `src/api/jira/fields.rs`.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/field"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {
+                "id": "customfield_12345",
+                "name": "Affected Services",
+                "custom": true,
+                "schema": {
+                    "type": "any",
+                    "custom": "com.atlassian.jira.plugins.cmdb:cmdb-object-cftype"
+                }
+            }
+        ])))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .args([
+            "--no-input",
+            "issue",
+            "create",
+            "--project",
+            "PROJ",
+            "--type",
+            "Task",
+            "--summary",
+            "extra-fields test",
+            "--output",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {stderr}, stdout: {stdout}"
+    );
+
+    // Inspect the actual follow-up GET URL. `received_requests` returns all
+    // requests the mock server saw; we filter for the GET on the issue and
+    // assert `fields=...` contains each configured id. Comma-joined ordering
+    // is an implementation detail of `get_issue` — membership is the contract.
+    let requests = server.received_requests().await.expect("requests recorded");
+    // Filter by path only: the POST goes to `/rest/api/3/issue` (no key
+    // suffix), so any hit on `/rest/api/3/issue/PROJ-789` is the follow-up
+    // GET by construction. Avoids importing wiremock's Method enum.
+    let follow_up = requests
+        .iter()
+        .find(|r| r.url.path() == "/rest/api/3/issue/PROJ-789")
+        .expect("follow-up GET must have been made");
+
+    let fields_query = follow_up
+        .url
+        .query_pairs()
+        .find(|(k, _)| k == "fields")
+        .map(|(_, v)| v.into_owned())
+        .expect("follow-up GET must carry a `fields` query parameter");
+
+    for expected in [
+        "customfield_10016", // SP (configured)
+        "customfield_12345", // CMDB (discovered)
+        "customfield_10001", // team (configured)
+    ] {
+        assert!(
+            fields_query.split(',').any(|f| f == expected),
+            "follow-up GET must request {expected}; got fields={fields_query}"
+        );
+    }
 }

--- a/tests/issue_create_json.rs
+++ b/tests/issue_create_json.rs
@@ -204,3 +204,74 @@ async fn issue_create_json_falls_back_on_get_failure() {
         "fallback shape must not contain `fields`, got: {parsed}"
     );
 }
+
+/// The table output path must not trigger a follow-up GET after a successful
+/// create. Table formatting only needs the key returned by POST, so fetching
+/// the full issue would be a wasted round trip.
+#[tokio::test]
+async fn issue_create_table_does_not_trigger_follow_up_get() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": "10001",
+            "key": "PROJ-125",
+            "self": format!("{}/rest/api/3/issue/10001", server.uri()),
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Critical: a GET on the issue MUST NOT be made on the table path.
+    // wiremock's .expect(0) will fail the test on drop if the GET was called.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/PROJ-125"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("should not be called"))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/field"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Value::Array(vec![])))
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .args([
+            "--no-input",
+            "issue",
+            "create",
+            "--project",
+            "PROJ",
+            "--type",
+            "Task",
+            "--summary",
+            "table test",
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {stderr}, stdout: {stdout}"
+    );
+    // `print_success` writes to stderr, not stdout, so check both to avoid
+    // coupling the assertion to output stream details — the key guarantee here
+    // is the .expect(0) on the GET mock.
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("Created issue PROJ-125"),
+        "output must announce the created key, stdout: {stdout}, stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #253. `jr issue create --output json` now returns the same full `Issue` payload that `jr issue view --output json` produces, plus a `url` field. The old minimal `{key, url}` shape made `jq '.fields.summary'` return empty strings silently — now it works.

- After a successful POST, a follow-up `GET /rest/api/3/issue/{key}` is issued using the same extra-fields composition as `handle_view` (story-points, team, CMDB field IDs from cache).
- If the follow-up GET fails (5xx, 404 eventual-consistency lag, network), the command still exits 0 (the create succeeded) and emits a machine-readable fallback: `{key, url, fetch_error}` + a stderr `warning:` with a recovery hint (`Run jr issue view <key> --output json ...`).
- Table output is unchanged — no extra round-trip when the user is on a terminal.

## Why not `?expand=...` on the POST?

Validated against Atlassian REST API v3 docs: `POST /rest/api/3/issue` returns only `{id, key, self}` and does not support `expand` or `fields` query params on POST. Follow-up GET is the documented path.

## Changes

- `src/cli/issue/helpers.rs` — new `compose_extra_fields` helper (shared between `handle_view` and `handle_create`).
- `src/cli/issue/list.rs` — `handle_view` uses the helper (no behavior change).
- `src/cli/issue/create.rs` — JSON branch now does the follow-up GET, handles Ok/Err, inserts `url` + (on Err) `fetch_error` sentinel.
- `tests/issue_create_json.rs` — 4 wiremock integration tests: happy path, fallback, table-path-no-GET (via `.expect(0)`), follow-up-GET-carries-configured-extras (via `received_requests()` inspection).

## Deferred / follow-up concern

One finding from local silent-failure-hunter review is deferred to a codebase-wide cleanup: `get_or_fetch_cmdb_fields(client).await.unwrap_or_default()` silently swallows auth/rate-limit/network errors at 4 call sites (`list.rs:365`, `list.rs:761`, `project.rs:79`, `create.rs:153`). Fixing in this PR would require touching unrelated handlers. Tracked inline via comment at `src/cli/issue/create.rs:154-157`; should be cleaned up in a dedicated PR that wraps the call in a `warning:` stderr emission and uses `Vec::new()` as the fallback value across all 4 sites.

## Local review

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` all green (523 unit + all integration)
- [x] 2 rounds of multi-agent local review (code-reviewer, pr-test-analyzer, silent-failure-hunter) — all agents clean on round 2
- [x] Perplexity-validated the Atlassian POST/GET contract (no expand on POST, minimal body response)

## Test plan

- [x] Happy path returns `{key, fields.*, url}` shape — covered by `issue_create_json_returns_full_shape`
- [x] Fallback on GET failure returns `{key, url, fetch_error}` + stderr warning + recovery hint — covered by `issue_create_json_falls_back_on_get_failure`
- [x] Table output path makes NO follow-up GET — covered by `issue_create_table_does_not_trigger_follow_up_get` (`.expect(0)` on both `/issue/{key}` and `/field`)
- [x] Follow-up GET carries configured SP + team + CMDB IDs — covered by `issue_create_json_follow_up_get_passes_configured_extra_fields`