### PR TITLE
fix(team): accept Atlas Teams object shape in team_id extraction (#254)

### DIFF
--- a/docs/specs/team-field-object-shape-tolerance.md
+++ b/docs/specs/team-field-object-shape-tolerance.md
@@ -74,10 +74,10 @@ This particular message is `--verbose`-gated (only emits when `client.verbose()`
 
 Revised warning:
 ```
-[verbose] team field "customfield_10001" has unexpected shape (got <kind>)
+[verbose] team field "customfield_10001" has unexpected shape (got <kind>). Expected string UUID or object with string "id".
 ```
 
-Same tag, dropped the config-blame clause, dropped the "expected string UUID" claim (we now accept two shapes, the "expected" is "string OR object-with-string-id").
+Same `[verbose]` tag, dropped the config-blame clause, replaced the "expected string UUID" suffix with a positive statement of the two accepted shapes — users hitting this (genuinely broken data: bool, number, array, or object missing a string `id`) get both diagnosis and expectation in one line.
 
 ## Testing
 

--- a/docs/specs/team-field-object-shape-tolerance.md
+++ b/docs/specs/team-field-object-shape-tolerance.md
@@ -1,0 +1,109 @@
+# Team field object-shape tolerance
+
+**Issue:** [#254](https://github.com/Zious11/jira-cli/issues/254)
+
+## Problem
+
+On tenants using the Atlas Teams custom field (the modern, cross-product "Team" field provided by the Atlassian Teams platform), `GET /rest/api/3/issue/{key}` returns `customfield_10001` as a **JSON object**:
+
+```json
+{"id": "<uuid>", "name": "Team Name"}
+```
+
+`src/types/jira/issue.rs:94` currently extracts team UUIDs via `value.as_str()` — it handles only the scalar string shape. For the object shape, `team_id()` returns `None` and emits a once-per-process verbose warning misleadingly claiming the config is broken:
+
+```
+[verbose] team field "customfield_10001" has unexpected shape (expected string UUID, got object). Check team_field_id in config.
+```
+
+User-visible impact:
+- Team row is silently dropped from `issue view` output.
+- Team column is silently dropped from `issue list`, `sprint view`, `board view`.
+- The verbose warning gaslights the user into re-checking their config when the config is correct.
+
+## Root cause validation
+
+Validated against Atlassian developer documentation (`developer.atlassian.com/platform/teams/components/team-field-in-jira-rest-api`):
+
+- The Team custom field (schema type `com.atlassian.teams:rm-teams-custom-field-team`) accepts a scalar UUID on write (POST/PUT).
+- On read (GET), some tenants return a scalar UUID string, others return an object with `id` and `name` properties. The object form is the Atlas Teams platform format, introduced alongside Atlassian Teams.
+- Both shapes are valid responses for the same custom-field type; the shape is tenant- and config-dependent.
+
+The existing code comment calling the object shape a "misconfigured `team_field_id`" is wrong. Reconciling the comment is part of this fix.
+
+## Design
+
+Extend `IssueFields::team_id` to accept both shapes. Extract `id` from the object form; keep the existing string form; emit the verbose warning only for genuinely unexpected shapes (bool, number, array, null-with-non-null-value).
+
+### Shape handling
+
+| Value shape | New behaviour |
+|---|---|
+| `null` or missing | `None`, no warning |
+| `"<uuid>"` (scalar string) | `Some("<uuid>".into())` |
+| `{"id": "<uuid>", ...}` (object with string `id`) | `Some("<uuid>".into())` |
+| `{"id": null, ...}` or object without string `id` | `None`, warn (genuinely unexpected) |
+| bool / number / array | `None`, warn (unchanged behaviour) |
+
+The `name` field in the object form is **not** consumed by this change. Display code already resolves UUIDs via the team cache; introducing a parallel "use embedded name when present" code path is scope creep (tracked separately if wanted).
+
+### Callers are unaffected
+
+`team_id()` returns `Option<String>` (a UUID). All four call sites (`list.rs:500`, `list.rs:983`, `sprint.rs:293`, `board.rs:235`) pipe the UUID into team-name resolution via the existing team cache. They do not need to change.
+
+### Warning message reconciliation
+
+The current warning text blames the config. With the fix, the object shape is a happy path and should produce no warning. For the remaining genuinely-unexpected shapes (bool, number, array, object-missing-id), keep a warning but drop the misleading "Check team_field_id in config" suffix — those shapes are genuinely surprising and not typically a config issue.
+
+New warning text (once per process when `verbose`):
+```
+warning: team field "customfield_10001" has unexpected shape: got <kind>
+```
+
+(Lowercase `warning:` per codebase convention established in PR #253. No more `[verbose]` tag — `[verbose]` is a separate pattern for `--verbose`-gated diagnostics, and this case is already verbose-gated via the existing `verbose: bool` parameter. Keep the parameter; drop the tag.)
+
+### What about the `[verbose]` vs `warning:` convention?
+
+Grepping the codebase:
+- `[verbose]` tag: used in `src/types/jira/issue.rs:102` (the one we're changing) and likely elsewhere for `--verbose`-gated logs.
+- `warning:` tag: used at ~7 sites for user-actionable warnings regardless of verbose mode.
+
+This particular message is `--verbose`-gated (only emits when `client.verbose()`), so `[verbose]` is arguably the right tag for consistency. The spec for this fix: keep `[verbose]` tag to match the existing gated-diagnostic pattern, just drop the misleading "Check team_field_id" suffix.
+
+### Decision
+
+Revised warning:
+```
+[verbose] team field "customfield_10001" has unexpected shape (got <kind>)
+```
+
+Same tag, dropped the config-blame clause, dropped the "expected string UUID" claim (we now accept two shapes, the "expected" is "string OR object-with-string-id").
+
+## Testing
+
+Unit tests inline in `src/types/jira/issue.rs`:
+
+1. **Object with string `id`** — `customfield_10001 = {"id": "team-uuid-abc", "name": "Platform Team"}` → `Some("team-uuid-abc")`, no warning.
+2. **Object with string `id` AND no `name`** — `{"id": "team-uuid-xyz"}` → `Some("team-uuid-xyz")`, no warning.
+3. **Object with null `id`** — `{"id": null, "name": "..."}` → `None`, warning emitted.
+4. **Object without `id` key** — `{"name": "..."}` → `None`, warning emitted.
+5. **String UUID (regression)** — existing behaviour preserved.
+6. **Missing / null / bool / number / array** — existing behaviour preserved.
+
+Existing tests at `src/types/jira/issue.rs:225-265` already cover most non-object cases; extend rather than replace.
+
+Integration test via wiremock: add to `tests/team_column_parity.rs` or a new `tests/team_object_shape.rs` — mount a wiremock issue response with the object-shape team field, run `jr issue view KEY --output json` with `team_field_id` configured, assert the team UUID is extracted (visible in the output, OR via the team-cache-resolved name if the cache is primed).
+
+## Files touched
+
+| Path | Change |
+|---|---|
+| `src/types/jira/issue.rs` | Rewrite `team_id` match to accept object shape. Update doc comment + warning text. Extend unit tests. |
+| `tests/team_object_shape.rs` (new) | Integration test: object-shape team field resolves through to display. |
+
+## Out of scope
+
+- Consuming the `name` field embedded in the object shape (would avoid a cache lookup; can be added later).
+- Cache format changes (no change to team cache).
+- `--verbose` / `warning:` tag reform across the codebase (tracked separately).
+- Write-path changes (the write path already sends a scalar UUID string, which Atlassian accepts for both shapes).

--- a/docs/specs/team-field-object-shape-tolerance.md
+++ b/docs/specs/team-field-object-shape-tolerance.md
@@ -33,7 +33,7 @@ The existing code comment calling the object shape a "misconfigured `team_field_
 
 ## Design
 
-Extend `IssueFields::team_id` to accept both shapes. Extract `id` from the object form; keep the existing string form; emit the verbose warning only for genuinely unexpected shapes (bool, number, array, null-with-non-null-value).
+Extend `IssueFields::team_id` to accept both shapes. Extract `id` from the object form; keep the existing string form; emit the verbose warning only for genuinely unexpected shapes (bool, number, array, or object values without a string `id`).
 
 ### Shape handling
 
@@ -42,8 +42,8 @@ Extend `IssueFields::team_id` to accept both shapes. Extract `id` from the objec
 | `null` or missing | `None`, no warning |
 | `"<uuid>"` (scalar string) | `Some("<uuid>".into())` |
 | `{"id": "<uuid>", ...}` (object with string `id`) | `Some("<uuid>".into())` |
-| `{"id": null, ...}` or object without string `id` | `None`, warn (genuinely unexpected) |
-| bool / number / array | `None`, warn (unchanged behaviour) |
+| `{"id": null, ...}` or object without string `id` | `None`, warn when verbose (genuinely unexpected) |
+| bool / number / array | `None`, warn when verbose (unchanged behaviour) |
 
 The `name` field in the object form is **not** consumed by this change. Display code already resolves UUIDs via the team cache; introducing a parallel "use embedded name when present" code path is scope creep (tracked separately if wanted).
 

--- a/docs/specs/team-field-object-shape-tolerance.md
+++ b/docs/specs/team-field-object-shape-tolerance.md
@@ -10,16 +10,16 @@ On tenants using the Atlas Teams custom field (the modern, cross-product "Team" 
 {"id": "<uuid>", "name": "Team Name"}
 ```
 
-`src/types/jira/issue.rs:94` currently extracts team UUIDs via `value.as_str()` — it handles only the scalar string shape. For the object shape, `team_id()` returns `None` and emits a once-per-process verbose warning misleadingly claiming the config is broken:
+Before this change, `IssueFields::team_id` in `src/types/jira/issue.rs` extracted team UUIDs via `value.as_str()` — it handled only the scalar string shape. For the object shape, `team_id()` returned `None` and emitted a once-per-process verbose warning misleadingly claiming the config was broken:
 
 ```
 [verbose] team field "customfield_10001" has unexpected shape (expected string UUID, got object). Check team_field_id in config.
 ```
 
-User-visible impact:
-- Team row is silently dropped from `issue view` output.
-- Team column is silently dropped from `issue list`, `sprint view`, `board view`.
-- The verbose warning gaslights the user into re-checking their config when the config is correct.
+User-visible impact before the fix:
+- Team row was silently dropped from `issue view` output.
+- Team column was silently dropped from `issue list`, `sprint view`, `board view`.
+- The verbose warning gaslit users into re-checking their config when the config was correct.
 
 ## Root cause validation
 
@@ -85,8 +85,8 @@ Unit tests inline in `src/types/jira/issue.rs`:
 
 1. **Object with string `id`** — `customfield_10001 = {"id": "team-uuid-abc", "name": "Platform Team"}` → `Some("team-uuid-abc")`, no warning.
 2. **Object with string `id` AND no `name`** — `{"id": "team-uuid-xyz"}` → `Some("team-uuid-xyz")`, no warning.
-3. **Object with null `id`** — `{"id": null, "name": "..."}` → `None`, warning emitted.
-4. **Object without `id` key** — `{"name": "..."}` → `None`, warning emitted.
+3. **Object with null `id`** — `{"id": null, "name": "..."}` → `None`, warning emitted when verbose.
+4. **Object without `id` key** — `{"name": "..."}` → `None`, warning emitted when verbose.
 5. **String UUID (regression)** — existing behaviour preserved.
 6. **Missing / null / bool / number / array** — existing behaviour preserved.
 

--- a/docs/superpowers/plans/2026-04-23-team-field-object-shape-tolerance.md
+++ b/docs/superpowers/plans/2026-04-23-team-field-object-shape-tolerance.md
@@ -90,20 +90,25 @@ pub fn team_id(&self, field_id: &str, verbose: bool) -> Option<String> {
     // Per developer.atlassian.com/platform/teams/components/team-field-in-jira-rest-api,
     // the Team custom field returns an object on GET in tenants that use the Atlas
     // Teams platform. Extract `id` as the UUID.
-    if let Some(obj) = value.as_object()
-        && let Some(id) = obj.get("id").and_then(|v| v.as_str())
+    if let Some(id) = value
+        .as_object()
+        .and_then(|obj| obj.get("id"))
+        .and_then(|v| v.as_str())
     {
         return Some(id.to_string());
     }
     if verbose && !LOGGED.swap(true, Ordering::Relaxed) {
         eprintln!(
-            "[verbose] team field \"{field_id}\" has unexpected shape (got {})",
+            "[verbose] team field \"{field_id}\" has unexpected shape (got {}). \
+             Expected string UUID or object with string \"id\".",
             value_kind(value)
         );
     }
     None
 }
 ```
+
+Note: this plan originally prescribed let-chain syntax (`if let Some(obj) = ... && let Some(id) = ...`), which stabilized in Rust 1.88 and breaks the crate's MSRV of 1.85. The snippet above uses the MSRV-safe `.and_then()` chain that the final code landed. The warning text includes the "Expected string UUID or object with string" suffix added during local review.
 
 Also update the doc comment immediately above the function to reflect the new contract:
 
@@ -115,9 +120,13 @@ Also update the doc comment immediately above the function to reflect the new co
 /// - Object `{"id": "<uuid>", "name": "..."}` (Atlas Teams platform).
 ///
 /// Returns `None` when the field is missing, null, or present but not one of
-/// the accepted shapes. On genuinely unexpected shapes (bool, number, array,
-/// or object without a string `id`), emits a once-per-process `[verbose]`
-/// hint on stderr when `verbose` is true.
+/// the accepted shapes. An object whose `id` is null or not a string is
+/// treated as unexpected. On genuinely unexpected shapes (bool, number,
+/// array, or object without a string `id`), emits a once-per-process
+/// `[verbose]` hint on stderr when `verbose` is true. The once-per-process
+/// gate is module-wide: if a single run needed to warn for two distinct
+/// team fields (not a supported configuration today), only the first would
+/// emit.
 ```
 
 - [ ] **Step 3: Run tests**

--- a/docs/superpowers/plans/2026-04-23-team-field-object-shape-tolerance.md
+++ b/docs/superpowers/plans/2026-04-23-team-field-object-shape-tolerance.md
@@ -1,0 +1,308 @@
+# Team field object-shape tolerance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `IssueFields::team_id` tolerant of the Atlas Teams object shape (`{"id": "uuid", "name": "..."}`) in addition to the scalar-UUID string shape. Fix silent team-row drop + misleading verbose warning.
+
+**Architecture:** Extend the pattern-match in `team_id` to cover `serde_json::Value::Object` with a string `id` field. Downstream callers (display, list, sprint, board) are unaffected — they still receive `Option<String>` containing a UUID.
+
+**Tech Stack:** serde_json (existing `Value::Object` / `Value::as_str`), insta for any applicable snapshots (none needed for this change), wiremock for integration.
+
+**Spec:** `docs/specs/team-field-object-shape-tolerance.md`
+
+---
+
+## Task 1: Unit tests for object-shape extraction
+
+**Files:**
+- Modify: `src/types/jira/issue.rs` — add failing unit tests inside the existing `#[cfg(test)] mod tests` block.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to the existing tests module (which already has `fields_with_extra` helper around line 218):
+
+```rust
+#[test]
+fn team_id_accepts_object_shape_with_string_id() {
+    let fields = fields_with_extra(
+        "customfield_10001",
+        json!({"id": "team-uuid-abc", "name": "Platform Team"}),
+    );
+    assert_eq!(
+        fields.team_id("customfield_10001", false),
+        Some("team-uuid-abc".to_string())
+    );
+}
+
+#[test]
+fn team_id_accepts_object_shape_without_name() {
+    let fields = fields_with_extra(
+        "customfield_10001",
+        json!({"id": "team-uuid-xyz"}),
+    );
+    assert_eq!(
+        fields.team_id("customfield_10001", false),
+        Some("team-uuid-xyz".to_string())
+    );
+}
+
+#[test]
+fn team_id_returns_none_for_object_with_null_id() {
+    let fields = fields_with_extra(
+        "customfield_10001",
+        json!({"id": null, "name": "Platform Team"}),
+    );
+    assert_eq!(fields.team_id("customfield_10001", false), None);
+}
+
+#[test]
+fn team_id_returns_none_for_object_without_id_key() {
+    let fields = fields_with_extra(
+        "customfield_10001",
+        json!({"name": "Platform Team"}),
+    );
+    assert_eq!(fields.team_id("customfield_10001", false), None);
+}
+```
+
+Check the existing `fields_with_extra` helper signature — it takes `(key: &str, value: serde_json::Value) -> IssueFields`. If the helper name or signature differs, adapt accordingly (grep the test module to confirm).
+
+Run: `cargo test --lib types::jira::issue::tests::team_id_accepts_object -- --nocapture`
+Expected: FAIL — the two "object with string id" tests fail because the current code returns `None` for objects.
+
+- [ ] **Step 2: Implement object-shape extraction**
+
+Replace the body of `team_id` at `src/types/jira/issue.rs:94-111` with:
+
+```rust
+pub fn team_id(&self, field_id: &str, verbose: bool) -> Option<String> {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static LOGGED: AtomicBool = AtomicBool::new(false);
+    let value = self.extra.get(field_id)?;
+    if value.is_null() {
+        return None;
+    }
+    // Scalar UUID shape (legacy and some tenants).
+    if let Some(s) = value.as_str() {
+        return Some(s.to_string());
+    }
+    // Atlas Teams object shape: {"id": "<uuid>", "name": "..."}
+    // Per developer.atlassian.com/platform/teams/components/team-field-in-jira-rest-api,
+    // the Team custom field returns an object on GET in tenants that use the Atlas
+    // Teams platform. Extract `id` as the UUID.
+    if let Some(obj) = value.as_object()
+        && let Some(id) = obj.get("id").and_then(|v| v.as_str())
+    {
+        return Some(id.to_string());
+    }
+    if verbose && !LOGGED.swap(true, Ordering::Relaxed) {
+        eprintln!(
+            "[verbose] team field \"{field_id}\" has unexpected shape (got {})",
+            value_kind(value)
+        );
+    }
+    None
+}
+```
+
+Also update the doc comment immediately above the function to reflect the new contract:
+
+```rust
+/// Extract the team UUID from the issue's team field.
+///
+/// Accepts two shapes documented for Jira's Team custom field:
+/// - Scalar string UUID (legacy / some tenants).
+/// - Object `{"id": "<uuid>", "name": "..."}` (Atlas Teams platform).
+///
+/// Returns `None` when the field is missing, null, or present but not one of
+/// the accepted shapes. On genuinely unexpected shapes (bool, number, array,
+/// or object without a string `id`), emits a once-per-process `[verbose]`
+/// hint on stderr when `verbose` is true.
+```
+
+- [ ] **Step 3: Run tests**
+
+`cargo test --lib types::jira::issue::tests`
+Expected: ALL pass (pre-existing tests + 4 new).
+
+- [ ] **Step 4: Full CI-equivalent check set**
+
+```
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+All green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/jira/issue.rs
+git commit -m "fix(team): accept Atlas Teams object shape in team_id extraction"
+```
+
+---
+
+## Task 2: Integration test via wiremock
+
+**Files:**
+- Create: `tests/team_object_shape.rs` — new integration test file.
+
+- [ ] **Step 1: Inspect existing integration tests**
+
+Read `tests/team_column_parity.rs` and `tests/issue_view_errors.rs` to learn the local conventions:
+- How to set `team_field_id` in the config file created under `$XDG_CONFIG_HOME/jr/config.toml`
+- How to prime (or skip priming) the team cache — if a test doesn't prime it, does display fall back to the raw UUID, or does the team lookup call Jira?
+- `JR_AUTH_HEADER` / `JR_BASE_URL` / `XDG_CACHE_HOME` / `XDG_CONFIG_HOME` env setup pattern
+- Whether `#[tokio::test]` is plain or `multi_thread`
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/team_object_shape.rs`. Test name: `issue_view_json_extracts_team_uuid_from_object_shape`.
+
+Shape:
+- Write config with `[fields] team_field_id = "customfield_10001"`
+- Mount wiremock `/rest/api/3/field` returning an empty array (no CMDB discovery for this test)
+- Mount `/rest/api/3/issue/PROJ-700` returning an issue whose `fields.customfield_10001` is the **object shape**: `{"id": "team-uuid-alpha", "name": "Platform Team"}`
+- Run `jr issue view PROJ-700 --output json`
+- Parse stdout. Assert `.fields.customfield_10001.id == "team-uuid-alpha"` (the raw response preserves the object, per Serde `extra: HashMap<String, Value>`)
+- Assert `output.status.success()`
+- Assert stderr does NOT contain `"unexpected shape"` (the warning we're fixing must not fire)
+
+Example skeleton — adapt to actual fixture conventions found in step 1:
+
+```rust
+use assert_cmd::Command;
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn issue_view_json_extracts_team_uuid_from_object_shape() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/field"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Value::Array(vec![])))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/PROJ-700"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "key": "PROJ-700",
+            "fields": {
+                "summary": "test",
+                "status": { "name": "To Do", "statusCategory": { "name": "To Do", "key": "new" } },
+                "issuetype": { "name": "Task" },
+                "project": { "key": "PROJ" },
+                "customfield_10001": { "id": "team-uuid-alpha", "name": "Platform Team" }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    // Write config with team_field_id set. Check src/config.rs for exact TOML shape.
+    std::fs::create_dir_all(config_dir.path().join("jr")).unwrap();
+    std::fs::write(
+        config_dir.path().join("jr/config.toml"),
+        "[fields]\nteam_field_id = \"customfield_10001\"\n",
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("jr").unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .args(["issue", "view", "PROJ-700", "--output", "json", "--no-input"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let parsed: Value = serde_json::from_str(&stdout).expect("valid JSON");
+
+    assert_eq!(
+        parsed["fields"]["customfield_10001"]["id"],
+        "team-uuid-alpha",
+        "team field must be preserved in JSON output as object with .id"
+    );
+    assert!(
+        !stderr.contains("unexpected shape"),
+        "warning about unexpected shape must not fire on object-shape response; stderr: {stderr}"
+    );
+}
+```
+
+Run: `cargo test --test team_object_shape`
+Expected: PASS after Task 1 changes. If it fails, diagnose and iterate.
+
+- [ ] **Step 3: (Optional) Add a second test asserting verbose-flag path works**
+
+If the codebase exposes `--verbose` at the CLI, add a companion test that invokes with `--verbose` and asserts the warning is NOT emitted on the object-shape response. Skip if `--verbose` isn't a CLI flag (grep `src/cli/mod.rs` for `verbose`).
+
+- [ ] **Step 4: Full CI set**
+
+```
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/team_object_shape.rs
+git commit -m "test(team): cover Atlas Teams object shape end-to-end"
+```
+
+---
+
+## Task 3: Spec + plan touch-up if diverged during implementation
+
+- [ ] **Step 1: Re-read the spec**
+
+`docs/specs/team-field-object-shape-tolerance.md` — check all assertions still hold against the final code.
+
+- [ ] **Step 2: Fix any drift**
+
+Examples of drift that matters:
+- If the final warning text differs from what the spec says, update the spec.
+- If the decision was made during implementation to also extract `name`, update both the spec and "out of scope" sections.
+
+- [ ] **Step 3: Commit (if any drift)**
+
+```bash
+git add docs/specs/team-field-object-shape-tolerance.md
+git commit -m "docs(spec): reconcile team-field spec with implementation"
+```
+
+Skip this task entirely if nothing drifted.
+
+---
+
+## Task 4: Final checks
+
+- [ ] **Step 1: Full CI-equivalent check set**
+
+```
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+All green.
+
+- [ ] **Step 2: Declare done**
+
+Branch ready for multi-agent local review + PR.

--- a/src/types/jira/issue.rs
+++ b/src/types/jira/issue.rs
@@ -109,14 +109,17 @@ impl IssueFields {
         // Per developer.atlassian.com/platform/teams/components/team-field-in-jira-rest-api,
         // the Team custom field returns an object on GET in tenants that use the Atlas
         // Teams platform. Extract `id` as the UUID.
-        if let Some(obj) = value.as_object()
-            && let Some(id) = obj.get("id").and_then(|v| v.as_str())
+        if let Some(id) = value
+            .as_object()
+            .and_then(|obj| obj.get("id"))
+            .and_then(|v| v.as_str())
         {
             return Some(id.to_string());
         }
         if verbose && !LOGGED.swap(true, Ordering::Relaxed) {
             eprintln!(
-                "[verbose] team field \"{field_id}\" has unexpected shape (got {})",
+                "[verbose] team field \"{field_id}\" has unexpected shape (got {}). \
+                 Expected string UUID or object with string \"id\".",
                 value_kind(value)
             );
         }

--- a/src/types/jira/issue.rs
+++ b/src/types/jira/issue.rs
@@ -91,9 +91,13 @@ impl IssueFields {
     /// - Object `{"id": "<uuid>", "name": "..."}` (Atlas Teams platform).
     ///
     /// Returns `None` when the field is missing, null, or present but not one of
-    /// the accepted shapes. On genuinely unexpected shapes (bool, number, array,
-    /// or object without a string `id`), emits a once-per-process `[verbose]`
-    /// hint on stderr when `verbose` is true.
+    /// the accepted shapes. An object whose `id` is null or not a string is
+    /// treated as unexpected. On genuinely unexpected shapes (bool, number,
+    /// array, or object without a string `id`), emits a once-per-process
+    /// `[verbose]` hint on stderr when `verbose` is true. The once-per-process
+    /// gate is module-wide: if a single run needed to warn for two distinct
+    /// team fields (not a supported configuration today), only the first would
+    /// emit.
     pub fn team_id(&self, field_id: &str, verbose: bool) -> Option<String> {
         use std::sync::atomic::{AtomicBool, Ordering};
         static LOGGED: AtomicBool = AtomicBool::new(false);
@@ -301,6 +305,29 @@ mod tests {
     fn team_id_returns_none_for_array_value() {
         let fields = fields_with_extra("customfield_10001", json!([1, 2, 3]));
         assert_eq!(fields.team_id("customfield_10001", false), None);
+    }
+
+    #[test]
+    fn team_id_returns_none_for_object_with_non_string_id() {
+        // The `id` field must be a string. Numeric/other types fall through to
+        // the "unexpected shape" branch rather than being coerced — a future
+        // lenient-parsing refactor would regress this case, so we pin it.
+        let fields = fields_with_extra(
+            "customfield_10001",
+            json!({"id": 42, "name": "Platform Team"}),
+        );
+        assert_eq!(fields.team_id("customfield_10001", false), None);
+    }
+
+    #[test]
+    fn team_id_exercises_verbose_warning_branch() {
+        // Ensures the `verbose: true` path compiles and runs without panic,
+        // covering the `eprintln!` branch (which all other tests skip to
+        // avoid tripping the module-wide LOGGED gate for subsequent tests).
+        // We can't capture stderr easily here; the integration test at
+        // tests/team_object_shape.rs covers the text-level assertions.
+        let fields = fields_with_extra("customfield_10001", json!([1, 2, 3]));
+        assert_eq!(fields.team_id("customfield_10001", true), None);
     }
 
     #[test]

--- a/src/types/jira/issue.rs
+++ b/src/types/jira/issue.rs
@@ -86,28 +86,41 @@ impl IssueFields {
 
     /// Extract the team UUID from the issue's team field.
     ///
-    /// Returns `None` when the field is missing, null, or present but not
-    /// a JSON string. In the present-but-not-a-string case — typically an
-    /// object like `{"id": "..."}` from a misconfigured `team_field_id`
-    /// pointing at a non-Teams custom field — emits a once-per-process
-    /// `[verbose]` hint on stderr so users can diagnose the silent drop.
+    /// Accepts two shapes documented for Jira's Team custom field:
+    /// - Scalar string UUID (legacy / some tenants).
+    /// - Object `{"id": "<uuid>", "name": "..."}` (Atlas Teams platform).
+    ///
+    /// Returns `None` when the field is missing, null, or present but not one of
+    /// the accepted shapes. On genuinely unexpected shapes (bool, number, array,
+    /// or object without a string `id`), emits a once-per-process `[verbose]`
+    /// hint on stderr when `verbose` is true.
     pub fn team_id(&self, field_id: &str, verbose: bool) -> Option<String> {
         use std::sync::atomic::{AtomicBool, Ordering};
         static LOGGED: AtomicBool = AtomicBool::new(false);
         let value = self.extra.get(field_id)?;
-        match value.as_str() {
-            Some(s) => Some(s.to_string()),
-            None => {
-                if !value.is_null() && verbose && !LOGGED.swap(true, Ordering::Relaxed) {
-                    eprintln!(
-                        "[verbose] team field \"{field_id}\" has unexpected shape \
-                         (expected string UUID, got {}). Check team_field_id in config.",
-                        value_kind(value)
-                    );
-                }
-                None
-            }
+        if value.is_null() {
+            return None;
         }
+        // Scalar UUID shape (legacy and some tenants).
+        if let Some(s) = value.as_str() {
+            return Some(s.to_string());
+        }
+        // Atlas Teams object shape: {"id": "<uuid>", "name": "..."}
+        // Per developer.atlassian.com/platform/teams/components/team-field-in-jira-rest-api,
+        // the Team custom field returns an object on GET in tenants that use the Atlas
+        // Teams platform. Extract `id` as the UUID.
+        if let Some(obj) = value.as_object()
+            && let Some(id) = obj.get("id").and_then(|v| v.as_str())
+        {
+            return Some(id.to_string());
+        }
+        if verbose && !LOGGED.swap(true, Ordering::Relaxed) {
+            eprintln!(
+                "[verbose] team field \"{field_id}\" has unexpected shape (got {})",
+                value_kind(value)
+            );
+        }
+        None
     }
 }
 
@@ -246,15 +259,38 @@ mod tests {
     }
 
     #[test]
-    fn team_id_returns_none_for_object_value() {
-        // Misconfigured team_field_id pointing at a non-Teams custom field
-        // (e.g., user-picker) can deliver an object like {"id": "..."}.
-        // team_id returns None and — if verbose — logs once; with verbose=false
-        // here, this just pins the None return without touching the gate flag.
+    fn team_id_accepts_object_shape_with_string_id() {
         let fields = fields_with_extra(
             "customfield_10001",
-            json!({"id": "36885b3c-1bf0-4f85-a357-c5b858c31de4"}),
+            json!({"id": "team-uuid-abc", "name": "Platform Team"}),
         );
+        assert_eq!(
+            fields.team_id("customfield_10001", false),
+            Some("team-uuid-abc".to_string())
+        );
+    }
+
+    #[test]
+    fn team_id_accepts_object_shape_without_name() {
+        let fields = fields_with_extra("customfield_10001", json!({"id": "team-uuid-xyz"}));
+        assert_eq!(
+            fields.team_id("customfield_10001", false),
+            Some("team-uuid-xyz".to_string())
+        );
+    }
+
+    #[test]
+    fn team_id_returns_none_for_object_with_null_id() {
+        let fields = fields_with_extra(
+            "customfield_10001",
+            json!({"id": null, "name": "Platform Team"}),
+        );
+        assert_eq!(fields.team_id("customfield_10001", false), None);
+    }
+
+    #[test]
+    fn team_id_returns_none_for_object_without_id_key() {
+        let fields = fields_with_extra("customfield_10001", json!({"name": "Platform Team"}));
         assert_eq!(fields.team_id("customfield_10001", false), None);
     }
 

--- a/tests/team_object_shape.rs
+++ b/tests/team_object_shape.rs
@@ -1,10 +1,19 @@
 //! End-to-end coverage for the Atlas Teams object shape on the team custom
-//! field (#254). Proves that `jr issue view KEY --output json` preserves the
-//! full `{"id": "...", "name": "..."}` object when a tenant returns the
-//! object form of the Team field — Task 1 widened `IssueFields::team_id` to
-//! accept both the scalar UUID and the object shape, and this test locks in
-//! the end-to-end contract so a regression in deserialization, JSON
-//! serialization, or the once-per-process warning path would surface here.
+//! field (#254). Covers three paths:
+//!
+//! 1. `jr issue view KEY --output json` — preserves the raw object through
+//!    Serde `#[serde(flatten)]` + JSON re-serialization. This path does NOT
+//!    call `IssueFields::team_id` (handle_view's JSON branch just re-
+//!    serializes `issue`); it's here to prove the wire response is not
+//!    mangled.
+//! 2. `jr issue view KEY` (table output) — actually calls `team_id()` at
+//!    `src/cli/issue/list.rs:983` and renders the UUID in the Team row,
+//!    which is the user-visible payoff of the fix. Without this test, a
+//!    future regression that narrows `team_id()` back to scalar-only would
+//!    pass the JSON-only coverage above while silently dropping the Team
+//!    row for every Atlas-Teams tenant.
+//! 3. `jr --verbose issue view KEY` on a truly-unexpected shape — asserts
+//!    the once-per-process warning branch fires with the documented text.
 //!
 //! Conventions match `tests/issue_view_errors.rs` — plain `#[tokio::test]`,
 //! the `JR_BASE_URL` / `JR_AUTH_HEADER` env pattern, and `XDG_CONFIG_HOME` +
@@ -90,6 +99,78 @@ async fn issue_view_json_extracts_team_uuid_from_object_shape() {
     assert!(
         !stderr.contains("unexpected shape"),
         "warning about unexpected shape must not fire on object-shape response; stderr: {stderr}"
+    );
+}
+
+#[tokio::test]
+async fn issue_view_table_renders_team_row_from_object_shape() {
+    // The JSON test above doesn't exercise `team_id()` — handle_view's JSON
+    // branch just re-serializes `issue`. The table branch at
+    // `src/cli/issue/list.rs:983` is where `team_id()` is called and where
+    // users actually see the Team row. This test proves the extraction
+    // reaches the rendered output for Atlas Teams tenants.
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/field"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Value::Array(vec![])))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/PROJ-702"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "key": "PROJ-702",
+            "fields": {
+                "summary": "test",
+                "status": { "name": "To Do", "statusCategory": { "name": "To Do", "key": "new" } },
+                "issuetype": { "name": "Task" },
+                "project": { "key": "PROJ" },
+                "customfield_10001": { "id": "team-uuid-alpha", "name": "Platform Team" }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(config_dir.path().join("jr")).unwrap();
+    std::fs::write(
+        config_dir.path().join("jr/config.toml"),
+        "[fields]\nteam_field_id = \"customfield_10001\"\n",
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .args(["issue", "view", "PROJ-702", "--no-input"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    assert!(
+        stdout.contains("team-uuid-alpha"),
+        "table output must include the extracted team UUID; stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Team"),
+        "table output must include a Team row label; stdout: {stdout}"
+    );
+    assert!(
+        !stderr.contains("unexpected shape"),
+        "no warning should fire on the valid object shape; stderr: {stderr}"
     );
 }
 

--- a/tests/team_object_shape.rs
+++ b/tests/team_object_shape.rs
@@ -1,0 +1,94 @@
+//! End-to-end coverage for the Atlas Teams object shape on the team custom
+//! field (#254). Proves that `jr issue view KEY --output json` preserves the
+//! full `{"id": "...", "name": "..."}` object when a tenant returns the
+//! object form of the Team field — Task 1 widened `IssueFields::team_id` to
+//! accept both the scalar UUID and the object shape, and this test locks in
+//! the end-to-end contract so a regression in deserialization, JSON
+//! serialization, or the once-per-process warning path would surface here.
+//!
+//! Conventions match `tests/issue_view_errors.rs` — plain `#[tokio::test]`,
+//! the `JR_BASE_URL` / `JR_AUTH_HEADER` env pattern, and `XDG_CONFIG_HOME` +
+//! `XDG_CACHE_HOME` tempdirs for isolation. The `/rest/api/3/field` stub is
+//! belt-and-braces: `handle_view` calls `get_or_fetch_cmdb_fields(...)
+//! .unwrap_or_default()`, so a cache miss that falls through to the live
+//! endpoint is already tolerated, but mocking keeps the test resilient if
+//! that swallow is ever removed.
+
+#[allow(dead_code)]
+mod common;
+
+use assert_cmd::Command;
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn issue_view_json_extracts_team_uuid_from_object_shape() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/field"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Value::Array(vec![])))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/PROJ-700"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "key": "PROJ-700",
+            "fields": {
+                "summary": "test",
+                "status": { "name": "To Do", "statusCategory": { "name": "To Do", "key": "new" } },
+                "issuetype": { "name": "Task" },
+                "project": { "key": "PROJ" },
+                "customfield_10001": { "id": "team-uuid-alpha", "name": "Platform Team" }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(config_dir.path().join("jr")).unwrap();
+    std::fs::write(
+        config_dir.path().join("jr/config.toml"),
+        "[fields]\nteam_field_id = \"customfield_10001\"\n",
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .args([
+            "issue",
+            "view",
+            "PROJ-700",
+            "--output",
+            "json",
+            "--no-input",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let parsed: Value = serde_json::from_str(&stdout).expect("valid JSON");
+
+    assert_eq!(
+        parsed["fields"]["customfield_10001"]["id"], "team-uuid-alpha",
+        "team field must be preserved in JSON output as object with .id"
+    );
+    assert!(
+        !stderr.contains("unexpected shape"),
+        "warning about unexpected shape must not fire on object-shape response; stderr: {stderr}"
+    );
+}

--- a/tests/team_object_shape.rs
+++ b/tests/team_object_shape.rs
@@ -92,3 +92,71 @@ async fn issue_view_json_extracts_team_uuid_from_object_shape() {
         "warning about unexpected shape must not fire on object-shape response; stderr: {stderr}"
     );
 }
+
+#[tokio::test]
+async fn issue_view_verbose_warns_on_truly_unexpected_team_shape() {
+    // Covers the warning-emission branch end-to-end. A numeric `id` is a
+    // genuinely unexpected shape (Atlassian documents `id` as a string UUID),
+    // and `jr --verbose issue view` should surface the diagnostic text on
+    // stderr with no retry/crash.
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/field"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Value::Array(vec![])))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/PROJ-701"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "key": "PROJ-701",
+            "fields": {
+                "summary": "test",
+                "status": { "name": "To Do", "statusCategory": { "name": "To Do", "key": "new" } },
+                "issuetype": { "name": "Task" },
+                "project": { "key": "PROJ" },
+                "customfield_10001": { "id": 42, "name": "Numeric Team" }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(config_dir.path().join("jr")).unwrap();
+    std::fs::write(
+        config_dir.path().join("jr/config.toml"),
+        "[fields]\nteam_field_id = \"customfield_10001\"\n",
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        // Table output — the `team_id()` extraction happens in the table
+        // render path (src/cli/issue/list.rs:983). The JSON path just
+        // re-serializes the raw value and would bypass the warning branch.
+        .args(["--verbose", "issue", "view", "PROJ-701", "--no-input"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected success (unexpected shape is a warning, not a fatal error), stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("unexpected shape"),
+        "verbose run should surface the warning; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Expected string UUID or object with string"),
+        "warning should hint at accepted shapes; stderr: {stderr}"
+    );
+}

--- a/tests/team_object_shape.rs
+++ b/tests/team_object_shape.rs
@@ -32,7 +32,7 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
-async fn issue_view_json_extracts_team_uuid_from_object_shape() {
+async fn issue_view_json_preserves_team_object_shape_without_warning() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))


### PR DESCRIPTION
## Summary

Closes #254. `IssueFields::team_id` now accepts Jira's Team custom field in both of its documented shapes:

- Scalar string UUID: `"customfield_10001": "team-uuid-abc"` (legacy / some tenants)
- Object: `"customfield_10001": {"id": "team-uuid-abc", "name": "Platform Team"}` (Atlas Teams platform)

Before: tenants using the Atlas Teams platform silently lost the team row from `issue view`, the team column from `issue list` / `sprint view` / `board view`, and saw a misleading `[verbose]` warning blaming their config.

## Validation

Validated against Atlassian developer documentation (`developer.atlassian.com/platform/teams/components/team-field-in-jira-rest-api`): the Team custom field returns an object on GET in tenants using the Atlas Teams platform, not a scalar UUID. Both shapes are valid responses — shape is tenant- and configuration-dependent.

## Changes

- `src/types/jira/issue.rs` — `team_id` extracts `id` from either scalar string or `{"id": "<uuid>", ...}` object. MSRV-safe Option chaining (`as_object().and_then(...).and_then(...)`) — no let-chains. Verbose warning text updated to drop the misleading "Check team_field_id in config" and "expected string UUID" claims; now reads `[verbose] team field "<id>" has unexpected shape (got <kind>). Expected string UUID or object with string "id".`
- Downstream callers unchanged (`src/cli/issue/list.rs:500,983`, `src/cli/sprint.rs:293`, `src/cli/board.rs:235`) — all still receive `Option<String>` UUID.
- `tests/team_object_shape.rs` — 2 wiremock integration tests: object-shape happy path (verifies `--output json` preserves the object, no warning fires) + verbose-warning-branch on truly-unexpected payload (numeric `id`).
- Unit tests: 4 new covering object shapes, 1 new pinning non-string `id`, 1 new exercising `verbose: true` code path. 1 obsolete test removed (`team_id_returns_none_for_object_value` — codified the bug).

## Local review

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` all green (528 unit + all integration)
- [x] 2 rounds of multi-agent local review (code-reviewer, pr-test-analyzer, silent-failure-hunter) — all clean on round 2
- [x] Perplexity + Atlassian developer docs confirm the object-shape claim
- [x] MSRV (1.85) verified — implementation uses only Option chaining stable since Rust 1.0

## Test plan

- [x] Object-shape Team field is preserved through `jr issue view --output json` — `issue_view_json_extracts_team_uuid_from_object_shape`
- [x] Misleading warning does NOT fire on valid object-shape tenants — same test, negative stderr assertion
- [x] `--verbose` run surfaces the warning on truly-unexpected shapes (numeric `id`) with the "Expected string UUID or object with string \"id\"" hint — `issue_view_verbose_warns_on_truly_unexpected_team_shape`
- [x] Object `{"id": "<uuid>"}` without `name` accepted — unit test
- [x] Object `{"id": null}` and `{"name": "..."}` still return `None` — unit tests
- [x] Scalar string UUID path preserved (regression) — pre-existing unit test retained