### PR TITLE
fix(auth): propagate Config::load errors in oauth login (#258)

### DIFF
--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -215,7 +215,8 @@ pub async fn login_oauth(
     let mut config = Config::load().map_err(|err| {
         JrError::ConfigError(format!(
             "Failed to load config: {err:#}\n\n\
-             Fix the error in {config_path}, or remove the file to start fresh.",
+             Fix or remove the file referenced above. Global config: {config_path}; \
+             per-project overrides come from `.jr.toml` in the current directory or any parent.",
             config_path = config_path.display()
         ))
     })?;

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -203,7 +203,21 @@ pub async fn login_oauth(
     // [instance].oauth_scopes (empty/whitespace-only) must fail fast, not
     // leave new client_id/client_secret in the keychain alongside a login
     // that never succeeded.
-    let mut config = Config::load().unwrap_or_default();
+    //
+    // Propagate load errors (malformed TOML, permission denied, etc.)
+    // instead of falling back to defaults. Falling back would cause the
+    // subsequent `save_global()` to overwrite the user's broken-but-
+    // recoverable config with a default payload, silently discarding
+    // settings they cared about (#258). figment's `Toml::file` already
+    // treats a missing file as empty, so a genuinely-absent config never
+    // reaches this error path — only real failures do.
+    let mut config = Config::load().map_err(|err| {
+        JrError::ConfigError(format!(
+            "Failed to load config: {err}\n\n\
+             Fix the error in your config file (usually ~/.config/jr/config.toml), \
+             or remove the file to start fresh."
+        ))
+    })?;
     let scopes = resolve_oauth_scopes(&config)?;
 
     // Store OAuth app credentials in keychain (only after scopes validate)

--- a/src/cli/auth.rs
+++ b/src/cli/auth.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use dialoguer::{Input, Password};
 
 use crate::api::auth;
-use crate::config::Config;
+use crate::config::{Config, global_config_path};
 use crate::error::JrError;
 use crate::output;
 
@@ -211,11 +211,12 @@ pub async fn login_oauth(
     // settings they cared about (#258). figment's `Toml::file` already
     // treats a missing file as empty, so a genuinely-absent config never
     // reaches this error path — only real failures do.
+    let config_path = global_config_path();
     let mut config = Config::load().map_err(|err| {
         JrError::ConfigError(format!(
-            "Failed to load config: {err}\n\n\
-             Fix the error in your config file (usually ~/.config/jr/config.toml), \
-             or remove the file to start fresh."
+            "Failed to load config: {err:#}\n\n\
+             Fix the error in {config_path}, or remove the file to start fresh.",
+            config_path = config_path.display()
         ))
     })?;
     let scopes = resolve_oauth_scopes(&config)?;

--- a/tests/auth_login_config_errors.rs
+++ b/tests/auth_login_config_errors.rs
@@ -39,9 +39,12 @@ fn auth_login_oauth_surfaces_malformed_config_without_overwriting() {
         .env("XDG_CACHE_HOME", cache_dir.path())
         .env("XDG_CONFIG_HOME", config_dir.path())
         .env("JR_SERVICE_NAME", "jr-jira-cli-test")
-        // env_remove to avoid figment picking up parent-shell JR_INSTANCE_*
-        // values that would let Config::load succeed by overriding the bad
-        // file with env values.
+        // Defense-in-depth env hygiene. Figment's extract() is fatal on a
+        // TOML parse error, so the malformed global config above will fail
+        // load regardless of JR_INSTANCE_* values in the parent shell. We
+        // still clear them so this test stays correct if the failure case
+        // is later broadened to valid-but-schema-wrong configs, where env
+        // vars WOULD contribute to the merged Config.
         .env_remove("JR_INSTANCE_URL")
         .env_remove("JR_INSTANCE_AUTH_METHOD")
         .env_remove("JR_INSTANCE_OAUTH_SCOPES")

--- a/tests/auth_login_config_errors.rs
+++ b/tests/auth_login_config_errors.rs
@@ -1,0 +1,88 @@
+//! Pin that `jr auth login --oauth` surfaces malformed-config errors
+//! instead of silently overwriting the broken file with defaults (#258).
+//!
+//! Before the fix: `src/cli/auth.rs` used `Config::load().unwrap_or_default()`,
+//! which swallowed TOML parse errors, permission errors, etc. The subsequent
+//! `save_global()` then wrote a `Config::default()` payload over the broken
+//! file, silently discarding the user's settings (story-points field id,
+//! team field id, etc.).
+//!
+//! After the fix: `Config::load()?` propagates, wrapped in
+//! `JrError::ConfigError` for exit code 78 + an actionable message.
+
+#[allow(dead_code)]
+mod common;
+
+use assert_cmd::Command;
+
+#[test]
+fn auth_login_oauth_surfaces_malformed_config_without_overwriting() {
+    // Arrange: write a malformed TOML file to the config dir and capture
+    // its contents so we can assert it's unchanged after the command runs.
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    let jr_dir = config_dir.path().join("jr");
+    std::fs::create_dir_all(&jr_dir).unwrap();
+    let config_path = jr_dir.join("config.toml");
+    // Intentionally malformed: unclosed table header.
+    let malformed = "[unclosed\nbad = \n";
+    std::fs::write(&config_path, malformed).unwrap();
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .env("JR_SERVICE_NAME", "jr-jira-cli-test")
+        // env_remove to avoid figment picking up parent-shell JR_INSTANCE_*
+        // values that would let Config::load succeed by overriding the bad
+        // file with env values.
+        .env_remove("JR_INSTANCE_URL")
+        .env_remove("JR_INSTANCE_AUTH_METHOD")
+        .env_remove("JR_INSTANCE_OAUTH_SCOPES")
+        .env_remove("JR_INSTANCE_CLOUD_ID")
+        .args([
+            "auth",
+            "login",
+            "--oauth",
+            "--client-id",
+            "test-client-id",
+            "--client-secret",
+            "test-client-secret",
+            "--no-input",
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Exit non-zero with ConfigError exit code (78) so scripts can branch.
+    assert!(
+        !output.status.success(),
+        "malformed config must fail the command, stdout: {stdout}, stderr: {stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(78),
+        "malformed config should exit 78 (ConfigError), got: {:?}, stderr: {stderr}",
+        output.status.code()
+    );
+
+    // Error message must surface the underlying parse failure so users can
+    // find and fix the broken TOML.
+    assert!(
+        stderr.to_lowercase().contains("toml") || stderr.to_lowercase().contains("parse"),
+        "stderr should surface the TOML parse error: {stderr}"
+    );
+
+    // The malformed file on disk must be unchanged — the bug was that a
+    // successful `save_global()` overwrote it with defaults, silently
+    // deleting the user's other config.
+    let after = std::fs::read_to_string(&config_path).unwrap();
+    assert_eq!(
+        after, malformed,
+        "config file must not be overwritten when load fails"
+    );
+
+    assert!(!stderr.contains("panic"), "stderr leaked a panic: {stderr}");
+}

--- a/tests/auth_login_config_errors.rs
+++ b/tests/auth_login_config_errors.rs
@@ -21,6 +21,11 @@ fn auth_login_oauth_surfaces_malformed_config_without_overwriting() {
     // its contents so we can assert it's unchanged after the command runs.
     let cache_dir = tempfile::tempdir().unwrap();
     let config_dir = tempfile::tempdir().unwrap();
+    // Pristine working directory so Config::load()'s upward walk for a
+    // per-project `.jr.toml` cannot pick up an unrelated file on the
+    // developer's machine and turn the test's intended global-config
+    // failure into a project-config failure (or a silent pass).
+    let cwd_dir = tempfile::tempdir().unwrap();
     let jr_dir = config_dir.path().join("jr");
     std::fs::create_dir_all(&jr_dir).unwrap();
     let config_path = jr_dir.join("config.toml");
@@ -30,6 +35,7 @@ fn auth_login_oauth_surfaces_malformed_config_without_overwriting() {
 
     let output = Command::cargo_bin("jr")
         .unwrap()
+        .current_dir(cwd_dir.path())
         .env("XDG_CACHE_HOME", cache_dir.path())
         .env("XDG_CONFIG_HOME", config_dir.path())
         .env("JR_SERVICE_NAME", "jr-jira-cli-test")


### PR DESCRIPTION
## Summary

Closes #258. `jr auth login --oauth` previously did `Config::load().unwrap_or_default()`, which swallowed malformed-TOML, permission, and deserialization errors. The subsequent `save_global()` then wrote a `Config::default()` payload over the user's broken-but-recoverable config — silently discarding their `[fields]`, `[instance].team_field_id`, story-points field id, and any other settings they had.

Now: `Config::load()` errors are mapped to `JrError::ConfigError` (exit code 78) with an actionable message that cites the config path and offers two recovery options. The command exits **before** reaching `save_global()` or the keychain write, so the broken file stays on disk for the user to fix.

## Validation

The issue suggested a `std::io::ErrorKind::NotFound` fallback, but empirical testing (`figment 0.10` + `Toml::file`) confirmed figment treats missing files as empty by design — only malformed TOML, permission errors, and deserialization failures reach the error path. Direct propagation is both correct and simpler than the suggested downcast.

## Scope

Single `.unwrap_or_default()` call site audited — `src/cli/auth.rs:206` was the only one in the codebase. All other `Config::load()` call sites (`src/main.rs`, `src/cli/init.rs`, `src/cli/team.rs`, `src/cli/auth.rs:225,290`) already use `?` propagation. No broader pass needed.

## Test plan

- [x] Integration test `auth_login_oauth_surfaces_malformed_config_without_overwriting` (tests/auth_login_config_errors.rs):
  - Writes malformed TOML to `\$XDG_CONFIG_HOME/jr/config.toml`
  - Invokes `jr auth login --oauth --client-id ... --client-secret ... --no-input`
  - Asserts exit code 78 (`ConfigError`)
  - Asserts stderr surfaces the underlying parse error
  - Asserts the config file on disk is **byte-identical** to the malformed input (the core #258 regression vector)
  - Asserts no panic leaked to stderr
- [x] Pre-existing tests all pass (528 unit + full integration suite)
- [x] fmt + clippy -D warnings + full cargo test all green

## Local review

- [x] 3 multi-agent reviews (code-reviewer, pr-test-analyzer, silent-failure-hunter) — all clean on the core contract
- [x] Perplexity-validated the figment `Toml::file` behavior (missing vs malformed)
- [x] Empirical probe confirmed missing-file returns Ok, malformed returns Err

## Deferred observations from review (not blocking)

- Keychain-not-written end-to-end assertion: contract holds by construction (load-first ordering is pinned by the `?` at line 206, before `store_oauth_app_credentials`); keychain-backed test would add coupling to keyring internals.
- JSON error-shape parity for `--output json`: codebase-wide concern, out of scope for this bug fix.
- Config-error message path uses "usually ~/.config/jr/config.toml" rather than the resolved `XDG_CONFIG_HOME` path — hedged with "usually"; threading the resolved path would require refactoring `Config::load`. Low-value polish.