### PR TITLE
test(partial_match): lock exit-64 rejection across remaining call sites (#240)

### DIFF
--- a/src/cli/issue/helpers.rs
+++ b/src/cli/issue/helpers.rs
@@ -122,11 +122,12 @@ pub(super) async fn resolve_team_field(
                     .iter()
                     .map(|t| format!("  {} (id: {})", t.name, t.id))
                     .collect();
-                anyhow::bail!(
+                return Err(JrError::UserError(format!(
                     "Multiple teams named \"{}\" found:\n{}\nUse a more specific name.",
                     team_name,
                     lines.join("\n")
-                );
+                ))
+                .into());
             }
 
             let labels: Vec<String> = duplicates
@@ -143,11 +144,12 @@ pub(super) async fn resolve_team_field(
         crate::partial_match::MatchResult::Ambiguous(matches) => {
             if no_input {
                 let quoted: Vec<String> = matches.iter().map(|m| format!("\"{}\"", m)).collect();
-                anyhow::bail!(
+                return Err(JrError::UserError(format!(
                     "Multiple teams match \"{}\": {}. Use a more specific name.",
                     team_name,
                     quoted.join(", ")
-                );
+                ))
+                .into());
             }
             let selection = dialoguer::Select::new()
                 .with_prompt(format!("Multiple teams match \"{team_name}\""))
@@ -165,16 +167,18 @@ pub(super) async fn resolve_team_field(
             // Any fresh fetch this call (cold-cache or retry) means advising
             // "run jr team list --refresh" would be misleading — we just did.
             if fetched_fresh {
-                anyhow::bail!(
+                return Err(JrError::UserError(format!(
                     "No team matching \"{}\" (checked a fresh team list). \
                      Verify the team name or check access permissions.",
                     team_name
-                );
+                ))
+                .into());
             }
-            anyhow::bail!(
+            Err(JrError::UserError(format!(
                 "No team matching \"{}\". Run \"jr team list --refresh\" to update.",
                 team_name
-            );
+            ))
+            .into())
         }
     }
 }
@@ -241,7 +245,7 @@ fn disambiguate_user(
     none_msg_fn: impl Fn(&[String]) -> String,
 ) -> Result<(String, String)> {
     if users.is_empty() {
-        anyhow::bail!("{}", empty_msg);
+        return Err(JrError::UserError(empty_msg.to_string()).into());
     }
 
     if users.len() == 1 {
@@ -280,11 +284,12 @@ fn disambiguate_user(
                         }
                     })
                     .collect();
-                anyhow::bail!(
+                return Err(JrError::UserError(format!(
                     "Multiple users named \"{}\" found:\n{}\nSpecify the accountId directly or use a more specific name.",
                     name,
                     lines.join("\n")
-                );
+                ))
+                .into());
             }
 
             let labels: Vec<String> = duplicates
@@ -306,11 +311,12 @@ fn disambiguate_user(
         }
         crate::partial_match::MatchResult::Ambiguous(matches) => {
             if no_input {
-                anyhow::bail!(
+                return Err(JrError::UserError(format!(
                     "Multiple users match \"{}\": {}. Use a more specific name.",
                     name,
                     matches.join(", ")
-                );
+                ))
+                .into());
             }
             let selection = dialoguer::Select::new()
                 .with_prompt(format!("Multiple users match \"{name}\""))
@@ -328,7 +334,7 @@ fn disambiguate_user(
             ))
         }
         crate::partial_match::MatchResult::None(all_names) => {
-            anyhow::bail!("{}", none_msg_fn(&all_names));
+            Err(JrError::UserError(none_msg_fn(&all_names)).into())
         }
     }
 }
@@ -483,10 +489,11 @@ pub(super) async fn resolve_asset(
         .await?;
 
     if results.is_empty() {
-        anyhow::bail!(
+        return Err(JrError::UserError(format!(
             "No assets matching \"{}\" found. Check the name and try again.",
             input
-        );
+        ))
+        .into());
     }
 
     if results.len() == 1 {
@@ -516,11 +523,12 @@ pub(super) async fn resolve_asset(
                     .iter()
                     .map(|a| format!("  {} ({})", a.object_key, a.label))
                     .collect();
-                anyhow::bail!(
+                return Err(JrError::UserError(format!(
                     "Multiple assets match \"{}\":\n{}\nUse a more specific name or pass the object key directly.",
                     input,
                     lines.join("\n")
-                );
+                ))
+                .into());
             }
 
             let items: Vec<String> = duplicates
@@ -545,11 +553,12 @@ pub(super) async fn resolve_asset(
                     .iter()
                     .map(|a| format!("  {} ({})", a.object_key, a.label))
                     .collect();
-                anyhow::bail!(
+                return Err(JrError::UserError(format!(
                     "Multiple assets match \"{}\":\n{}\nUse a more specific name or pass the object key directly.",
                     input,
                     lines.join("\n")
-                );
+                ))
+                .into());
             }
 
             let items: Vec<String> = filtered
@@ -571,11 +580,12 @@ pub(super) async fn resolve_asset(
                 .iter()
                 .map(|a| format!("  {} ({})", a.object_key, a.label))
                 .collect();
-            anyhow::bail!(
+            Err(JrError::UserError(format!(
                 "No assets with a name matching \"{}\" found. Similar results:\n{}\nUse the object key directly.",
                 input,
                 lines.join("\n")
-            );
+            ))
+            .into())
         }
     }
 }

--- a/tests/assets.rs
+++ b/tests/assets.rs
@@ -1471,7 +1471,7 @@ async fn schema_single_substring_schema_filter_rejected() {
     );
 }
 
-// ── partial_match single-substring rejection (#240) — helpers.rs sites ──
+// ── partial_match single-substring rejection (#240) — helpers.rs and assets.rs sites ──
 
 /// `issue list --asset <substring>` must exit 64 when the substring matches
 /// multiple asset labels. Locks `helpers::resolve_asset`'s Ambiguous branch

--- a/tests/assets.rs
+++ b/tests/assets.rs
@@ -1470,3 +1470,320 @@ async fn schema_single_substring_schema_filter_rejected() {
         "Expected matched schema 'ITSM' in stderr: {stderr}"
     );
 }
+
+// ── partial_match single-substring rejection (#240) — helpers.rs sites ──
+
+/// `issue list --asset <substring>` must exit 64 when the substring matches
+/// multiple asset labels. Locks `helpers::resolve_asset`'s Ambiguous branch
+/// after #240's refactor to `JrError::UserError`.
+///
+/// Flow: `Acme` is not a SCHEMA-NUMBER key, so it takes the AQL-search path
+/// → workspace discovery → search_assets returns two assets whose labels
+/// both contain "Acme" → `partial_match` routes through Ambiguous. No JQL
+/// search for issues fires.
+#[tokio::test]
+async fn issue_list_asset_substring_rejected() {
+    let server = MockServer::start().await;
+
+    // Workspace discovery
+    Mock::given(method("GET"))
+        .and(path("/rest/servicedeskapi/assets/workspace"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "size": 1, "start": 0, "limit": 50, "isLastPage": true,
+            "values": [{ "workspaceId": "ws-123" }]
+        })))
+        .mount(&server)
+        .await;
+
+    // AQL search — both results share the "Acme" substring, neither is an
+    // exact match. Routes through MatchResult::Ambiguous.
+    Mock::given(method("POST"))
+        .and(path("/jsm/assets/workspace/ws-123/v1/object/aql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "startAt": 0, "maxResults": 25, "total": 2, "isLast": true,
+            "values": [
+                {
+                    "id": "80",
+                    "label": "Acme Corp HQ",
+                    "objectKey": "OBJ-80",
+                    "objectType": { "id": "13", "name": "Client" }
+                },
+                {
+                    "id": "81",
+                    "label": "Acme Corp EU",
+                    "objectKey": "OBJ-81",
+                    "objectType": { "id": "13", "name": "Client" }
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    // Assert no issue search fires — asset resolution must short-circuit.
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/search/jql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "issues": [], "nextPageToken": null
+        })))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let _guard = set_cache_dir(cache_dir.path()).await;
+
+    // Isolate config so no parent `.jr.toml` leaks in (e.g. dev-shell project).
+    let project_dir = tempfile::tempdir().unwrap();
+    std::fs::write(project_dir.path().join(".jr.toml"), "project = \"PROJ\"\n").unwrap();
+
+    let output = assert_cmd::Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .current_dir(project_dir.path())
+        .args(["--no-input", "issue", "list", "--asset", "Acme"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "Expected failure on ambiguous asset substring, stderr: {stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "Ambiguous asset should exit 64 (UserError), got: {:?}",
+        output.status.code()
+    );
+    assert!(
+        stderr.contains("Multiple assets match"),
+        "Expected 'Multiple assets match' in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Acme Corp HQ"),
+        "Expected candidate 'Acme Corp HQ' in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Acme Corp EU"),
+        "Expected candidate 'Acme Corp EU' in stderr: {stderr}"
+    );
+}
+
+/// `assets tickets <key> --status <substring>` must exit 64 when the
+/// substring matches multiple distinct status names. Locks the
+/// `filter_tickets` Ambiguous branch at `src/cli/assets.rs:336` after #240
+/// (this site already used `JrError::UserError` pre-refactor).
+#[tokio::test]
+async fn assets_tickets_status_substring_rejected() {
+    let server = MockServer::start().await;
+
+    // Workspace discovery
+    Mock::given(method("GET"))
+        .and(path("/rest/servicedeskapi/assets/workspace"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "size": 1, "start": 0, "limit": 50, "isLastPage": true,
+            "values": [{ "workspaceId": "ws-123" }]
+        })))
+        .mount(&server)
+        .await;
+
+    // resolve_object_key: non-numeric key → AQL search by Key.
+    Mock::given(method("POST"))
+        .and(path("/jsm/assets/workspace/ws-123/v1/object/aql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "startAt": 0, "maxResults": 1, "total": 1, "isLast": true,
+            "values": [{
+                "id": "70",
+                "label": "Acme Corp",
+                "objectKey": "OBJ-70",
+                "objectType": { "id": "13", "name": "Client" }
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    // Connected tickets endpoint: two tickets whose status names both
+    // contain "Prog" as a substring ("In Progress" and "Progressing").
+    // Neither is an exact match → MatchResult::Ambiguous.
+    Mock::given(method("GET"))
+        .and(path(
+            "/jsm/assets/workspace/ws-123/v1/objectconnectedtickets/70/tickets",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "tickets": [
+                {
+                    "key": "PROJ-1",
+                    "id": "1001",
+                    "title": "Ticket one",
+                    "status": { "name": "In Progress", "colorName": "yellow" },
+                    "type": { "name": "Task" },
+                    "priority": { "name": "Medium" }
+                },
+                {
+                    "key": "PROJ-2",
+                    "id": "1002",
+                    "title": "Ticket two",
+                    "status": { "name": "Progressing", "colorName": "yellow" },
+                    "type": { "name": "Task" },
+                    "priority": { "name": "Medium" }
+                }
+            ],
+            "allTicketsQuery": "issueFunction in assetsObject(\"objectId = 70\")"
+        })))
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let _guard = set_cache_dir(cache_dir.path()).await;
+
+    let output = assert_cmd::Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args([
+            "--no-input",
+            "assets",
+            "tickets",
+            "OBJ-70",
+            "--status",
+            "Prog",
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "Expected failure on ambiguous status substring, stderr: {stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "Ambiguous ticket status should exit 64 (UserError), got: {:?}",
+        output.status.code()
+    );
+    assert!(
+        stderr.contains("Ambiguous status"),
+        "Expected 'Ambiguous status' in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("In Progress"),
+        "Expected candidate 'In Progress' in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Progressing"),
+        "Expected candidate 'Progressing' in stderr: {stderr}"
+    );
+}
+
+/// `assets schema <type_substring>` must exit 64 when the substring matches
+/// multiple object-type names. Locks `handle_schema`'s partial_match
+/// Ambiguous branch at `src/cli/assets.rs:669` (already uses UserError
+/// pre-#240, so this locks the existing exit-64 contract against regression).
+///
+/// Flow: two object types across a single schema share the "Serv" substring.
+/// Passing `Serv` as the type name routes through `MatchResult::Ambiguous`
+/// → `ambiguous_type_error` with schema-labeled candidates. No per-type
+/// attribute fetch fires.
+#[tokio::test]
+async fn assets_schema_type_substring_rejected() {
+    let server = MockServer::start().await;
+
+    // Workspace discovery
+    Mock::given(method("GET"))
+        .and(path("/rest/servicedeskapi/assets/workspace"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "size": 1, "start": 0, "limit": 50, "isLastPage": true,
+            "values": [{ "workspaceId": "ws-123" }]
+        })))
+        .mount(&server)
+        .await;
+
+    // Schemas list
+    Mock::given(method("GET"))
+        .and(path("/jsm/assets/workspace/ws-123/v1/objectschema/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "startAt": 0, "maxResults": 25, "total": 1, "isLast": true,
+            "values": [{
+                "id": "6", "name": "ITSM", "objectSchemaKey": "ITSM",
+                "status": "Ok", "objectCount": 95, "objectTypeCount": 2
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    // Object-type listing for schema 6 — two types both contain the "Serv"
+    // substring but neither is an exact match → Ambiguous.
+    Mock::given(method("GET"))
+        .and(path(
+            "/jsm/assets/workspace/ws-123/v1/objectschema/6/objecttypes/flat",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {
+                "id": "50", "name": "Service", "position": 0,
+                "objectCount": 10, "objectSchemaId": "6",
+                "inherited": false, "abstractObjectType": false
+            },
+            {
+                "id": "51", "name": "Server", "position": 1,
+                "objectCount": 20, "objectSchemaId": "6",
+                "inherited": false, "abstractObjectType": false
+            }
+        ])))
+        .mount(&server)
+        .await;
+
+    // Per-type attribute fetch must NOT fire — resolution short-circuits.
+    Mock::given(method("GET"))
+        .and(path(
+            "/jsm/assets/workspace/ws-123/v1/objecttype/50/attributes",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .expect(0)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/jsm/assets/workspace/ws-123/v1/objecttype/51/attributes",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let _guard = set_cache_dir(cache_dir.path()).await;
+
+    let output = assert_cmd::Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["--no-input", "assets", "schema", "Serv"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "Expected failure on ambiguous type substring, stderr: {stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "Ambiguous object type should exit 64 (UserError), got: {:?}",
+        output.status.code()
+    );
+    assert!(
+        stderr.contains("Ambiguous type"),
+        "Expected 'Ambiguous type' in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Service"),
+        "Expected candidate 'Service' in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Server"),
+        "Expected candidate 'Server' in stderr: {stderr}"
+    );
+}

--- a/tests/assets.rs
+++ b/tests/assets.rs
@@ -1532,14 +1532,16 @@ async fn issue_list_asset_substring_rejected() {
     let cache_dir = tempfile::tempdir().unwrap();
     let _guard = set_cache_dir(cache_dir.path()).await;
 
-    // Isolate config so no parent `.jr.toml` leaks in (e.g. dev-shell project).
+    // Isolate cwd, global, and project configs so no dev-machine state leaks.
     let project_dir = tempfile::tempdir().unwrap();
     std::fs::write(project_dir.path().join(".jr.toml"), "project = \"PROJ\"\n").unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
 
     let output = assert_cmd::Command::cargo_bin("jr")
         .unwrap()
         .env("JR_BASE_URL", server.uri())
         .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CONFIG_HOME", config_dir.path())
         .current_dir(project_dir.path())
         .args(["--no-input", "issue", "list", "--asset", "Acme"])
         .output()
@@ -1636,11 +1638,15 @@ async fn assets_tickets_status_substring_rejected() {
 
     let cache_dir = tempfile::tempdir().unwrap();
     let _guard = set_cache_dir(cache_dir.path()).await;
+    let config_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = tempfile::tempdir().unwrap();
 
     let output = assert_cmd::Command::cargo_bin("jr")
         .unwrap()
         .env("JR_BASE_URL", server.uri())
         .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .current_dir(cwd_dir.path())
         .args([
             "--no-input",
             "assets",
@@ -1754,11 +1760,15 @@ async fn assets_schema_type_substring_rejected() {
 
     let cache_dir = tempfile::tempdir().unwrap();
     let _guard = set_cache_dir(cache_dir.path()).await;
+    let config_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = tempfile::tempdir().unwrap();
 
     let output = assert_cmd::Command::cargo_bin("jr")
         .unwrap()
         .env("JR_BASE_URL", server.uri())
         .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .current_dir(cwd_dir.path())
         .args(["--no-input", "assets", "schema", "Serv"])
         .output()
         .unwrap();

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1617,6 +1617,134 @@ async fn test_edit_team_substring_rejects_under_no_input() {
         .stderr(predicate::str::contains("Platform Ops"));
 }
 
+/// Complements `test_edit_team_substring_rejects_under_no_input` by covering
+/// `issue list --team` through `helpers::resolve_team_field`. Cache seeds
+/// "Platform" and "Platform Ops" — substring "Platf" hits both, routing
+/// through `MatchResult::Ambiguous`. After #240's refactor of helpers.rs to
+/// `JrError::UserError`, this path must exit 64 with a disambiguation message
+/// listing every candidate and NO JQL search fired.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_list_team_substring_rejects_with_exit_64() {
+    let server = MockServer::start().await;
+
+    // No JQL search mock: the call must fail at resolve_team_field before
+    // any issue search hits the wire. Asserting 0 hits pins the
+    // short-circuit contract.
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/search/jql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "issues": [], "nextPageToken": null
+        })))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    write_test_team_cache(cache_dir.path());
+    write_test_config_with_team_field(config_dir.path());
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .current_dir(cache_dir.path())
+        .args(["--no-input", "issue", "list", "--team", "Platf"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "Expected failure on ambiguous team substring, stderr: {stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "Ambiguous team should exit 64 (UserError), got: {:?}",
+        output.status.code()
+    );
+    assert!(
+        stderr.contains("Multiple teams match"),
+        "Expected 'Multiple teams match' in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Platform Ops"),
+        "Expected candidate 'Platform Ops' in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Platform"),
+        "Expected candidate 'Platform' in stderr: {stderr}"
+    );
+}
+
+/// `issue assign <key> --to <substring>` must exit 64 when the substring
+/// matches multiple assignable users. The assignable-user search endpoint
+/// returns two active users whose display names both contain "Jane"; neither
+/// is an exact match, so `disambiguate_user` routes through
+/// `MatchResult::Ambiguous`. #240's refactor guarantees `JrError::UserError`
+/// (exit 64). The PUT assignee endpoint must NOT be hit.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_assign_user_substring_rejects_with_exit_64() {
+    let server = MockServer::start().await;
+
+    // Two active users both match substring "Jane" — routes through Ambiguous.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/user/assignable/search"))
+        .and(query_param("query", "Jane"))
+        .and(query_param("issueKey", "HDL-900"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            common::fixtures::user_search_response(vec![
+                ("acc-jane-doe", "Jane Doe", true),
+                ("acc-jane-smith", "Jane Smith", true),
+            ]),
+        ))
+        .mount(&server)
+        .await;
+
+    // No PUT assignee mock — the command must fail before any assignment.
+    Mock::given(method("PUT"))
+        .and(path("/rest/api/3/issue/HDL-900/assignee"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args(["--no-input", "issue", "assign", "HDL-900", "--to", "Jane"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "Expected failure on ambiguous user substring, stderr: {stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "Ambiguous user should exit 64 (UserError), got: {:?}",
+        output.status.code()
+    );
+    assert!(
+        stderr.contains("Multiple users match"),
+        "Expected 'Multiple users match' in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Jane Doe"),
+        "Expected candidate 'Jane Doe' in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Jane Smith"),
+        "Expected candidate 'Jane Smith' in stderr: {stderr}"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_verbose_logs_request_body_for_put() {
     let server = MockServer::start().await;

--- a/tests/cli_handler.rs
+++ b/tests/cli_handler.rs
@@ -1644,14 +1644,10 @@ async fn test_list_team_substring_rejects_with_exit_64() {
     write_test_team_cache(cache_dir.path());
     write_test_config_with_team_field(config_dir.path());
 
-    let output = Command::cargo_bin("jr")
-        .unwrap()
-        .env("JR_BASE_URL", server.uri())
-        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
-        .env("XDG_CACHE_HOME", cache_dir.path())
-        .env("XDG_CONFIG_HOME", config_dir.path())
+    let server_uri = server.uri();
+    let output = jr_cmd_with_xdg(&server_uri, cache_dir.path(), config_dir.path())
         .current_dir(cache_dir.path())
-        .args(["--no-input", "issue", "list", "--team", "Platf"])
+        .args(["issue", "list", "--team", "Platf"])
         .output()
         .unwrap();
 
@@ -1712,11 +1708,9 @@ async fn test_assign_user_substring_rejects_with_exit_64() {
         .mount(&server)
         .await;
 
-    let output = Command::cargo_bin("jr")
-        .unwrap()
-        .env("JR_BASE_URL", server.uri())
-        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
-        .args(["--no-input", "issue", "assign", "HDL-900", "--to", "Jane"])
+    let server_uri = server.uri();
+    let output = jr_cmd(&server_uri)
+        .args(["issue", "assign", "HDL-900", "--to", "Jane"])
         .output()
         .unwrap();
 


### PR DESCRIPTION
## Summary

Closes #240. Completes the substring-rejection coverage rollout (follow-on to #236). Every `partial_match` call site in the codebase now has a handler-level integration test asserting exit 64 + disambiguation text + candidate listing + short-circuit on the downstream endpoint.

## Changes

**Refactor (`src/cli/issue/helpers.rs`):** 12 `anyhow::bail!(...)` sites in `resolve_team_field`, `disambiguate_user`, and `resolve_asset` replaced with `JrError::UserError(format!(...)).into()`. Every message is byte-identical pre/post — the only semantic change is the exit code mapping (1 → 64) to unify with the other partial_match handlers (`workflow.rs`, `list.rs`, `queue.rs`, `assets.rs`) that already use `UserError`.

**Tests:** 5 new integration tests covering the remaining call sites from #240:

| Call site | Test | Command |
|---|---|---|
| `helpers.rs` team resolution | `test_list_team_substring_rejects_with_exit_64` | `jr issue list --team Platf` |
| `helpers.rs` user resolution | `test_assign_user_substring_rejects_with_exit_64` | `jr issue assign HDL-900 --to Jane` |
| `helpers.rs` asset resolution | `issue_list_asset_substring_rejected` | `jr issue list --asset Acme` |
| `assets.rs:336` status filter | `assets_tickets_status_substring_rejected` | `jr assets tickets OBJ-70 --status Prog` |
| `assets.rs:669` schema type | `assets_schema_type_substring_rejected` | `jr assets schema Serv` |

Note: issue #240 proposed `assets search --status` for test 4, but the actual `--status` call site lives under `assets tickets` (in `filter_tickets`); test was written against the real path.

Each test:
- Mounts minimal wiremock endpoints for the setup
- Invokes the real `jr` binary with a substring query that matches 2 candidates
- Asserts `exit == 64` + "Multiple ..." or "Ambiguous ..." text + both candidate names appear in stderr
- Asserts the downstream endpoint (JQL search, PUT assignee, per-type attribute fetch) was NOT hit via `.expect(0)` on the mock

## Local review

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` all green (528 unit + full integration: 908 total after the 5 new tests)
- [x] 3 multi-agent local reviewers (code-reviewer, pr-test-analyzer, silent-failure-hunter) — all clean
- [x] Message integrity confirmed — no wording or formatting changed

## Test plan

- [x] Team substring-rejection — `test_list_team_substring_rejects_with_exit_64`
- [x] User substring-rejection — `test_assign_user_substring_rejects_with_exit_64`
- [x] Asset substring-rejection — `issue_list_asset_substring_rejected`
- [x] Tickets `--status` substring-rejection — `assets_tickets_status_substring_rejected`
- [x] Schema type substring-rejection — `assets_schema_type_substring_rejected`
- [x] Pre-existing `disambiguate_*` unit tests (helpers.rs) unchanged; all 21 still pass