### PR TITLE
feat(issue): jr issue remote-link — attach Confluence/web URLs to issues (#199)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,6 +1141,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
+ "url",
  "urlencoding",
  "wiremock",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ chrono = { version = "0.4", features = ["serde"] }
 futures = { version = "0.3", default-features = false, features = ["async-await"] }
 rand = "0.9"
 urlencoding = "2"
+url = "2"
 pulldown-cmark = { version = "0.13", default-features = false }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ jr issue comment JSM-42 "customer is on the paid plan — prioritizing" --intern
 | `jr issue link KEY1 KEY2` | Link two issues (`--type blocks`, defaults to Relates) |
 | `jr issue unlink KEY1 KEY2` | Remove link(s) between issues (`--type` to filter) |
 | `jr issue link-types` | List available link types |
+| `jr issue remote-link KEY --url URL` | Attach a Confluence page or web URL (`--title` optional, defaults to URL) |
 | `jr issue assets KEY`          | Show assets linked to an issue                |
 | `jr board list` | List boards (`--project`, `--type scrum\|kanban`) |
 | `jr board view --board 42` | Show current board issues (`--board` or config, `--limit`/`--all`) |

--- a/docs/specs/issue-remote-link.md
+++ b/docs/specs/issue-remote-link.md
@@ -1,0 +1,87 @@
+# `jr issue remote-link` — link Confluence/web URLs to issues
+
+**Issue:** [#199](https://github.com/Zious11/jira-cli/issues/199)
+
+## Problem
+
+`jr issue link` only accepts two Jira issue keys and only creates issue↔issue links. Users who want to attach a Confluence page or arbitrary web URL to an issue (to render under the "Confluence pages" / "Web links" panel on the Jira UI) have no option — the current workaround is pasting the URL into the description as plaintext, which does not surface in the linked-items panel.
+
+## Validation
+
+Validated against Atlassian REST API v3 docs (`developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-remote-links/`):
+
+- **Endpoint:** `POST /rest/api/3/issue/{issueIdOrKey}/remotelink`
+- **Required body field:** `object` (the remote-link target).
+- **Minimum viable body:** `{"object": {"url": "...", "title": "..."}}`. Both `url` and `title` are needed for the link to render usefully; the API doesn't reject a missing title outright, but the UI needs it.
+- **Response:** `{"id": <number>, "self": "<url>"}` with status `201 Created` (new) or `200 OK` (update via matching `globalId`).
+- **Scope:** classic `write:jira-work` — already held by `jr`.
+- **`application.type` is informational, NOT a UI-panel selector.** The Jira UI groups remote links into "Confluence pages" vs "Web links" panels based on its own app-integration metadata, not user-supplied `type` values. This spec does not attempt to auto-route to the Confluence panel.
+- **`globalId`** acts as an upsert key. Omitted by V1 (always create a new link).
+
+## Design
+
+### Command
+
+```
+jr issue remote-link <KEY> --url <URL> [--title <TITLE>]
+```
+
+- `<KEY>`: positional, required. The Jira issue to attach the remote link to (e.g. `PROJ-123`).
+- `--url`: required. The remote URL.
+- `--title`: optional. Label shown in the Jira UI. Defaults to the URL when omitted (so scripts can create links with a single flag).
+
+`--no-input` is a no-op (no prompts — this is a pure-flag command).
+
+### Output
+
+| Mode | Shape |
+|---|---|
+| `--output json` | `{"key": "<issue>", "id": <linkId>, "url": "<url>", "title": "<title>", "self": "<atlassian-rest-url>"}` |
+| Default (table) | `Linked https://... → PROJ-123 (id: 10000)` on stdout |
+
+Exit 0 on success. On Atlassian error: surface the error body, exit 1 (or 2 for auth errors, per existing conventions).
+
+### Scope — V1
+
+- Create a remote link. That's the only operation the issue asks for.
+- **Not in V1:** list, delete, update, globalId support, auto-Confluence-icon inference. Those can be follow-up issues if wanted.
+
+### Why not extend `jr issue link`?
+
+`jr issue link KEY1 KEY2 --type X` takes two positional issue keys. Adding `--url` would make `KEY2` conditionally required and mix issue-link and remote-link semantics on one command. A separate `remote-link` subcommand is cleaner:
+
+- Different resource (`/issue/{key}/link` vs `/issue/{key}/remotelink`)
+- Different args (two keys vs one key + URL)
+- Different response shape
+
+Mirrors the `jr issue link` vs future `jr issue remote-unlink` symmetry (not implemented in V1 but leaves the namespace clean).
+
+## Files touched
+
+| Path | Change |
+|---|---|
+| `src/cli/mod.rs` | Add `IssueCommand::RemoteLink { key, url, title }` variant. |
+| `src/cli/issue/mod.rs` | Dispatch `RemoteLink` to the new handler. |
+| `src/cli/issue/links.rs` | New `handle_remote_link` function. Minimal: builds body, calls API, prints output. |
+| `src/api/jira/links.rs` | New `JiraClient::create_remote_link(key, url, title) -> Result<CreateRemoteLinkResponse>`. |
+| `src/types/jira/issue.rs` (or a new `links.rs`) | New `CreateRemoteLinkResponse { id: u64, self_url: String }` (with `#[serde(rename = "self")]`). |
+| `src/cli/issue/json_output.rs` | New `remote_link_response(key, id, url, title, self_url)` helper. |
+| `tests/issue_remote_link.rs` (new) | Wiremock integration: happy path + missing-title default + server error. |
+| `README.md` | One-line mention under the commands table. |
+
+## Testing
+
+All tests use `wiremock::MockServer` + `assert_cmd::Command::cargo_bin("jr")` per the established pattern.
+
+1. **Happy path — with title.** Mount `POST /rest/api/3/issue/PROJ-123/remotelink` returning 201 + `{"id": 10000, "self": "..."}`. Invoke `jr issue remote-link PROJ-123 --url https://example.com --title "Example"`. Assert stdout JSON has `.key`, `.id`, `.url`, `.title`, `.self`. Assert the POST body contained `{"object": {"url": "https://example.com", "title": "Example"}}`.
+2. **Happy path — title defaults to URL.** Same mock, invoke without `--title`. Assert the POST body contained `{"object": {"url": "https://example.com", "title": "https://example.com"}}` and stdout shows the URL as the title.
+3. **Server error.** Mount POST returning 400 + `{"errorMessages": ["Issue does not exist"]}`. Assert non-zero exit, stderr surfaces the error body.
+
+## Out of scope
+
+- Listing remote links (`GET /issue/{key}/remotelink`).
+- Deleting remote links.
+- `--relationship` flag (Atlassian supports it; no current user demand).
+- `--global-id` flag / upsert support.
+- Auto-detection of Confluence URLs to attach an `application.type` (confirmed no UI effect).
+- `jr issue view` rendering remote links in its output.

--- a/docs/specs/issue-remote-link.md
+++ b/docs/specs/issue-remote-link.md
@@ -37,7 +37,7 @@ jr issue remote-link <KEY> --url <URL> [--title <TITLE>]
 | Mode | Shape |
 |---|---|
 | `--output json` | `{"key": "<issue>", "id": <linkId>, "url": "<url>", "title": "<title>", "self": "<atlassian-rest-url>"}` |
-| Default (table) | `Linked https://... → PROJ-123 (id: 10000)` on stdout |
+| Default (table) | `Linked PROJ-123 → https://... (id: 10000)` on stderr (via `output::print_success`) |
 
 Exit 0 on success. On Atlassian error: surface the error body, exit 1 (or 2 for auth errors, per existing conventions).
 

--- a/docs/superpowers/plans/2026-04-23-issue-remote-link.md
+++ b/docs/superpowers/plans/2026-04-23-issue-remote-link.md
@@ -1,0 +1,409 @@
+# `jr issue remote-link` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add a `jr issue remote-link <KEY> --url <URL> [--title <TITLE>]` subcommand that attaches a remote link (URL+title) to a Jira issue via `POST /rest/api/3/issue/{key}/remotelink`. MVP — create only, no list/delete/update.
+
+**Architecture:** Mirrors the existing `jr issue link` pattern: clap enum variant in `cli/mod.rs`, dispatch in `cli/issue/mod.rs`, handler in `cli/issue/links.rs`, API wrapper in `api/jira/links.rs`, serde types in `types/jira/links.rs` (or extend existing).
+
+**Tech Stack:** reqwest (existing JiraClient), serde_json, wiremock for integration tests, clap derive.
+
+**Spec:** `docs/specs/issue-remote-link.md`
+
+---
+
+## Task 1: Add `CreateRemoteLinkResponse` type + `JiraClient::create_remote_link` wrapper
+
+**Files:**
+- Modify or add: `src/types/jira/links.rs` OR `src/types/jira/issue.rs` — whichever already exports `CreateIssueLinkResponse` / `IssueLink`. Grep first.
+- Modify: `src/api/jira/links.rs` — add `create_remote_link`.
+- Unit test: inside one of the above via `#[cfg(test)]`.
+
+- [ ] **Step 1: Write the failing unit test**
+
+In `src/api/jira/links.rs` (or wherever the module tests live), add a failing test that:
+- Uses `JiraClient::new_for_test` against a `wiremock::MockServer`.
+- Mounts `POST /rest/api/3/issue/PROJ-1/remotelink` returning status 201 with body `{"id": 10000, "self": "https://tenant.atlassian.net/rest/api/2/issue/PROJ-1/remotelink/10000"}`.
+- Asserts the request body sent was `{"object": {"url": "https://example.com", "title": "Example"}}`.
+- Asserts the deserialized `CreateRemoteLinkResponse` has `id == 10000` and `self_url == "https://..."`.
+
+Run: `cargo test --lib api::jira::links::tests` → FAIL (type + method not defined).
+
+- [ ] **Step 2: Add the type**
+
+```rust
+// in src/types/jira/issue.rs (alongside CreateIssueResponse):
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CreateRemoteLinkResponse {
+    pub id: u64,
+    #[serde(rename = "self")]
+    pub self_url: String,
+}
+```
+
+Export from `src/types/jira/mod.rs` if that file re-exports types.
+
+- [ ] **Step 3: Add the API wrapper**
+
+In `src/api/jira/links.rs`:
+
+```rust
+pub async fn create_remote_link(
+    &self,
+    issue_key: &str,
+    url: &str,
+    title: &str,
+) -> Result<CreateRemoteLinkResponse> {
+    let path = format!(
+        "/rest/api/3/issue/{}/remotelink",
+        urlencoding::encode(issue_key)
+    );
+    let body = serde_json::json!({
+        "object": { "url": url, "title": title }
+    });
+    self.post(&path, &body).await
+}
+```
+
+Match the signature style of the sibling `create_issue_link` above it.
+
+- [ ] **Step 4: Run the test, confirm green**
+
+`cargo test --lib api::jira::links::tests` → PASS.
+
+- [ ] **Step 5: Full CI set**
+
+```
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+All green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/jira/issue.rs src/api/jira/links.rs
+git commit -m "feat(api): add create_remote_link wrapper for POST /issue/{key}/remotelink"
+```
+
+---
+
+## Task 2: CLI enum variant + handler + dispatch
+
+**Files:**
+- Modify: `src/cli/mod.rs` — add `IssueCommand::RemoteLink { key, url, title }` variant.
+- Modify: `src/cli/issue/mod.rs` — dispatch `RemoteLink` to handler.
+- Modify: `src/cli/issue/links.rs` — new `handle_remote_link`.
+- Modify: `src/cli/issue/json_output.rs` — add `remote_link_response(...)` helper.
+
+- [ ] **Step 1: Read the existing `IssueCommand::Link` variant** in `src/cli/mod.rs` to match the clap attributes, long-help style, and visibility.
+
+- [ ] **Step 2: Add the variant**
+
+```rust
+/// Link a Confluence page or arbitrary web URL to an issue as a remote link.
+/// Renders under the issue's "Web links" (or "Confluence pages") panel.
+RemoteLink {
+    /// Issue key (e.g. PROJ-123).
+    key: String,
+
+    /// URL to link to.
+    #[arg(long)]
+    url: String,
+
+    /// Label shown in the Jira UI. Defaults to the URL when omitted.
+    #[arg(long)]
+    title: Option<String>,
+},
+```
+
+- [ ] **Step 3: Add dispatch in `src/cli/issue/mod.rs`**
+
+Mirror the existing `IssueCommand::Link` dispatch arm:
+
+```rust
+IssueCommand::RemoteLink { .. } => {
+    links::handle_remote_link(command, output_format, client).await
+}
+```
+
+Note: no `no_input` param — this command has no prompts.
+
+- [ ] **Step 4: Add `handle_remote_link` in `src/cli/issue/links.rs`**
+
+```rust
+pub(super) async fn handle_remote_link(
+    command: IssueCommand,
+    output_format: &OutputFormat,
+    client: &JiraClient,
+) -> Result<()> {
+    let IssueCommand::RemoteLink { key, url, title } = command else {
+        unreachable!()
+    };
+
+    // Default the title to the URL for script-friendly single-flag invocation.
+    let title = title.unwrap_or_else(|| url.clone());
+
+    let response = client.create_remote_link(&key, &url, &title).await?;
+
+    match output_format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&json_output::remote_link_response(
+                    &key,
+                    response.id,
+                    &url,
+                    &title,
+                    &response.self_url,
+                ))?
+            );
+        }
+        OutputFormat::Table => {
+            output::print_success(&format!(
+                "Linked {} → {} (id: {})",
+                url, key, response.id
+            ));
+        }
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Add `remote_link_response` helper in `src/cli/issue/json_output.rs`**
+
+```rust
+pub(super) fn remote_link_response(
+    key: &str,
+    id: u64,
+    url: &str,
+    title: &str,
+    self_url: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "key": key,
+        "id": id,
+        "url": url,
+        "title": title,
+        "self": self_url,
+    })
+}
+```
+
+- [ ] **Step 6: Full CI set**
+
+```
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cli/mod.rs src/cli/issue/mod.rs src/cli/issue/links.rs src/cli/issue/json_output.rs
+git commit -m "feat(issue): jr issue remote-link subcommand (#199)"
+```
+
+---
+
+## Task 3: Integration tests
+
+**Files:**
+- Create: `tests/issue_remote_link.rs` — new wiremock integration test file.
+
+- [ ] **Step 1: Read existing conventions**
+
+Inspect `tests/issue_commands.rs` or `tests/issue_create_json.rs` for fixture patterns — env vars, tempdir XDG isolation, `assert_cmd::Command::cargo_bin("jr")` invocation style.
+
+- [ ] **Step 2: Write 3 tests**
+
+```rust
+mod common;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use wiremock::matchers::{body_partial_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn remote_link_creates_with_explicit_title() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue/PROJ-123/remotelink"))
+        .and(body_partial_json(serde_json::json!({
+            "object": { "url": "https://example.com", "title": "Example" }
+        })))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": 10000,
+            "self": format!("{}/rest/api/2/issue/PROJ-123/remotelink/10000", server.uri())
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = tempfile::tempdir().unwrap();
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .current_dir(cwd_dir.path())
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .args([
+            "issue", "remote-link", "PROJ-123",
+            "--url", "https://example.com",
+            "--title", "Example",
+            "--output", "json",
+            "--no-input",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(parsed["key"], "PROJ-123");
+    assert_eq!(parsed["id"], 10000);
+    assert_eq!(parsed["url"], "https://example.com");
+    assert_eq!(parsed["title"], "Example");
+    assert!(parsed["self"].as_str().unwrap().ends_with("/remotelink/10000"));
+}
+
+#[tokio::test]
+async fn remote_link_defaults_title_to_url() {
+    let server = MockServer::start().await;
+
+    // Key assertion: the POST body should use the URL as the title when --title is omitted.
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue/PROJ-124/remotelink"))
+        .and(body_partial_json(serde_json::json!({
+            "object": { "url": "https://example.com/page", "title": "https://example.com/page" }
+        })))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": 10001,
+            "self": format!("{}/rest/api/2/issue/PROJ-124/remotelink/10001", server.uri())
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // ...env setup identical...
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        // env vars ...
+        .args([
+            "issue", "remote-link", "PROJ-124",
+            "--url", "https://example.com/page",
+            "--output", "json",
+            "--no-input",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let parsed: Value = serde_json::from_str(&String::from_utf8(output.stdout).unwrap()).unwrap();
+    assert_eq!(parsed["title"], "https://example.com/page");
+}
+
+#[tokio::test]
+async fn remote_link_surfaces_server_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue/PROJ-999/remotelink"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+            "errorMessages": ["Issue does not exist or you do not have permission to see it."],
+            "errors": {}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // ...env setup identical...
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        // env vars ...
+        .args([
+            "issue", "remote-link", "PROJ-999",
+            "--url", "https://example.com",
+            "--output", "json",
+            "--no-input",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "expected failure on 400");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Issue does not exist") || stderr.contains("400"),
+        "server error should be surfaced in stderr: {stderr}"
+    );
+}
+```
+
+- [ ] **Step 3: Run + iterate**
+
+`cargo test --test issue_remote_link` → all 3 pass.
+
+- [ ] **Step 4: Full CI set**
+
+```
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/issue_remote_link.rs
+git commit -m "test(issue): wiremock coverage for jr issue remote-link"
+```
+
+---
+
+## Task 4: README + help-text polish
+
+**Files:**
+- Modify: `README.md` — add one-line entry under the commands table.
+
+- [ ] **Step 1: Grep README for the commands table**
+
+`grep -n "jr issue link" README.md`. Insert `jr issue remote-link` row immediately after.
+
+- [ ] **Step 2: Verify `jr issue remote-link --help`** renders nicely.
+
+```
+cargo run -- issue remote-link --help
+```
+
+- [ ] **Step 3: Commit (only if README was touched)**
+
+```bash
+git add README.md
+git commit -m "docs: mention jr issue remote-link in commands table"
+```
+
+---
+
+## Task 5: Final checks
+
+- [ ] **Step 1: Full CI-equivalent set**
+```
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+- [ ] **Step 2: Declare done.** Branch ready for local review + PR.

--- a/docs/superpowers/plans/2026-04-23-issue-remote-link.md
+++ b/docs/superpowers/plans/2026-04-23-issue-remote-link.md
@@ -23,7 +23,7 @@
 
 In `src/api/jira/links.rs` (or wherever the module tests live), add a failing test that:
 - Uses `JiraClient::new_for_test` against a `wiremock::MockServer`.
-- Mounts `POST /rest/api/3/issue/PROJ-1/remotelink` returning status 201 with body `{"id": 10000, "self": "https://tenant.atlassian.net/rest/api/2/issue/PROJ-1/remotelink/10000"}`.
+- Mounts `POST /rest/api/3/issue/PROJ-1/remotelink` returning status 201 with body `{"id": 10000, "self": "https://tenant.atlassian.net/rest/api/3/issue/PROJ-1/remotelink/10000"}`.
 - Asserts the request body sent was `{"object": {"url": "https://example.com", "title": "Example"}}`.
 - Asserts the deserialized `CreateRemoteLinkResponse` has `id == 10000` and `self_url == "https://..."`.
 
@@ -165,7 +165,7 @@ pub(super) async fn handle_remote_link(
         OutputFormat::Table => {
             output::print_success(&format!(
                 "Linked {} → {} (id: {})",
-                url, key, response.id
+                key, url, response.id
             ));
         }
     }

--- a/src/api/jira/links.rs
+++ b/src/api/jira/links.rs
@@ -1,5 +1,5 @@
 use crate::api::client::JiraClient;
-use crate::types::jira::issue::{IssueLinkType, IssueLinkTypesResponse};
+use crate::types::jira::issue::{CreateRemoteLinkResponse, IssueLinkType, IssueLinkTypesResponse};
 use anyhow::Result;
 use serde_json::json;
 
@@ -31,5 +31,67 @@ impl JiraClient {
     pub async fn list_link_types(&self) -> Result<Vec<IssueLinkType>> {
         let resp: IssueLinkTypesResponse = self.get("/rest/api/3/issueLinkType").await?;
         Ok(resp.issue_link_types)
+    }
+
+    /// Create a remote link (e.g., web URL, Confluence page) on an issue.
+    ///
+    /// Endpoint: `POST /rest/api/3/issue/{issueIdOrKey}/remotelink`.
+    /// Minimum body is `{"object": {"url": ..., "title": ...}}`. Jira returns
+    /// `201 Created` with `{"id": <number>, "self": "<url>"}` on create, or
+    /// `200 OK` when an existing link with the same `globalId` is updated.
+    pub async fn create_remote_link(
+        &self,
+        issue_key: &str,
+        url: &str,
+        title: &str,
+    ) -> Result<CreateRemoteLinkResponse> {
+        let path = format!(
+            "/rest/api/3/issue/{}/remotelink",
+            urlencoding::encode(issue_key)
+        );
+        let body = json!({
+            "object": { "url": url, "title": title }
+        });
+        self.post(&path, &body).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_partial_json, method, path},
+    };
+
+    #[tokio::test]
+    async fn create_remote_link_posts_object_url_and_title() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/rest/api/3/issue/PROJ-1/remotelink"))
+            .and(body_partial_json(serde_json::json!({
+                "object": {
+                    "url": "https://example.com",
+                    "title": "Example"
+                }
+            })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": 10000,
+                "self": "https://example.atlassian.net/rest/api/3/issue/PROJ-1/remotelink/10000"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = JiraClient::new_for_test(server.uri(), "Basic dGVzdDp0ZXN0".to_string());
+        let resp = client
+            .create_remote_link("PROJ-1", "https://example.com", "Example")
+            .await
+            .unwrap();
+
+        assert_eq!(resp.id, 10000);
+        assert_eq!(
+            resp.self_url,
+            "https://example.atlassian.net/rest/api/3/issue/PROJ-1/remotelink/10000"
+        );
     }
 }

--- a/src/cli/issue/json_output.rs
+++ b/src/cli/issue/json_output.rs
@@ -64,6 +64,23 @@ pub(crate) fn unlink_response(unlinked: bool, count: usize) -> Value {
     })
 }
 
+/// JSON response for `issue remote-link`.
+pub(crate) fn remote_link_response(
+    key: &str,
+    id: u64,
+    url: &str,
+    title: &str,
+    self_url: &str,
+) -> Value {
+    json!({
+        "key": key,
+        "id": id,
+        "url": url,
+        "title": title,
+        "self": self_url,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -117,5 +134,16 @@ mod tests {
     #[test]
     fn test_unlink_no_match() {
         assert_json_snapshot!(unlink_response(false, 0));
+    }
+
+    #[test]
+    fn test_remote_link() {
+        assert_json_snapshot!(remote_link_response(
+            "TEST-1",
+            10000,
+            "https://example.com",
+            "Example",
+            "https://example.atlassian.net/rest/api/3/issue/TEST-1/remotelink/10000",
+        ));
     }
 }

--- a/src/cli/issue/links.rs
+++ b/src/cli/issue/links.rs
@@ -238,10 +238,34 @@ pub(super) async fn handle_remote_link(
         unreachable!()
     };
 
-    // Default the title to the URL for script-friendly single-flag use.
-    let title = title.unwrap_or_else(|| url.clone());
+    // Input validation — Jira's /remotelink endpoint accepts any string for
+    // `object.url` without verifying it's a real URL. Creating a link to
+    // "not-a-url" would succeed silently and produce a broken remote link
+    // in the Jira UI. Validate on the CLI boundary instead.
+    let url = url.trim();
+    if url.is_empty() {
+        return Err(JrError::UserError("--url must not be empty.".into()).into());
+    }
+    let parsed = url::Url::parse(url).map_err(|err| {
+        JrError::UserError(format!(
+            "--url is not a valid URL: {err}. Expected something like https://example.com/path."
+        ))
+    })?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(JrError::UserError(format!(
+            "--url must use http or https (got {:?}).",
+            parsed.scheme()
+        ))
+        .into());
+    }
 
-    let response = client.create_remote_link(&key, &url, &title).await?;
+    // Default the title to the URL for script-friendly single-flag use.
+    let title = title
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .unwrap_or_else(|| url.to_string());
+
+    let response = client.create_remote_link(&key, url, &title).await?;
 
     match output_format {
         OutputFormat::Json => {
@@ -250,14 +274,14 @@ pub(super) async fn handle_remote_link(
                 serde_json::to_string_pretty(&json_output::remote_link_response(
                     &key,
                     response.id,
-                    &url,
+                    url,
                     &title,
                     &response.self_url,
                 ))?
             );
         }
         OutputFormat::Table => {
-            output::print_success(&format!("Linked {} → {} (id: {})", url, key, response.id));
+            output::print_success(&format!("Linked {} → {} (id: {})", key, url, response.id));
         }
     }
 

--- a/src/cli/issue/links.rs
+++ b/src/cli/issue/links.rs
@@ -258,6 +258,10 @@ pub(super) async fn handle_remote_link(
         ))
         .into());
     }
+    // Use the normalized form so the API request, stdout JSON, and the table
+    // success line all agree. The raw `url: &str` may contain quirks the url
+    // crate silently normalized away (e.g. tabs/newlines stripped from path).
+    let url = parsed.as_str();
 
     // Default the title to the URL for script-friendly single-flag use.
     let title = title

--- a/src/cli/issue/links.rs
+++ b/src/cli/issue/links.rs
@@ -253,7 +253,7 @@ pub(super) async fn handle_remote_link(
     })?;
     if !matches!(parsed.scheme(), "http" | "https") {
         return Err(JrError::UserError(format!(
-            "--url must use http or https (got {:?}).",
+            "--url must use http or https (got {}).",
             parsed.scheme()
         ))
         .into());

--- a/src/cli/issue/links.rs
+++ b/src/cli/issue/links.rs
@@ -226,3 +226,40 @@ pub(super) async fn handle_unlink(
 
     Ok(())
 }
+
+// ── Remote Link ───────────────────────────────────────────────────
+
+pub(super) async fn handle_remote_link(
+    command: IssueCommand,
+    output_format: &OutputFormat,
+    client: &JiraClient,
+) -> Result<()> {
+    let IssueCommand::RemoteLink { key, url, title } = command else {
+        unreachable!()
+    };
+
+    // Default the title to the URL for script-friendly single-flag use.
+    let title = title.unwrap_or_else(|| url.clone());
+
+    let response = client.create_remote_link(&key, &url, &title).await?;
+
+    match output_format {
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&json_output::remote_link_response(
+                    &key,
+                    response.id,
+                    &url,
+                    &title,
+                    &response.self_url,
+                ))?
+            );
+        }
+        OutputFormat::Table => {
+            output::print_success(&format!("Linked {} → {} (id: {})", url, key, response.id));
+        }
+    }
+
+    Ok(())
+}

--- a/src/cli/issue/mod.rs
+++ b/src/cli/issue/mod.rs
@@ -80,6 +80,9 @@ pub async fn handle(
         IssueCommand::Unlink { .. } => {
             links::handle_unlink(command, output_format, client, no_input).await
         }
+        IssueCommand::RemoteLink { .. } => {
+            links::handle_remote_link(command, output_format, client).await
+        }
         IssueCommand::LinkTypes => links::handle_link_types(output_format, client).await,
         IssueCommand::Assets { key } => {
             assets::handle_issue_assets(&key, output_format, client).await

--- a/src/cli/issue/snapshots/jr__cli__issue__json_output__tests__remote_link.snap
+++ b/src/cli/issue/snapshots/jr__cli__issue__json_output__tests__remote_link.snap
@@ -1,0 +1,11 @@
+---
+source: src/cli/issue/json_output.rs
+expression: "remote_link_response(\"TEST-1\", 10000, \"https://example.com\", \"Example\",\n\"https://example.atlassian.net/rest/api/3/issue/TEST-1/remotelink/10000\",)"
+---
+{
+  "id": 10000,
+  "key": "TEST-1",
+  "self": "https://example.atlassian.net/rest/api/3/issue/TEST-1/remotelink/10000",
+  "title": "Example",
+  "url": "https://example.com"
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -494,6 +494,24 @@ pub enum IssueCommand {
         #[arg(long)]
         r#type: Option<String>,
     },
+    /// Link a Confluence page or arbitrary web URL to an issue as a remote link.
+    ///
+    /// Renders under the issue's "Web links" (or "Confluence pages") panel in
+    /// Jira's UI. Jira decides which panel based on its own app-integration
+    /// metadata — this command creates a plain remote link and lets Jira sort
+    /// it into the right panel.
+    RemoteLink {
+        /// Issue key (e.g. PROJ-123).
+        key: String,
+
+        /// URL to link to.
+        #[arg(long)]
+        url: String,
+
+        /// Label shown in the Jira UI. Defaults to the URL when omitted.
+        #[arg(long)]
+        title: Option<String>,
+    },
     /// List available link types
     LinkTypes,
     /// Show assets linked to an issue

--- a/src/types/jira/issue.rs
+++ b/src/types/jira/issue.rs
@@ -230,6 +230,13 @@ pub struct CreateIssueResponse {
     pub key: String,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CreateRemoteLinkResponse {
+    pub id: u64,
+    #[serde(rename = "self")]
+    pub self_url: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/issue_remote_link.rs
+++ b/tests/issue_remote_link.rs
@@ -179,15 +179,72 @@ async fn remote_link_surfaces_server_error() {
         .unwrap();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        !output.status.success(),
-        "expected failure on 400, stderr: {stderr}, stdout: {stdout}"
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "malformed-request API error should exit 1 (ApiError default), got: {:?}, stderr: {}",
+        output.status.code(),
+        stderr
     );
 
-    let lower = stderr.to_lowercase();
     assert!(
-        lower.contains("issue does not exist") || stderr.contains("400"),
-        "stderr must surface the server error (either the message or the status), got: {stderr}"
+        stderr.to_lowercase().contains("issue does not exist"),
+        "server error body should surface on stderr, got: {stderr}"
+    );
+}
+
+#[tokio::test]
+async fn remote_link_surfaces_not_authenticated_on_401() {
+    // Mirrors the 401 regression guard at tests/issue_changelog.rs:1109 —
+    // pins that unauthenticated responses route through JrError::NotAuthenticated
+    // (exit 2) with the "run jr auth login" hint, instead of a generic
+    // JrError::ApiError (exit 1).
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue/PROJ-125/remotelink"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "errorMessages": ["Authentication required"],
+            "errors": {}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = tempfile::tempdir().unwrap();
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .current_dir(cwd_dir.path())
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .args([
+            "issue",
+            "remote-link",
+            "PROJ-125",
+            "--url",
+            "https://example.com",
+            "--output",
+            "json",
+            "--no-input",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "401 should route to NotAuthenticated (exit 2), got: {:?}, stderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Not authenticated") || stderr.contains("jr auth login"),
+        "401 should surface reauth hint, got: {stderr}"
     );
 }

--- a/tests/issue_remote_link.rs
+++ b/tests/issue_remote_link.rs
@@ -1,0 +1,193 @@
+//! Integration tests for `jr issue remote-link` — issue #199.
+//!
+//! Covers the happy path (explicit title), the default-title-to-URL behavior,
+//! and server error propagation. The command POSTs to
+//! `/rest/api/3/issue/{key}/remotelink` with a body shaped like
+//! `{"object": {"url": "...", "title": "..."}}` and renders the Atlassian
+//! response (`id`, `self`) plus the caller-provided `key`/`url`/`title` in its
+//! `--output json` payload.
+
+#[allow(dead_code)]
+mod common;
+
+use assert_cmd::Command;
+use serde_json::Value;
+use wiremock::matchers::{body_partial_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn remote_link_creates_with_explicit_title() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    let cwd = tempfile::tempdir().unwrap();
+
+    let self_url = format!(
+        "{}/rest/api/3/issue/PROJ-123/remotelink/10000",
+        server.uri()
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue/PROJ-123/remotelink"))
+        .and(body_partial_json(serde_json::json!({
+            "object": {
+                "url": "https://example.com",
+                "title": "Example"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": 10000,
+            "self": self_url,
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .current_dir(cwd.path())
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .args([
+            "--no-input",
+            "issue",
+            "remote-link",
+            "PROJ-123",
+            "--url",
+            "https://example.com",
+            "--title",
+            "Example",
+            "--output",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {stderr}, stdout: {stdout}"
+    );
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(parsed["key"], "PROJ-123");
+    assert_eq!(parsed["id"], 10000);
+    assert_eq!(parsed["url"], "https://example.com");
+    assert_eq!(parsed["title"], "Example");
+    assert_eq!(parsed["self"], self_url.as_str());
+}
+
+#[tokio::test]
+async fn remote_link_defaults_title_to_url() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    let cwd = tempfile::tempdir().unwrap();
+
+    let self_url = format!(
+        "{}/rest/api/3/issue/PROJ-123/remotelink/10001",
+        server.uri()
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue/PROJ-123/remotelink"))
+        .and(body_partial_json(serde_json::json!({
+            "object": {
+                "url": "https://example.com/page",
+                "title": "https://example.com/page"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": 10001,
+            "self": self_url,
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .current_dir(cwd.path())
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .args([
+            "--no-input",
+            "issue",
+            "remote-link",
+            "PROJ-123",
+            "--url",
+            "https://example.com/page",
+            "--output",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "expected success, stderr: {stderr}, stdout: {stdout}"
+    );
+
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+    assert_eq!(
+        parsed["title"], "https://example.com/page",
+        "title must default to the URL when --title is omitted"
+    );
+    assert_eq!(parsed["url"], "https://example.com/page");
+}
+
+#[tokio::test]
+async fn remote_link_surfaces_server_error() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    let cwd = tempfile::tempdir().unwrap();
+
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/issue/PROJ-123/remotelink"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+            "errorMessages": ["Issue does not exist or you do not have permission to see it."],
+            "errors": {}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .current_dir(cwd.path())
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .args([
+            "--no-input",
+            "issue",
+            "remote-link",
+            "PROJ-123",
+            "--url",
+            "https://example.com",
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !output.status.success(),
+        "expected failure on 400, stderr: {stderr}, stdout: {stdout}"
+    );
+
+    let lower = stderr.to_lowercase();
+    assert!(
+        lower.contains("issue does not exist") || stderr.contains("400"),
+        "stderr must surface the server error (either the message or the status), got: {stderr}"
+    );
+}

--- a/tests/issue_remote_link.rs
+++ b/tests/issue_remote_link.rs
@@ -27,11 +27,14 @@ async fn remote_link_creates_with_explicit_title() {
         server.uri()
     );
 
+    // Note: the CLI normalizes URLs via `url::Url::parse` before sending, so
+    // `https://example.com` becomes `https://example.com/` (trailing slash
+    // added). The mock body + stdout assertions use the normalized form.
     Mock::given(method("POST"))
         .and(path("/rest/api/3/issue/PROJ-123/remotelink"))
         .and(body_partial_json(serde_json::json!({
             "object": {
-                "url": "https://example.com",
+                "url": "https://example.com/",
                 "title": "Example"
             }
         })))
@@ -75,7 +78,7 @@ async fn remote_link_creates_with_explicit_title() {
     let parsed: Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
     assert_eq!(parsed["key"], "PROJ-123");
     assert_eq!(parsed["id"], 10000);
-    assert_eq!(parsed["url"], "https://example.com");
+    assert_eq!(parsed["url"], "https://example.com/");
     assert_eq!(parsed["title"], "Example");
     assert_eq!(parsed["self"], self_url.as_str());
 }
@@ -246,5 +249,100 @@ async fn remote_link_surfaces_not_authenticated_on_401() {
     assert!(
         stderr.contains("Not authenticated") || stderr.contains("jr auth login"),
         "401 should surface reauth hint, got: {stderr}"
+    );
+}
+
+/// Validation guard: junk string in `--url` must exit 64 at the CLI boundary
+/// before any HTTP call is made. Mirrors the empty-input guards at
+/// `tests/issue_changelog.rs:477` — Jira's /remotelink endpoint accepts any
+/// string and would silently create a broken remote link without this check.
+#[test]
+fn remote_link_rejects_invalid_url_with_exit_64() {
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = tempfile::tempdir().unwrap();
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .current_dir(cwd_dir.path())
+        // Unreachable base URL — validation must short-circuit before any
+        // network call, so this should never be dialed.
+        .env("JR_BASE_URL", "http://127.0.0.1:1")
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .args([
+            "issue",
+            "remote-link",
+            "PROJ-1",
+            "--url",
+            "not-a-url",
+            "--no-input",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "junk --url must exit 64 (UserError), got: {:?}, stderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--url"),
+        "stderr should name the offending flag, got: {stderr}"
+    );
+    assert!(
+        stderr.to_lowercase().contains("not a valid url"),
+        "stderr should describe the failure mode, got: {stderr}"
+    );
+}
+
+/// Validation guard: the http|https scheme gate rejects URLs that parse
+/// cleanly as URLs but would render as unclickable/unsafe links in Jira
+/// (e.g. `ftp://`, `javascript:`, `file://`). Locks the `matches!(..., "http"
+/// | "https")` check so a future refactor that broadens the scheme set gets
+/// a test failure.
+#[test]
+fn remote_link_rejects_non_http_scheme_with_exit_64() {
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = tempfile::tempdir().unwrap();
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .current_dir(cwd_dir.path())
+        .env("JR_BASE_URL", "http://127.0.0.1:1")
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir.path())
+        .env("XDG_CONFIG_HOME", config_dir.path())
+        .args([
+            "issue",
+            "remote-link",
+            "PROJ-1",
+            "--url",
+            "ftp://example.com",
+            "--no-input",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "non-http scheme must exit 64 (UserError), got: {:?}, stderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("http or https"),
+        "stderr should name the accepted schemes, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("ftp"),
+        "stderr should echo the rejected scheme, got: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary

Closes #199. Adds `jr issue remote-link <KEY> --url <URL> [--title <TITLE>]` to attach arbitrary web/Confluence URLs to a Jira issue as remote links (renders under the "Web links" or "Confluence pages" panel in the Jira UI).

## Validation

Endpoint and response shape validated against Atlassian developer docs (`developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-remote-links/`) via WebFetch:

- `POST /rest/api/3/issue/{issueIdOrKey}/remotelink`
- Minimum body: `{"object":{"url":"...","title":"..."}}`
- Response: `{id, self}` with status 201 (create) or 200 (update via matching `globalId`)
- Scope: `write:jira-work` (already held)

**Design note:** The Jira UI panel routing (Confluence pages vs Web links) is not driven by user-supplied `application.type` — Atlassian docs confirm `application.type` is informational. V1 creates plain remote links and lets Jira sort them into the correct panel.

## CLI

```
jr issue remote-link PROJ-123 --url https://example.com --title "Example"
jr issue remote-link PROJ-123 --url https://example.com         # --title defaults to URL
jr issue remote-link PROJ-123 --url https://... --output json    # structured output
```

Output: stdout JSON `{"key", "id", "url", "title", "self"}` under `--output json`; `Linked PROJ-123 → https://... (id: 10000)` on stderr by default.

## Input validation (CLI boundary)

Jira's `/remotelink` endpoint silently accepts any string for `object.url` and would create broken links from junk input. jr validates on the CLI boundary instead:

- `--url` must not be empty / whitespace-only
- `--url` must parse as a valid URL (`url::Url::parse`)
- `--url` scheme must be `http` or `https` (rejects `ftp://`, `javascript:`, `file://`, …)
- `--title` trimmed + empty-fallback to URL

Invalid input exits 64 (`JrError::UserError`) with an actionable message before any HTTP call is made.

## URL normalization

After `url::Url::parse`, the downstream API request body, stdout JSON, and table success line all use `parsed.as_str()` — so quirks the `url` crate normalizes (e.g. `https://example.com` → `https://example.com/`, stripped control characters) are consistently reflected everywhere.

## Scope — V1

- Create a remote link.

**Out of scope for V1:** list / delete / update / `globalId` upsert / `--relationship` / auto-Confluence-icon inference.

## Local review

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` all green (530 unit + 6 new integration, full suite passes)
- [x] 2 rounds of multi-agent local review (code-reviewer, pr-test-analyzer, silent-failure-hunter)
- [x] WebFetch-validated Atlassian REST docs for endpoint + response shape

## Test plan

- [x] Happy path with explicit `--title` — `remote_link_creates_with_explicit_title`
- [x] `--title` defaults to URL when omitted — `remote_link_defaults_title_to_url`
- [x] 400 server error exits 1 and surfaces `errorMessages[0]` — `remote_link_surfaces_server_error`
- [x] 401 routes to `JrError::NotAuthenticated` (exit 2 + reauth hint) — `remote_link_surfaces_not_authenticated_on_401`
- [x] Junk `--url` (e.g. `"not-a-url"`) exits 64 before network — `remote_link_rejects_invalid_url_with_exit_64`
- [x] Non-http scheme (`ftp://...`) exits 64 — `remote_link_rejects_non_http_scheme_with_exit_64`
- [x] Unit: `CreateRemoteLinkResponse` round-trip + request body shape — `api::jira::links::tests::create_remote_link_posts_object_url_and_title`
- [x] Insta snapshot for JSON output helper — `cli::issue::json_output::tests::test_remote_link`