### PR TITLE
chore: bump version to 0.5.0-dev.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.5.0-dev.2"
+version = "0.5.0-dev.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.5.0-dev.2"
+version = "0.5.0-dev.3"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
Pre-release dev bump for `develop`.

## Changes since v0.5.0-dev.2

- **fix(issue):** `jr issue create --output json` returns the full Issue shape (#253, PR #265)
- **fix(team):** accept Atlas Teams object shape in `team_id` extraction (#254, PR #266)
- **fix(auth):** propagate `Config::load` errors in oauth login (#258, PR #267)
- **test(partial_match):** lock exit-64 rejection across remaining call sites (#240, PR #268)
- **feat(issue):** `jr issue remote-link` — attach Confluence/web URLs to issues (#199, PR #269)

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test` all green (530 unit + full integration)

Tag `v0.5.0-dev.3` will be created on `develop` after this PR merges; the Release workflow then builds and publishes pre-release binaries.