### PR TITLE
chore: surface silent IO errors and isolate blocking stdin from tokio runtime

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -163,7 +163,11 @@ pub async fn handle() -> Result<()> {
                     name: t.display_name,
                 })
                 .collect();
-            let _ = crate::cache::write_team_cache(&cached);
+            if let Err(err) = crate::cache::write_team_cache(&cached) {
+                eprintln!(
+                    "warning: failed to warm team cache: {err}. First `jr team list` will refetch."
+                );
+            }
         }
     }
 

--- a/src/cli/issue/create.rs
+++ b/src/cli/issue/create.rs
@@ -79,10 +79,16 @@ pub(super) async fn handle_create(
         })
         .ok_or_else(|| JrError::UserError("Summary is required. Use --summary".into()))?;
 
-    // Resolve description
+    // Resolve description. spawn_blocking isolates the blocking stdin read
+    // from the tokio runtime so later async work isn't starved while waiting
+    // on piped input.
     let desc_text = if description_stdin {
-        let mut buf = String::new();
-        std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
+        let buf = tokio::task::spawn_blocking(|| {
+            let mut buf = String::new();
+            std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
+            Ok::<_, std::io::Error>(buf)
+        })
+        .await??;
         Some(buf)
     } else {
         description
@@ -222,10 +228,14 @@ pub(super) async fn handle_edit(
     let mut fields = json!({});
     let mut has_updates = false;
 
-    // Resolve description
+    // Resolve description (see handle_create for rationale on spawn_blocking).
     let desc_text = if description_stdin {
-        let mut buf = String::new();
-        std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
+        let buf = tokio::task::spawn_blocking(|| {
+            let mut buf = String::new();
+            std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
+            Ok::<_, std::io::Error>(buf)
+        })
+        .await??;
         Some(buf)
     } else {
         description

--- a/src/cli/issue/list.rs
+++ b/src/cli/issue/list.rs
@@ -416,9 +416,19 @@ pub(super) async fn handle_list(
 
         if !to_enrich.is_empty() {
             // Get workspace ID for assets that don't carry their own.
-            let fallback_wid = crate::api::assets::workspace::get_or_fetch_workspace_id(client)
-                .await
-                .ok();
+            let fallback_wid = match crate::api::assets::workspace::get_or_fetch_workspace_id(
+                client,
+            )
+            .await
+            {
+                Ok(wid) => Some(wid),
+                Err(err) => {
+                    eprintln!(
+                        "warning: failed to fetch workspace ID for asset enrichment: {err}. Assets without embedded workspace IDs will be skipped."
+                    );
+                    None
+                }
+            };
 
             let futures: Vec<_> = to_enrich
                 .keys()

--- a/src/cli/issue/workflow.rs
+++ b/src/cli/issue/workflow.rs
@@ -578,11 +578,15 @@ pub(super) async fn handle_comment(
         unreachable!()
     };
 
-    // Resolve comment text from the various sources
+    // Resolve comment text from the various sources. spawn_blocking isolates
+    // the blocking stdin read from the tokio runtime.
     let text = if stdin {
-        let mut buf = String::new();
-        std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
-        buf
+        tokio::task::spawn_blocking(|| {
+            let mut buf = String::new();
+            std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
+            Ok::<_, std::io::Error>(buf)
+        })
+        .await??
     } else if let Some(ref path) = file {
         std::fs::read_to_string(path)?
     } else if let Some(ref msg) = message {


### PR DESCRIPTION
## Summary

Fixes three Rust-best-practice findings from a repo-wide audit, each validated with Perplexity before acting:

1. **`init.rs:166`** — team cache warm used `let _ = write_team_cache(...)`, silently dropping errors during first-run setup. If the cache write fails, the user had no indication — their first `jr team list` would just mysteriously refetch. Now logs the error to stderr with a clear fallback statement.

2. **`list.rs:421`** — `.ok()` on `get_or_fetch_workspace_id` during asset enrichment swallowed network errors. Assets without embedded workspace IDs would silently fail to enrich. Now logs to stderr before falling through, so the user knows *why* some assets lack detail.

3. **`create.rs:85,228` + `workflow.rs:584`** — `std::io::Read::read_to_string(&mut std::io::stdin(), ...)` in async fns blocks the tokio runtime. Per Perplexity-validated tokio guidance, wrapped in `tokio::task::spawn_blocking` to isolate the blocking read from the async executor.

No behavior change on success paths. Failure paths now tell the user what happened and what the fallback is.

## Validation

Both non-obvious claims were validated with Perplexity before implementing:
- `let _ = fallible_op()` / `.ok()` on IO/network without logging — confirmed silent-failure anti-pattern per Rust API Guidelines and Clippy's `let_underscore_must_use` lint
- `std::io::stdin()` in tokio async fn — confirmed runtime-blocking per tokio maintainers; `spawn_blocking` is the recommended isolation pattern

The fourth audit finding (merging `Tag::Image { .. }` and `_` arms in `adf.rs:128-129`) was dropped after re-reading — the code has an explicit comment documenting the split is intentional.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — all passing (782+ tests)
- [x] Behavioral: error paths still compile and propagate as before; only the observability of soft-fail warnings changes