### PR TITLE
refactor(error): add JrError::Internal for invariant-violation errors

### DIFF
--- a/src/cli/issue/workflow.rs
+++ b/src/cli/issue/workflow.rs
@@ -34,10 +34,11 @@ fn resolve_resolution_by_name(resolutions: &[Resolution], query: &str) -> Result
             .find(|r| r.name == name)
             .cloned()
             .ok_or_else(|| {
-                anyhow::anyhow!(
+                JrError::Internal(format!(
                     "Internal error: matched resolution \"{}\" not found. Please report this as a bug.",
                     name
-                )
+                ))
+                .into()
             }),
         // Multiple case-insensitive exact duplicates — list ONLY the
         // duplicate entries that actually collide with the query, so the
@@ -261,10 +262,10 @@ pub(super) async fn handle_move(
                     .find(|(n, _)| n == &name)
                     .map(|(_, i)| *i)
                     .ok_or_else(|| {
-                        anyhow::anyhow!(
+                        JrError::Internal(format!(
                             "Internal error: matched candidate \"{}\" not found. Please report this as a bug.",
                             name
-                        )
+                        ))
                     })?;
                 &transitions[idx]
             }
@@ -275,10 +276,10 @@ pub(super) async fn handle_move(
                     .find(|(n, _)| n == &name)
                     .map(|(_, i)| *i)
                     .ok_or_else(|| {
-                        anyhow::anyhow!(
+                        JrError::Internal(format!(
                             "Internal error: matched candidate \"{}\" not found. Please report this as a bug.",
                             name
-                        )
+                        ))
                     })?;
                 &transitions[idx]
             }
@@ -312,10 +313,10 @@ pub(super) async fn handle_move(
                     .find(|(n, _)| n == selected_name)
                     .map(|(_, i)| *i)
                     .ok_or_else(|| {
-                        anyhow::anyhow!(
+                        JrError::Internal(format!(
                             "Internal error: selected candidate \"{}\" not found. Please report this as a bug.",
                             selected_name
-                        )
+                        ))
                     })?;
                 &transitions[tidx]
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,14 @@ pub enum JrError {
     #[error("{0}")]
     UserError(String),
 
+    /// Invariant violation / "should never happen" bug. Prefix the message with
+    /// "Internal error:" at call sites so the formatted output self-describes
+    /// as a bug. Exit code 1 (default), distinguished from UserError (64) and
+    /// ConfigError (78) so callers matching on `JrError` can tell "we have a
+    /// bug" apart from "user did something wrong".
+    #[error("{0}")]
+    Internal(String),
+
     #[error("Interrupted")]
     Interrupted,
 
@@ -65,6 +73,19 @@ mod tests {
     #[test]
     fn user_error_exit_code() {
         assert_eq!(JrError::UserError("test".into()).exit_code(), 64);
+    }
+
+    #[test]
+    fn internal_error_exit_code_is_one() {
+        assert_eq!(JrError::Internal("bug".into()).exit_code(), 1);
+    }
+
+    #[test]
+    fn internal_error_display_passthrough() {
+        assert_eq!(
+            JrError::Internal("Internal error: x not found".into()).to_string(),
+            "Internal error: x not found"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a typed `JrError::Internal(String)` variant so code matching on `JrError` can distinguish our invariant violations ("this is a bug") from user errors (`UserError`, exit 64) and config errors (`ConfigError`, exit 78). Exit code stays at 1 (via the catch-all), so no user-visible behavior change.

Replaces four `anyhow::anyhow!("Internal error: ... Please report this as a bug.")` sites in `src/cli/issue/workflow.rs` — all the places where `partial_match` matched a name that couldn't then be re-located in the source slice. Message format preserved verbatim.

## Scope validation

Verified via `grep 'anyhow::anyhow!' src/` that the other `anyhow!` sites in the codebase are **not** invariant violations — they're user-facing input validation (duration.rs), OAuth flow errors (api/auth.rs), API client retry logic (api/client.rs), Atlas Teams error formatting (api/jira/teams.rs), and API not-found responses (api/jira/issues.rs). Those stay as `anyhow!` because they already communicate specific failure modes (and many carry wrapped `reqwest`/`io` errors via `#[from]`). Only the four "Internal error: X not found" sites match this pattern.

## Design decisions

- **Naming**: `Internal` over `Bug` / `Unreachable`. Both `Internal` and `Bug` are acceptable per Rust taxonomy conventions; `Internal` aligns with how the existing "Internal error:" message prefix reads (message and variant name agree).
- **`String` payload**: dynamic messages needed — three of the four sites interpolate a matched candidate name. Static context would force per-site variants.
- **Exit code via catch-all**: deliberately did not add an explicit `JrError::Internal(_) => 1` arm. Internal bugs are the *default* failure mode; spelling it out implies the other default-1 variants (`NetworkError`, `ApiError`, `Http`, `Io`, `Json`) are somehow less default, which they aren't.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo test` — 918 passed (baseline 916 + 2 new: `internal_error_exit_code_is_one`, `internal_error_display_passthrough`)
- [x] All 4 `anyhow::anyhow!` sites in `workflow.rs` removed (\`grep\` returned empty)
- [ ] CI stays green on PR