### PR TITLE
chore: bump version to 0.5.0-dev.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.5.0-dev.3"
+version = "0.5.0-dev.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.5.0-dev.3"
+version = "0.5.0-dev.4"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary
- Bumps `Cargo.toml` and `Cargo.lock` from `0.5.0-dev.3` to `0.5.0-dev.4`.
- Pre-release for the next dev cycle on top of last stable `v0.4.0`.

## Test plan
- [x] `cargo check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full suite passes)

After merge, tag `v0.5.0-dev.4` on develop to trigger the Release workflow.