### PR TITLE
chore: bump version to 0.5.0-dev.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.5.0-dev.4"
+version = "0.5.0-dev.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.5.0-dev.4"
+version = "0.5.0-dev.5"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary

Pre-release version bump for the next dev cycle. First dev release on `develop` after the embedded OAuth app feature merged in #282 (`2345dca`), so this dev tag will be the first to exercise the embedded OAuth code path end-to-end.

- `Cargo.toml`: `0.5.0-dev.4` → `0.5.0-dev.5`
- `Cargo.lock`: refreshed via `cargo check`

## Verification

- [x] `cargo check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — full suite green

After merge, tag `v0.5.0-dev.5` on develop's HEAD to trigger the Release workflow. The "Verify embedded OAuth app present" smoke step on native targets should validate the embedded OAuth credentials (`OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` repo secrets must be set).