### PR TITLE
chore: bump version to 0.5.0-dev.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.5.0-dev.5"
+version = "0.5.0-dev.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.5.0-dev.5"
+version = "0.5.0-dev.6"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary

Pre-release version bump for the next dev cycle. Re-cuts an embedded-OAuth dev release after the Atlassian Developer Console `client_secret` was rotated and the `OAUTH_CLIENT_SECRET` GitHub Secret was updated.

- `Cargo.toml`: `0.5.0-dev.5` → `0.5.0-dev.6`
- `Cargo.lock`: refreshed via `cargo check`

## Why

`v0.5.0-dev.5` shipped with a stale embedded `client_secret`; OAuth login failed at the token-exchange step with Atlassian returning `access_denied / Unauthorized` (their wording for client_secret authentication failure). After rotating the secret in Developer Console and updating the matching GitHub Secret, this release rebuilds with the correct value embedded.

## Verification

- [x] `cargo check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — full suite green
- [ ] Manual: after merge + tag, attempt `jr auth login --oauth` against a real Atlassian instance; expect token exchange to succeed and the keychain to receive the access/refresh token pair