### PR TITLE
chore: bump version to 0.5.0-dev.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.5.0-dev.6"
+version = "0.5.0-dev.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.5.0-dev.6"
+version = "0.5.0-dev.7"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary

Re-cut embedded-OAuth dev release after the `OAUTH_CLIENT_SECRET` GitHub Secret was corrected. Manual `auth.atlassian.com/oauth/token` exchange with the live Developer Console secret now returns `200 + access_token` (verified via standalone curl test). Previous secret value embedded in `v0.5.0-dev.6` differed from what Atlassian had on file; this rebuild embeds the correct value.

- `Cargo.toml`: `0.5.0-dev.6` → `0.5.0-dev.7`
- `Cargo.lock`: refreshed via `cargo check`

## Verification

- [x] `cargo check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — full suite green
- [x] Manual OAuth token exchange via curl with the values now in the GitHub Secret — returns access_token + refresh_token successfully

After merge + tag, this is the first dev release where `jr auth login --oauth` should complete end-to-end against a real Atlassian site (consent screen → callback → token exchange → keychain persist).