### PR TITLE
feat: add gitleaks secret-scan CI step (S-1.05)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,19 @@ jobs:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+
+  security:
+    name: Secret Scan (gitleaks)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 0
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,22 +2,25 @@ title = "jr secret scan config"
 version = 8
 
 # Use the default gitleaks rule set; add only project-specific allowlist entries.
+# Global allowlist format for gitleaks v8: paths and regexes are string arrays.
 
 [allowlist]
 description = "Project-specific allowlist for jr"
 
-[[allowlist.regexes]]
-description = "Test fixture credentials in auth_embedded.rs (deliberately fake round-trip tests)"
-regex = '''(hello-world-secret|secret-xyz|client-abc|super-secret-must-not-leak)'''
+# Fake credential strings used in unit/integration test fixtures.
+# hello-world-secret, secret-xyz, client-abc, super-secret-must-not-leak:
+#   deliberately fake tokens in auth_embedded.rs round-trip tests.
+# Basic dGVzdDp0ZXN0: base64("test:test") used as mock Basic auth header.
+regexes = [
+  '''(hello-world-secret|secret-xyz|client-abc|super-secret-must-not-leak)''',
+  '''Basic dGVzdDp0ZXN0''',
+]
 
-[[allowlist.regexes]]
-description = "Base64-encoded test:test used as mock Basic auth header in integration tests"
-regex = '''Basic dGVzdDp0ZXN0'''
-
-[[allowlist.paths]]
-description = "build.rs reads JR_BUILD_OAUTH_CLIENT_SECRET from env; no hardcoded secret present"
-regex = '''build\.rs'''
-
-[[allowlist.paths]]
-description = "Embedded OAuth XOR constants are generated into OUT_DIR at build time, not stored in source"
-regex = '''src/api/auth_embedded\.rs'''
+# build.rs reads JR_BUILD_OAUTH_CLIENT_SECRET from env at compile time;
+# no hardcoded secret is present in the file itself.
+# src/api/auth_embedded.rs: embedded OAuth XOR constants are generated into
+# OUT_DIR at build time, not stored in source.
+paths = [
+  '''build\.rs''',
+  '''src/api/auth_embedded\.rs''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,27 @@
+title = "jr secret scan config"
+version = 8
+
+# Use the default gitleaks rule set; add only project-specific allowlist entries.
+
+[allowlist]
+description = "Project-specific allowlist for jr"
+
+[[allowlist.regexes]]
+description = "Test fixture credentials in auth_embedded.rs (deliberately fake round-trip tests)"
+regex = '''(hello-world-secret|secret-xyz|client-abc|super-secret-must-not-leak)'''
+
+[[allowlist.regexes]]
+description = "Base64-encoded test:test used as mock Basic auth header in integration tests"
+regex = '''Basic dGVzdDp0ZXN0'''
+
+[[allowlist.paths]]
+description = "build.rs reads JR_BUILD_OAUTH_CLIENT_SECRET from env; no hardcoded secret present"
+regex = '''build\.rs'''
+
+[[allowlist.paths]]
+description = "Embedded OAuth XOR constants are generated into OUT_DIR at build time, not stored in source"
+regex = '''src/api/auth_embedded\.rs'''
+
+[[allowlist.paths]]
+description = "Test files use mock credentials only — no real secrets"
+regex = '''tests/.*'''

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -21,7 +21,3 @@ regex = '''build\.rs'''
 [[allowlist.paths]]
 description = "Embedded OAuth XOR constants are generated into OUT_DIR at build time, not stored in source"
 regex = '''src/api/auth_embedded\.rs'''
-
-[[allowlist.paths]]
-description = "Test files use mock credentials only — no real secrets"
-regex = '''tests/.*'''


### PR DESCRIPTION
## Summary

- Add `security` job to `.github/workflows/ci.yml` using `gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7` (v2.3.9), SHA-pinned per S-1.01 policy
- PR-only trigger; 10-minute timeout; `contents: read` permission only (minimal blast radius)
- Create `.gitleaks.toml` with a targeted allowlist for known fake test fixtures (`hello-world-secret`, `Basic dGVzdDp0ZXN0`, etc.) and embedded OAuth constants that live in `OUT_DIR` at build time, not in source

## Story

**S-1.05** — Wave 1, fifth story. Adds gitleaks secret scanning to CI as a mandatory gate on every PR.

## Acceptance Criteria Status

| AC | Description | Status |
|----|-------------|--------|
| AC-001 | GitHub repo-level secret scanning enabled in Settings | **MANUAL — see below** |
| AC-002 | `security` job exists in `ci.yml` with `gitleaks-action` | PASS |
| AC-003 | Job scoped to `pull_request` trigger only | PASS |
| AC-004 | SHA-pinned action ref (`ff98106e...`) | PASS |
| AC-005 | `.gitleaks.toml` allowlist covers known test fixtures without over-permissiveness | PASS |

> **REQUIRED MAINTAINER ACTION (AC-001):** After merge, enable GitHub repo-level secret scanning at:
> https://github.com/Zious11/jira-cli/settings/security_analysis
> (Settings → Code security → Secret scanning → Enable)
> This cannot be automated via a workflow file — it requires a repo admin to toggle it in the UI.

## Diff Scope

Two files changed — no source code modifications:
- `.github/workflows/ci.yml` — added `security` job
- `.gitleaks.toml` — new allowlist config

## Test Plan

- [ ] Gitleaks job runs on this PR's own diff (first self-validation run)
- [ ] Job passes with no false positives from known test fixtures
- [ ] If gitleaks flags anything, triage: false positive → update allowlist; true positive → fix before merge
- [ ] After merge: maintainer enables AC-001 GitHub secret scanning setting

## Related

- Follows S-1.01 (#295) — SHA-pinning policy that governs the `ff98106e...` pin used here
- Follows S-1.04 (#298) — timeout-minutes policy; this job uses `timeout-minutes: 10`

## Breaking Change

No.

## Pre-Merge Checklist

- [x] Two-file diff only (ci.yml + .gitleaks.toml)
- [x] Action SHA pinned to `ff98106e4c7b2bc287b24eaf42907196329070c7` (v2.3.9)
- [x] Allowlist entries are specific regex/path patterns, not wildcards
- [x] No source code changes
- [x] All cargo CI gates pass (build, test, clippy, fmt, deny)
- [ ] Gitleaks job passes on this PR (first run)
- [ ] AC-001 manual maintainer step completed post-merge