### PR TITLE
chore: bump version to 0.5.0-dev.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.5.0-dev.7"
+version = "0.5.0-dev.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.5.0-dev.7"
+version = "0.5.0-dev.8"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary

Routine dev pre-release bump. Cuts `v0.5.0-dev.8` after the Wave 2 integration gate closed cleanly and `WV2-SEC-01` (CWE-400 input length cap on `parse_duration_validate`) merged via PR #310.

- `Cargo.toml`: `0.5.0-dev.7` → `0.5.0-dev.8`
- `Cargo.lock`: refreshed via `cargo build` (1-line update; no transitive dep changes)

## Wave 2 highlights since v0.5.0-dev.7

- 7 stories merged (S-2.01..S-2.07; PRs #303-#309): regression-pin holdout suites, CLAUDE.md NFR documentation sweep, worklog \`timeSpent\` server-side parsing, auth \`--output json\` for 4 subcommands, verb-aligned JSON policy + test naming convention
- 2 design pivots driven by Perplexity verification (DEC-010 timeSpent passthrough; DEC-011 BC re-anchor)
- WV2-SEC-01 hardening: 64-byte input length cap on \`parse_duration_validate\` (defense-in-depth, not exploitable)
- Wave 2 integration gate CLOSED with 4 fix-PRs landing all BLOCKING findings; verdict GATE-PASSES

## Verification

- [x] \`cargo build --release\` — clean
- [x] \`cargo test\` — 1108 pass, 0 fail, 13 ignored
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo +nightly fmt --all -- --check\` — clean
- [x] \`cargo deny check\` — advisories/bans/licenses/sources all ok

## After merge

- Tag \`v0.5.0-dev.8\` on develop (post-merge SHA)
- Tag push triggers \`.github/workflows/release.yml\` to build 4 targets (macOS x86_64/aarch64 + Linux x86_64/aarch64) and create a GitHub pre-release with embedded OAuth credentials

## Breaking change
None.

## Related
- Wave 2 close: factory-artifacts \`bb576bf\`
- Recent dev bumps: PR #287 (v0.5.0-dev.7), #286 (v0.5.0-dev.6), #285 (v0.5.0-dev.5)