### PR TITLE
docs(gotchas): S-3.03 verified Atlassian 401 shape + single-use rotation + mutex layering rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,25 @@ When adding a new feature:
   columns — use --all to see everything") is written to stderr, consistent with the
   convention used by `issue list` and `sprint current`. This is intentional — stderr
   keeps hints out of `--output json` and pipe-friendly stdout.
+- **Atlassian's expired-access-token 401 response shape:** The Jira REST API v3 returns
+  `HTTP 401` with body `{"errorMessages": ["The access token provided is expired, revoked,
+  malformed, or invalid for other reasons."]}` — there is NO machine-readable `code` field
+  and NO RFC-6750-compliant `WWW-Authenticate: Bearer error="invalid_token"` header.
+  Auto-refresh wiring (S-3.03) uses blanket-401 trigger (matches `gh` CLI pattern), not
+  substring-match (locale-fragile) and not RFC-6750 header inspection (Atlassian doesn't
+  follow the spec). Source: `.factory/research/S-3.03-wave3-verification.md` (Claim 2, REFUTED).
+- **Refresh-token rotation is strictly single-use on Atlassian.** The "10-minute reuse
+  window" mentioned in some secondary sources (Nango.dev, etc.) is NOT documented by
+  Atlassian and is known to fail in clusters. Treat each refresh token as one-shot.
+  Concurrent refresh attempts MUST go through `src/api/refresh_coordinator.rs`
+  per-profile single-flight to avoid `invalid_grant` races. Source:
+  `.factory/research/S-3.03-v2-design-verification.md` (Claim 5, REFUTED).
+- **`refresh_coordinator.rs` mutex layering rule:** outer `std::sync::Mutex<HashMap<...>>`
+  is held ONLY BRIEFLY for HashMap lookup/insert; it is released BEFORE any `.await`.
+  Inner `tokio::sync::Mutex<RefreshState>` is held across the refresh `.await`. NEVER
+  use `std::sync::Mutex` for the inner mutex — `tokio::sync::Mutex` is mandatory because
+  it does NOT poison on panic, which is the correct semantic for refresh (a panicked
+  refresh should not permanently break the coordinator). Source: S-3.03 v2 spec.
 
 ## AI Agent Notes
 


### PR DESCRIPTION
## Summary

Adds three verified gotchas to `CLAUDE.md` documenting Atlassian OAuth/refresh behavior and the concurrency primitive design for the upcoming S-3.03 auto-refresh implementation. **Documentation-only** — no code changes.

The gotchas were produced by Perplexity-driven pre-flight verification (DEC-013) before the S-3.03 v2.0.0 spec was written, so future agents (and humans) starting Phase 3 TDD work begin from verified facts:

1. **Atlassian's expired-access-token 401 shape** — `{"errorMessages": [...]}`, no machine-readable `code` field, no RFC-6750 `WWW-Authenticate` header. Refutes the `{"code": "EXPIRED"}` assumption in S-3.03 v1.0.0 (which would never have fired).
2. **Refresh-token rotation is strictly single-use on Atlassian.** The "10-minute reuse window" cited in some secondary sources is not documented by Atlassian; concurrent refreshes must use the per-profile single-flight in `src/api/refresh_coordinator.rs`.
3. **`refresh_coordinator.rs` mutex layering rule** — outer `std::sync::Mutex<HashMap<...>>` for brief sync lookup (released before `.await`); inner `tokio::sync::Mutex<RefreshState>` across `.await`. Mandate `tokio::sync::Mutex` for the inner — `std::sync::Mutex` poisons on panic, wrong semantic for refresh.

## Why this lands ahead of S-3.03 implementation

The gotchas are **factual claims about the external Atlassian API + an architectural rule** that any future agent writing or reviewing the auto-refresh code needs to know **today**, regardless of when the implementation lands. Putting them in `CLAUDE.md` now prevents the v1 defect class ("agent assumed wrong response shape") from recurring during Phase 3 TDD.

The S-3.03 v2.0.0 story spec is on `factory-artifacts@85e47ef` (separate worktree); implementation will follow in a separate PR.

## Verification trail

- `.factory/research/S-3.03-wave3-verification.md` — v1 defects (5 claims, 1 REFUTED)
- `.factory/research/S-3.03-v2-design-verification.md` — v2 design pre-flight (8 claims, 8 amendments)
- DEC-013 (pending state-manager log)

## Test plan

- [ ] Markdown lint passes (no broken links/sections)
- [ ] `git diff origin/develop -- CLAUDE.md` shows only `Gotchas` section additions, no other edits
- [ ] CI green (no workflows touch `CLAUDE.md` directly, but a normal CI pass confirms nothing else regressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)