### PR TITLE
chore: bump version to 0.5.0-dev.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.5.0-dev.8"
+version = "0.5.0-dev.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.5.0-dev.8"
+version = "0.5.0-dev.9"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary

Dev release marker after Wave 3 closure (10/10 stories merged).

This PR ONLY bumps `Cargo.toml` + `Cargo.lock` from `0.5.0-dev.8` → `0.5.0-dev.9`. It does not modify any source code, tests, docs, or CI configuration.

## Wave 3 highlights (since v0.5.0-dev.8)

- **S-3.03 v2** (#321): Auto-refresh OAuth on 401 + per-profile single-flight coordinator
- **S-3.04** (#320): Multi-cloudId disambiguation + `--cloud-id` flag + H-047 KNOWN-GAP→MUST-PASS
- **S-3.01** (#319): `cli/auth.rs` shard-split into `cli/auth/` module (9 files)
- **S-3.02** (#318): `cli/assets.rs` shard-split into `cli/assets/` module (5 files)
- **S-3.08** (#317): 11 LOW NFR closures (5 source comments + 6 CLAUDE.md additions)
- **S-3.05** (#316): Asset enrichment concurrency cap (`buffer_unordered(8)`)
- **S-3.07 v2** (#315): Retry-After cap (60s) + JRACLOUD-94632 anti-loop guard
- **S-3.06** (#314): Pre-merge spec count validation script (DRIFT-001 mitigation)
- **S-3.10** (#313): `format_roundtrip` proptest rewrite + deprecated `parse_duration` calculator deletion
- **S-3.09** (factory-only): PKCE deferral closure (NFR-S-A → DEFER per ADR-0013)

Phase 3 progress: 32/32 (100% v2 scope). Wave 3 closed.

## Test plan

- [ ] CI green (Format / Clippy / MSRV / Deny / Coverage / Test (macOS+Ubuntu) / Secret Scan)
- [ ] `Cargo.lock` change limited to the `jr` package's own version