### PR TITLE
chore(test): gate keyring test + add is_terminal unit table (closes #339, #344)

### DIFF
--- a/src/types/jira/bulk.rs
+++ b/src/types/jira/bulk.rs
@@ -132,3 +132,46 @@ impl BulkActionError {
         "unknown error".to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn progress_with_status(status: &str) -> BulkOperationProgress {
+        BulkOperationProgress {
+            task_id: None,
+            status: status.to_string(),
+            processed_accessible_issues: Vec::new(),
+            failed_accessible_issues: std::collections::HashMap::new(),
+            progress_percent: None,
+            total_issue_count: None,
+            invalid_or_inaccessible_issue_count: None,
+        }
+    }
+
+    #[test]
+    fn is_terminal_recognizes_all_documented_statuses() {
+        let terminal = ["COMPLETE", "COMPLETED", "FAILED", "CANCELLED", "DEAD"];
+        let non_terminal = [
+            "RUNNING",
+            "ENQUEUED",
+            "PENDING",
+            "IN_PROGRESS",
+            "CANCEL_REQUESTED",
+            "",
+            "unknown",
+        ];
+        for s in terminal {
+            assert!(
+                progress_with_status(s).is_terminal(),
+                "expected {s} terminal"
+            );
+        }
+        for s in non_terminal {
+            assert!(
+                !progress_with_status(s).is_terminal(),
+                "expected {s} non-terminal"
+            );
+        }
+    }
+}

--- a/src/types/jira/bulk.rs
+++ b/src/types/jira/bulk.rs
@@ -146,11 +146,16 @@ mod tests {
             progress_percent: None,
             total_issue_count: None,
             invalid_or_inaccessible_issue_count: None,
+            failure_reason: None,
         }
     }
 
     #[test]
-    fn is_terminal_recognizes_all_documented_statuses() {
+    fn is_terminal_recognizes_documented_and_empirical_aliases() {
+        // Documented terminal statuses per OpenAPI: COMPLETE, FAILED, CANCELLED, DEAD.
+        // COMPLETED is included as an empirical-safety alias (some live API responses
+        // observed it; tracked at #331 pending sandbox verification). Do not remove
+        // COMPLETED without confirming the live API never emits it.
         let terminal = ["COMPLETE", "COMPLETED", "FAILED", "CANCELLED", "DEAD"];
         let non_terminal = [
             "RUNNING",

--- a/tests/auth_output_json.rs
+++ b/tests/auth_output_json.rs
@@ -313,8 +313,17 @@ fn test_auth_switch_unknown_profile_returns_json_error() {
 ///
 /// RED-GATE: FAILS on develop because `handle_login` does NOT check
 /// `--output json`.
+///
+/// Gated behind `JR_RUN_KEYRING_TESTS=1` because `login_token` writes to the
+/// keychain; a second run without clearing the keychain entry fails with
+/// "The specified item already exists in the keychain." Linux CI may also
+/// lack a secret-service backend entirely.
 #[test]
+#[ignore = "requires keyring backend; set JR_RUN_KEYRING_TESTS=1 to run"]
 fn test_auth_login_emits_json_when_output_json_set() {
+    if std::env::var("JR_RUN_KEYRING_TESTS").is_err() {
+        return;
+    }
     let config_dir = TempDir::new().unwrap();
     let cache_dir = TempDir::new().unwrap();
     let cwd_dir = TempDir::new().unwrap();

--- a/tests/auth_output_json.rs
+++ b/tests/auth_output_json.rs
@@ -321,8 +321,18 @@ fn test_auth_switch_unknown_profile_returns_json_error() {
 #[test]
 #[ignore = "requires keyring backend; set JR_RUN_KEYRING_TESTS=1 to run"]
 fn test_auth_login_emits_json_when_output_json_set() {
-    if std::env::var("JR_RUN_KEYRING_TESTS").is_err() {
-        return;
+    match std::env::var("JR_RUN_KEYRING_TESTS").as_deref() {
+        Ok("1") => {} // run
+        Ok(other) => panic!(
+            "JR_RUN_KEYRING_TESTS must be \"1\" to run this test; got {other:?}. \
+             This test writes to the macOS keychain and produces stale state if run \
+             without the explicit opt-in."
+        ),
+        Err(_) => panic!(
+            "JR_RUN_KEYRING_TESTS=1 is required to run this test (it writes to the \
+             macOS keychain). The test is gated behind #[ignore] for default runs; \
+             setting --include-ignored without the env opt-in is a misuse."
+        ),
     }
     let config_dir = TempDir::new().unwrap();
     let cache_dir = TempDir::new().unwrap();

--- a/tests/auth_output_json.rs
+++ b/tests/auth_output_json.rs
@@ -325,13 +325,14 @@ fn test_auth_login_emits_json_when_output_json_set() {
         Ok("1") => {} // run
         Ok(other) => panic!(
             "JR_RUN_KEYRING_TESTS must be \"1\" to run this test; got {other:?}. \
-             This test writes to the macOS keychain and produces stale state if run \
-             without the explicit opt-in."
+             This test writes to the system keyring (macOS Keychain / Linux Secret \
+             Service / Windows Credential Manager)."
         ),
         Err(_) => panic!(
-            "JR_RUN_KEYRING_TESTS=1 is required to run this test (it writes to the \
-             macOS keychain). The test is gated behind #[ignore] for default runs; \
-             setting --include-ignored without the env opt-in is a misuse."
+            "JR_RUN_KEYRING_TESTS=1 is required to run this test (writes to the system \
+             keyring — macOS Keychain / Linux Secret Service / Windows Credential \
+             Manager). The test is gated behind #[ignore]; running --include-ignored \
+             without the env opt-in is a misuse."
         ),
     }
     let config_dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- Closes #339: gates `test_auth_login_emits_json_when_output_json_set` behind `JR_RUN_KEYRING_TESTS` to match the documented keyring-test policy in CLAUDE.md. Fixes a known pre-existing failure on develop where a second run fails with "The specified item already exists in the keychain."
- Closes #344: adds inline unit-test table for `BulkOperationProgress::is_terminal` covering all 5 terminal arms (`COMPLETE`, `COMPLETED`, `FAILED`, `CANCELLED`, `DEAD`) + 7 non-terminal strings (`RUNNING`, `ENQUEUED`, `PENDING`, `IN_PROGRESS`, `CANCEL_REQUESTED`, `""`, `"unknown"`). Codified lesson from F6 hardening of PR #348.

Note: #347 (rename `test_yes_flag_skips_confirmation_prompt`) is deferred — that test
lives in `tests/issue_bulk_pr2.rs` which is introduced by PR #348. Re-file or chain
the rename PR after #348 merges.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --test auth_output_json test_auth_login_emits_json_when_output_json_set` — 0 passed; 0 failed; 1 ignored (gated correctly)
- [x] `JR_RUN_KEYRING_TESTS=1 cargo test -- --include-ignored test_auth_login_emits_json_when_output_json_set` — runs when env set
- [x] `cargo test --lib types::jira::bulk` — 1 passed (new unit table green)
- [x] `cargo test` (full suite) — all green, 0 failures