### PR TITLE
chore(docs): bulk idempotency note + --max pagination doc + yes-flag test rename (closes #337, #341, #347)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,10 +208,13 @@ When adding a new feature:
   it does NOT poison on panic, which is the correct semantic for refresh (a panicked
   refresh should not permanently break the coordinator). Source: S-3.03 v2 spec.
 - **Bulk transitions are not idempotent.** Single-key `move` exits 0 if the issue is
-  already in the target status. Multi-key `move ... --jql` and `move KEY1 KEY2 STATUS`
-  issue the transition unconditionally for every key. For workflows that reject
-  same-status transitions, expect per-key 400 errors in the bulk response. To
-  pre-filter, run `jr issue list --jql "<query> AND status != \"<target>\""` first.
+  already in the target status. Multi-key `move KEY1 KEY2 ... STATUS` (legacy positional
+  form) and `move KEY1 KEY2 ... --to STATUS` issue the transition unconditionally for
+  every key. For workflows that reject same-status transitions, expect per-key 400
+  errors in the bulk response. To pre-filter, list candidate keys first with
+  `jr issue list --jql "<query> AND status != \"<target>\"" --output json` and pass
+  them as positional args. The `--jql` selection form is on `edit` only — `move` does
+  not accept `--jql`.
 
 ## AI Agent Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,11 @@ When adding a new feature:
   use `std::sync::Mutex` for the inner mutex — `tokio::sync::Mutex` is mandatory because
   it does NOT poison on panic, which is the correct semantic for refresh (a panicked
   refresh should not permanently break the coordinator). Source: S-3.03 v2 spec.
+- **Bulk transitions are not idempotent.** Single-key `move` exits 0 if the issue is
+  already in the target status. Multi-key `move ... --jql` and `move KEY1 KEY2 STATUS`
+  issue the transition unconditionally for every key. For workflows that reject
+  same-status transitions, expect per-key 400 errors in the bulk response. To
+  pre-filter, run `jr issue list --jql "<query> AND status != \"<target>\""` first.
 
 ## AI Agent Notes
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -398,7 +398,7 @@ pub enum IssueCommand {
         /// exceeds this value, the command errors without mutating.
         ///
         /// Values above 100 trigger cursor pagination on /rest/api/3/search/jql (Jira
-        /// caps maxResults at 100 per page), so --max 1000 issues up to ~10 search
+        /// caps maxResults at 100 per page), so --max 1000 triggers up to ~10 search
         /// requests before the bulk call. Use the smallest --max that fits your workflow.
         #[arg(long, value_parser = clap::value_parser!(u32).range(1..=1000))]
         max: Option<u32>,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -396,6 +396,10 @@ pub enum IssueCommand {
         /// Maximum number of issues to match via --jql (default 50, hard ceiling 1000).
         /// Requires --jql; cannot be used with positional keys. If the JQL match count
         /// exceeds this value, the command errors without mutating.
+        ///
+        /// Values above 100 trigger cursor pagination on /rest/api/3/search/jql (Jira
+        /// caps maxResults at 100 per page), so --max 1000 issues up to ~10 search
+        /// requests before the bulk call. Use the smallest --max that fits your workflow.
         #[arg(long, value_parser = clap::value_parser!(u32).range(1..=1000))]
         max: Option<u32>,
         /// Skip the interactive confirmation prompt for large JQL match sets.

--- a/tests/issue_bulk_pr2.rs
+++ b/tests/issue_bulk_pr2.rs
@@ -551,7 +551,8 @@ async fn test_yes_flag_passes_through_below_threshold_without_effect() {
         .mount(&server)
         .await;
 
-    // Bulk POST must be made (--yes bypasses the prompt).
+    // Bulk POST is made because 3 keys is below JQL_CONFIRM_THRESHOLD (5), so the
+    // confirmation prompt is never entered; --yes is a no-op for this match size.
     Mock::given(method("POST"))
         .and(path("/rest/api/3/bulk/issues/fields"))
         .respond_with(ResponseTemplate::new(200).set_body_json(bulk_enqueued("task-yes-001")))

--- a/tests/issue_bulk_pr2.rs
+++ b/tests/issue_bulk_pr2.rs
@@ -530,13 +530,17 @@ async fn test_dry_run_with_multi_key_positional_skips_bulk_post() {
 }
 
 // ---------------------------------------------------------------------------
-// AC-004 / --yes: explicit --yes flag skips confirmation prompt.
+// AC-004 / --yes: explicit --yes flag passes through below threshold without effect.
 // ---------------------------------------------------------------------------
 
 /// `jr issue edit --jql '...' --label add:foo --yes --no-input`
-/// The bulk POST is made without reading stdin (no prompt hang).
+/// Below JQL_CONFIRM_THRESHOLD (5) the confirmation gate is never entered,
+/// so --yes has no behavioral effect. This test pins that providing --yes
+/// alongside a small JQL match set does not error or hang — it's a no-op
+/// backward-compatibility guard. For the > threshold case where --yes
+/// actually bypasses the prompt, see a future dedicated test.
 #[tokio::test]
-async fn test_yes_flag_skips_confirmation_prompt() {
+async fn test_yes_flag_passes_through_below_threshold_without_effect() {
     let server = MockServer::start().await;
 
     let matched_keys = ["YES-1", "YES-2", "YES-3"];


### PR DESCRIPTION
## Summary

- Closes #337: documents bulk transition non-idempotency deviation in CLAUDE.md — single-key `move` exits 0 if already in target state; multi-key bulk move issues the transition unconditionally (intentional perf trade-off, now documented in Gotchas)
- Closes #341: extends `--max` clap doc-comment with a pagination note (values >100 trigger cursor pagination on `/rest/api/3/search/jql`, up to ~10 search requests for `--max 1000`)
- Closes #347: renames `test_yes_flag_skips_confirmation_prompt` → `test_yes_flag_passes_through_below_threshold_without_effect`; the 3-key fixture is below `JQL_CONFIRM_THRESHOLD (5)` so `--yes` never enters the confirmation gate — the old name was misleading

All three are doc / rename only; no behavioral changes. Test suite still 38/38 on `issue_bulk_pr2`.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --test issue_bulk_pr2` — 38/38 passing (renamed test included)
- [x] `cargo test` — full suite green
- [x] `cargo run -- issue edit --help` — updated `--max` pagination paragraph visible