### PR TITLE
refactor(bulk): consolidate BULK_MAX_KEYS constant (#338)

### DIFF
--- a/src/api/jira/bulk.rs
+++ b/src/api/jira/bulk.rs
@@ -18,6 +18,15 @@ use crate::types::jira::bulk::{
     BulkEditRequest, BulkOperationProgress, BulkSubmitResponse, BulkTransitionRequest,
 };
 
+/// Maximum number of issue keys allowed in a single bulk operation call.
+///
+/// Sourced from the Atlassian per-call cap documented on both
+/// POST /rest/api/3/bulk/issues/fields and POST /rest/api/3/bulk/issues/transition
+/// (Issue Bulk Operations API). Reused by all bulk CLI handlers
+/// (`issue edit` multi-key + `--jql`, `issue move` multi-key) so that a future
+/// Atlassian cap change only requires editing this single constant.
+pub const BULK_MAX_KEYS: usize = 1000;
+
 /// Exponential backoff base interval for poll retries (used when task is not yet terminal).
 const POLL_BASE_SECS: u64 = 1;
 /// Maximum backoff interval (caps exponential growth).

--- a/src/cli/issue/create.rs
+++ b/src/cli/issue/create.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use crate::adf;
 use crate::api::assets::linked::get_or_fetch_cmdb_fields;
 use crate::api::client::JiraClient;
+use crate::api::jira::bulk::BULK_MAX_KEYS;
 use crate::cli::{IssueCommand, OutputFormat};
 use crate::config::Config;
 use crate::error::JrError;
@@ -12,9 +13,6 @@ use crate::output;
 
 use super::helpers;
 use super::json_output;
-
-/// Maximum number of keys allowed in a single bulk edit call (Atlassian API limit).
-const BULK_MAX_KEYS: usize = 1000;
 
 /// Number of issues above which a `--jql`-driven bulk edit requires explicit
 /// `--yes` (or `--no-input` implicit-yes) to proceed. Below this threshold the

--- a/src/cli/issue/workflow.rs
+++ b/src/cli/issue/workflow.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use crate::adf;
 use crate::api::client::JiraClient;
+use crate::api::jira::bulk::BULK_MAX_KEYS;
 use crate::cli::{IssueCommand, OutputFormat};
 use crate::error::JrError;
 use crate::output;
@@ -11,9 +12,6 @@ use crate::partial_match::{self, MatchResult};
 use crate::types::jira::Resolution;
 
 use super::helpers;
-
-/// Maximum number of keys allowed in a single bulk transition call.
-const BULK_MOVE_MAX_KEYS: usize = 1000;
 
 // ── Resolution resolver ───────────────────────────────────────────────
 
@@ -194,13 +192,13 @@ pub(super) async fn handle_move(
     };
 
     // --- Validate key count ---
-    if move_keys.len() > BULK_MOVE_MAX_KEYS {
+    if move_keys.len() > BULK_MAX_KEYS {
         return Err(JrError::UserError(format!(
             "Too many issue keys: {} provided, maximum is {}. \
              Split into batches of {} or fewer and run multiple times.",
             move_keys.len(),
-            BULK_MOVE_MAX_KEYS,
-            BULK_MOVE_MAX_KEYS,
+            BULK_MAX_KEYS,
+            BULK_MAX_KEYS,
         ))
         .into());
     }


### PR DESCRIPTION
## Summary

- Move duplicate `BULK_MAX_KEYS` / `BULK_MOVE_MAX_KEYS` (both `usize = 1000`) into a single canonical `pub const BULK_MAX_KEYS: usize = 1000;` in `src/api/jira/bulk.rs`.
- `src/cli/issue/create.rs` and `src/cli/issue/workflow.rs` now import this single source of truth.
- No behavioral change — same numeric cap applied at the same call sites. Closes #338.

## Rationale

Both constants come from the same Atlassian per-call cap (POST `/rest/api/3/bulk/issues/fields` + POST `/rest/api/3/bulk/issues/transition`). Having them in two places meant a future Atlassian cap change would require editing two files; now one.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 613 unit + all integration suites (incl. 38 bulk tests in `tests/issue_bulk_pr2.rs`)
- [x] `grep -rE 'BULK_(MOVE_)?MAX_KEYS' src/ tests/` shows only the canonical declaration in `src/api/jira/bulk.rs` and import-or-usage references in `create.rs` + `workflow.rs`