### PR TITLE
docs(bulk): document plannedChanges.labels shape divergence (#342)

### DIFF
--- a/src/cli/issue/create.rs
+++ b/src/cli/issue/create.rs
@@ -483,23 +483,28 @@ pub(super) async fn handle_edit(
                     planned.insert("priority".into(), json!(p));
                 }
                 if !labels.is_empty() {
-                    // NOTE: This dry-run preview shape `[{"action": "ADD", "name": "foo"}]`
-                    // is INTENTIONALLY simpler than the actual POST body shape sent by
-                    // `handle_edit_bulk_labels` to Atlassian, which uses
-                    // `{"labelsAction": "ADD", "labels": [{"name": "foo"}]}` (or an array
-                    // of those objects when ADD+REMOVE coalesce). The dry-run JSON is a
-                    // human-and-tool-friendly preview, NOT a byte-for-byte snapshot of
-                    // the wire request. Two specific divergences:
-                    //   - key: `action` (dry-run) vs `labelsAction` (POST)
-                    //   - nesting: flat `[{action, name}]` (dry-run) vs nested
-                    //     `{labelsAction, labels: [{name}]}` (POST)
-                    // Rationale: the POST shape is itself a best-guess pending #331
-                    // empirical verification. Locking dry-run consumers to an
-                    // unverified canonical Atlassian shape now would force a second
-                    // breaking change once #331 confirms the true shape. Once #331
-                    // verifies and #345 extracts the label-coalesce builder into a
-                    // pure function, this dry-run builder can be unified with
-                    // `handle_edit_bulk_labels`'s builder to emit byte-identical JSON.
+                    // NOTE: This entire dry-run preview block (labels here, plus
+                    // `priority` and `issueType` below) emits INTENTIONALLY simplified
+                    // shapes that DO NOT match the POST body shapes sent to Atlassian:
+                    //   - `labels`: dry-run emits `[{"action": "ADD", "name": "foo"}]`
+                    //     (flat array). POST body emits
+                    //     `{"labelsAction": "ADD", "labels": [{"name": "foo"}]}` (nested,
+                    //     or an array of those objects when ADD+REMOVE coalesce).
+                    //   - `priority`: dry-run emits a bare string. POST body wraps as
+                    //     `{"name": "..."}` (best-guess; Atlassian docs document
+                    //     `{"priorityId": <int>}`).
+                    //   - `issueType`: dry-run emits a bare string. POST body wraps as
+                    //     `{"issuetype": {"name": "..."}}` (best-guess; Atlassian docs
+                    //     document `{"issueTypeId": "..."}`).
+                    // The dry-run JSON is a human-and-tool-friendly preview, NOT a
+                    // byte-for-byte snapshot of the wire request. Rationale: all three
+                    // POST shapes are best-guesses pending #331 empirical verification.
+                    // Locking dry-run consumers to unverified canonical Atlassian
+                    // shapes now would force a second breaking change once #331
+                    // confirms the true shapes. Once #331 verifies the wire shapes and
+                    // #345 extracts pure builders, this dry-run builder can be unified
+                    // with `handle_edit_bulk_labels` / `handle_edit_bulk_fields` to
+                    // emit byte-identical JSON.
                     let label_entries: Vec<serde_json::Value> = labels
                         .iter()
                         .map(|l| {
@@ -908,6 +913,14 @@ async fn handle_edit_bulk_labels(
 /// Route non-label multi-key edits through the Atlassian Bulk Fields API.
 ///
 /// Supports 2..=1000 keys with --summary, --priority, --type.
+///
+/// NOTE: The `--dry-run --output json` `plannedChanges` block emits SIMPLIFIED
+/// previews for these same fields (bare strings for `priority` and `issueType`,
+/// see the dry-run builder in `handle_edit` above) that do NOT match the POST
+/// body shapes built here. Dry-run is a human-and-tool-friendly diff; the POST
+/// body shapes here are the current best-guess (still unverified, pending #331).
+/// Once #331 confirms the canonical wire shapes and the bulk builders are
+/// extracted into pure functions, the two paths can converge.
 ///
 /// editedFieldsInput shape (best-guess — unverified against live API):
 /// ```json

--- a/src/cli/issue/create.rs
+++ b/src/cli/issue/create.rs
@@ -803,9 +803,10 @@ pub(super) async fn handle_edit(
 /// NOTE: The `--dry-run --output json` `plannedChanges.labels` shape (built in the
 /// dry-run block of `handle_edit` above) is a SIMPLIFIED preview using `{action, name}`
 /// pairs in a flat array, NOT a byte-for-byte snapshot of the POST body built here.
-/// Dry-run is a human-and-tool-friendly diff; the POST body below is the canonical
-/// (still-unverified, pending #331) Atlassian shape. Once #331 confirms the shape and
-/// #345 extracts a pure builder, the two paths can converge.
+/// Dry-run is a human-and-tool-friendly diff; the POST body below is the current
+/// best-guess Atlassian shape (still unverified, pending #331). Once #331 confirms
+/// the canonical wire shape and #345 extracts a pure builder, the two paths can
+/// converge.
 ///
 /// editedFieldsInput shape (best-guess pending #331 empirical verification):
 /// - When BOTH ADD and REMOVE labels are present, coalesced into ONE bulk POST

--- a/src/cli/issue/create.rs
+++ b/src/cli/issue/create.rs
@@ -483,6 +483,23 @@ pub(super) async fn handle_edit(
                     planned.insert("priority".into(), json!(p));
                 }
                 if !labels.is_empty() {
+                    // NOTE: This dry-run preview shape `[{"action": "ADD", "name": "foo"}]`
+                    // is INTENTIONALLY simpler than the actual POST body shape sent by
+                    // `handle_edit_bulk_labels` to Atlassian, which uses
+                    // `{"labelsAction": "ADD", "labels": [{"name": "foo"}]}` (or an array
+                    // of those objects when ADD+REMOVE coalesce). The dry-run JSON is a
+                    // human-and-tool-friendly preview, NOT a byte-for-byte snapshot of
+                    // the wire request. Two specific divergences:
+                    //   - key: `action` (dry-run) vs `labelsAction` (POST)
+                    //   - nesting: flat `[{action, name}]` (dry-run) vs nested
+                    //     `{labelsAction, labels: [{name}]}` (POST)
+                    // Rationale: the POST shape is itself a best-guess pending #331
+                    // empirical verification. Locking dry-run consumers to an
+                    // unverified canonical Atlassian shape now would force a second
+                    // breaking change once #331 confirms the true shape. Once #331
+                    // verifies and #345 extracts the label-coalesce builder into a
+                    // pure function, this dry-run builder can be unified with
+                    // `handle_edit_bulk_labels`'s builder to emit byte-identical JSON.
                     let label_entries: Vec<serde_json::Value> = labels
                         .iter()
                         .map(|l| {
@@ -782,6 +799,13 @@ pub(super) async fn handle_edit(
 /// Route label edits through the Atlassian Bulk Fields API.
 ///
 /// Supports 1..=1000 keys. `labels` is a list of "add:NAME" / "remove:NAME" / "NAME" strings.
+///
+/// NOTE: The `--dry-run --output json` `plannedChanges.labels` shape (built in the
+/// dry-run block of `handle_edit` above) is a SIMPLIFIED preview using `{action, name}`
+/// pairs in a flat array, NOT a byte-for-byte snapshot of the POST body built here.
+/// Dry-run is a human-and-tool-friendly diff; the POST body below is the canonical
+/// (still-unverified, pending #331) Atlassian shape. Once #331 confirms the shape and
+/// #345 extracts a pure builder, the two paths can converge.
 ///
 /// editedFieldsInput shape (best-guess pending #331 empirical verification):
 /// - When BOTH ADD and REMOVE labels are present, coalesced into ONE bulk POST


### PR DESCRIPTION
## Summary

- Document the intentional divergence between the `--dry-run --output json` `plannedChanges.labels` preview shape and the actual POST body shape sent to Atlassian's bulk edit endpoint.
- Cross-referenced comments at both divergence sites so the divergence is discoverable from either end.
- Closes #342. Pure documentation; no behavioral change.

## The divergence

| Path | Shape |
|------|-------|
| Dry-run JSON | `"labels": [{"action": "ADD", "name": "foo"}]` (flat array, friendly keys) |
| POST body | `"labels": {"labelsAction": "ADD", "labels": [{"name": "foo"}]}` (nested, Atlassian keys) |

## Why document instead of normalize

The POST shape is itself a best-guess pending #331 empirical verification against a live Jira sandbox. Locking dry-run consumers to that unverified canonical shape now would force a second breaking change for dry-run consumers when #331 confirms the true shape. Once #331 + #345 (extract pure label-coalesce builder) land, the two paths can be unified to emit byte-identical JSON.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 613 unit + all integration suites (no behavioral change → no test changes needed)