### PR TITLE
chore(security): sanitize errorMessages before stderr (#334)

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1201,11 +1201,12 @@ fn sanitize_for_stderr(input: String) -> String {
 /// Extract a human-readable error message from a Jira error response body.
 ///
 /// All return paths run through `sanitize_for_stderr` (CWE-117 defense:
-/// escapes ASCII control chars from server-supplied content as visible
-/// `\xNN` literals before they reach stderr, preventing CR/LF/ANSI
-/// injection from a hostile or proxy-controlled response while keeping
-/// the byte information visible to the operator). UTF-8 in legitimate
-/// localized error messages is preserved.
+/// escapes Unicode control characters from server-supplied content as
+/// visible escape sequences — ASCII controls (C0 + DEL) as `\xNN` and
+/// C1 controls (U+0080..U+009F) as `\u{NNNN}` — before they reach stderr,
+/// preventing CR/LF/ANSI/CSI injection from a hostile or proxy-controlled
+/// response while keeping the byte information visible to the operator).
+/// UTF-8 in legitimate localized error messages is preserved.
 ///
 /// Precedence:
 /// 1. Non-empty `errorMessages` array → joined with "; "

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -963,6 +963,23 @@ fn serialize_value_bounded(v: &serde_json::Value, limit: usize) -> String {
     }
     impl std::io::Write for Bounded {
         fn write(&mut self, src: &[u8]) -> std::io::Result<usize> {
+            // Per std::io::Write::write contract (Perplexity-validated
+            // 2026-05-11): "If an error is returned then no bytes in the
+            // buffer were written to this writer." We honor this strictly:
+            //
+            // - `remaining == 0`: write nothing, return Err(WriteZero) to
+            //   signal stop. This is the ONLY path that returns Err.
+            // - `take == src.len()` (full write fits): write all, return
+            //   Ok(take).
+            // - `take < src.len()` (partial write fits): write the prefix,
+            //   return Ok(take), set `overflowed`. The NEXT call will hit
+            //   `remaining == 0` and return Err to stop serialization while
+            //   preserving the buffered prefix.
+            //
+            // Violating "no bytes on Err" would break write_all and similar
+            // retry-aware callers that rely on the invariant. The serde_json
+            // caller uses write_all-style loops, so the partial-write path
+            // now correctly accepts bytes and lets the next call error out.
             let remaining = self.limit.saturating_sub(self.buf.len());
             if remaining == 0 {
                 self.overflowed = true;
@@ -974,12 +991,9 @@ fn serialize_value_bounded(v: &serde_json::Value, limit: usize) -> String {
             let take = src.len().min(remaining);
             self.buf.extend_from_slice(&src[..take]);
             if take < src.len() {
-                // Partial write — propagate to serde_json so it stops.
+                // Partial write case: bytes accepted, but next call errors.
+                // Mark overflowed for the caller's marker logic.
                 self.overflowed = true;
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::WriteZero,
-                    "bounded JSON writer reached byte limit mid-write",
-                ));
             }
             Ok(take)
         }
@@ -1196,9 +1210,42 @@ fn extract_error_message_raw(body: &[u8]) -> String {
             // cap kicks in. Pre-cap the byte slice to a small multiple of the entry
             // cap (allows worst-case lossy expansion via U+FFFD replacement chars
             // at 3 bytes each) before conversion.
+            //
+            // Use a custom marker that records the ORIGINAL body.len() rather than
+            // relying on `cap_entry`'s default marker (R12 finding): cap_entry's
+            // marker reports the *post-pre-cap* string length, which can never
+            // exceed PRE_CAP_BYTES (~4096 bytes). When operators are diagnosing a
+            // resource-exhaustion / flood attempt, they need to see that the
+            // response was, e.g., 100 MB — not "4096 bytes total".
             const PRE_CAP_BYTES: usize = MAX_ERROR_ENTRY_LEN * 4;
-            let bounded = &body[..body.len().min(PRE_CAP_BYTES)];
-            return cap_entry(&String::from_utf8_lossy(bounded)).into_owned();
+            let original_len = body.len();
+            let bounded = &body[..original_len.min(PRE_CAP_BYTES)];
+            let lossy = String::from_utf8_lossy(bounded);
+            // Fast path: body already fits in MAX_ERROR_ENTRY_LEN, no marker needed.
+            if lossy.len() <= MAX_ERROR_ENTRY_LEN && original_len <= MAX_ERROR_ENTRY_LEN {
+                return lossy.into_owned();
+            }
+            // Custom marker reports the true original byte length and flags the
+            // non-UTF8 source so operators can distinguish this fallback from
+            // the normal cap_entry truncation path.
+            let marker = format!(" [...truncated, {original_len} bytes total, non-UTF8 body]");
+            let target_prefix_len = MAX_ERROR_ENTRY_LEN.saturating_sub(marker.len());
+            // Degenerate-case fallback: if marker is larger than the entry cap
+            // (would only fire if MAX_ERROR_ENTRY_LEN is shrunk drastically),
+            // return only the marker (or its truncated form) so we still emit
+            // SOME signal rather than nothing.
+            if target_prefix_len == 0 {
+                let mut end = MAX_ERROR_ENTRY_LEN.min(marker.len());
+                while end > 0 && !marker.is_char_boundary(end) {
+                    end -= 1;
+                }
+                return marker[..end].to_string();
+            }
+            let mut end = target_prefix_len.min(lossy.len());
+            while end > 0 && !lossy.is_char_boundary(end) {
+                end -= 1;
+            }
+            return format!("{}{}", &lossy[..end], marker);
         }
     };
 
@@ -1826,5 +1873,59 @@ mod sanitize_tests {
         // amplification vector. Future tweaks should update the doc comment
         // and Perplexity-revalidate.
         assert_eq!(MAX_PARSE_BODY_LEN, 16 * 1024);
+    }
+
+    // R12 pins — std::io::Write contract compliance + non-UTF8 marker accuracy.
+
+    #[test]
+    fn test_serialize_value_bounded_returns_marker_with_correct_data_on_partial_write() {
+        // R12 contract pin: previously the Bounded::write violated the
+        // std::io::Write contract by returning Err alongside a partial
+        // write. The fix returns Ok(take) on partial writes and lets the
+        // NEXT call hit remaining==0 and return Err. Verify that this
+        // does not break serialization correctness: oversized values
+        // still produce a bounded prefix + truncation marker.
+        let big_string = "y".repeat(5000);
+        let v = serde_json::json!({"key": big_string});
+        let out = serialize_value_bounded(&v, MAX_ERROR_ENTRY_LEN);
+        assert!(out.len() <= MAX_ERROR_ENTRY_LEN);
+        assert!(out.starts_with("{\"key\":\"y"));
+        assert!(
+            out.ends_with(" [...truncated]"),
+            "marker missing on partial-write contract-compliant path: {out:?}"
+        );
+    }
+
+    #[test]
+    fn test_extract_error_message_non_utf8_marker_reports_true_body_size() {
+        // R12 pin: the non-UTF8 fallback marker MUST report the actual
+        // body.len(), not the pre-capped lossy-string length. Operators
+        // diagnosing a flood attempt need to see "5000000 bytes total",
+        // not "4096 bytes total" which would silently under-report.
+        // Build a 5 MB non-UTF8 body (lots of 0xff bytes).
+        let body = vec![0xffu8; 5_000_000];
+        let out = extract_error_message(&body);
+        // The marker should reference the true 5_000_000-byte length.
+        assert!(
+            out.contains("5000000 bytes total"),
+            "marker missing or wrong-size for non-UTF8 5MB body: {out:?}"
+        );
+        // And flag the non-UTF8 source for disambiguation.
+        assert!(out.contains("non-UTF8 body"));
+        // And still respect the post-sanitization output cap.
+        assert!(out.len() <= MAX_SANITIZED_OUTPUT_LEN);
+    }
+
+    #[test]
+    fn test_extract_error_message_non_utf8_small_body_no_marker() {
+        // R12 pin: a small non-UTF8 body that fits in MAX_ERROR_ENTRY_LEN
+        // skips the marker (the fast path). No regression for legitimate
+        // tiny non-UTF8 responses.
+        let body = vec![0xffu8; 16];
+        let out = extract_error_message(&body);
+        // No marker present.
+        assert!(!out.contains("[...truncated"));
+        // No "non-UTF8 body" string (custom marker not used).
+        assert!(!out.contains("non-UTF8 body"));
     }
 }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -863,6 +863,25 @@ const MAX_ERROR_ENTRY_LEN: usize = 1024;
 /// the immutable `original_len` so its length doesn't shift under the trim.
 const MAX_SANITIZED_OUTPUT_LEN: usize = 4096;
 
+/// Maximum byte length of an error response body that will be parsed as JSON.
+///
+/// Defense against memory-amplification at the JSON parse step (OWASP A06 /
+/// AP11, Perplexity-validated 2026-05-11). `serde_json::from_str::<Value>`
+/// builds a full DOM that costs roughly 2-3x the body size in memory; a
+/// hostile server returning a valid 100 MB JSON body would force 200-300 MB
+/// of DOM allocation even though every downstream cap (`cap_entry`,
+/// `serialize_value_bounded`, `sanitize_for_stderr`) is in place. The
+/// downstream caps bound the OUTPUT — they cannot prevent the INPUT DOM
+/// from being materialized.
+///
+/// Bodies larger than this cap skip JSON parsing entirely and fall back to
+/// the raw-body path (which is itself byte-bounded via `cap_entry`). Per
+/// Perplexity-validated industry guidance the recommended pattern is a
+/// byte-level size gate at ~16 KiB for error-response paths; legitimate
+/// Atlassian/Jira error responses are <1 KiB, so 16 KiB is generous yet
+/// blocks the amplification vector.
+const MAX_PARSE_BODY_LEN: usize = 16 * 1024;
+
 /// Truncate a server-supplied string at a UTF-8 char boundary if it exceeds
 /// `MAX_ERROR_ENTRY_LEN`, appending a `[...truncated, N bytes total]` marker
 /// so the operator sees that truncation happened.
@@ -1183,6 +1202,26 @@ fn extract_error_message_raw(body: &[u8]) -> String {
         }
     };
 
+    // Memory-amplification defense at the JSON parse step (OWASP A06 / AP11,
+    // Perplexity-validated 2026-05-11, R11 finding). `serde_json::from_str::<Value>`
+    // materializes a full DOM that costs roughly 2-3x the body size in memory.
+    // Even though every downstream cap (cap_entry, serialize_value_bounded,
+    // sanitize_for_stderr) bounds OUTPUT, none of them prevent the INPUT DOM
+    // from being allocated. A hostile valid 100 MB JSON body would force
+    // 200-300 MB of DOM allocation before any cap kicks in.
+    //
+    // Size-gate at the byte level: bodies larger than MAX_PARSE_BODY_LEN
+    // (16 KiB) skip JSON parsing and fall back to the byte-bounded raw-body
+    // path. Legitimate Jira error responses are <1 KiB, so 16 KiB is a
+    // generous threshold that blocks the amplification vector without
+    // affecting real responses. The byte-level gate is preferred over a
+    // streaming/partial parse because it has zero allocation attack surface —
+    // we reject before serde_json::Value DOM materialization rather than
+    // hoping the streaming parse stops at the right point.
+    if body_str.len() > MAX_PARSE_BODY_LEN {
+        return cap_entry(body_str).into_owned();
+    }
+
     if let Ok(json) = serde_json::from_str::<serde_json::Value>(body_str) {
         if let Some(msgs) = json.get("errorMessages").and_then(|v| v.as_array()) {
             // Memory-amplification defense (OWASP A06 / AP11, Perplexity-validated
@@ -1326,8 +1365,8 @@ fn extract_error_message_raw(body: &[u8]) -> String {
 #[cfg(test)]
 mod sanitize_tests {
     use super::{
-        MAX_ERROR_ENTRY_LEN, MAX_SANITIZED_OUTPUT_LEN, cap_entry, sanitize_for_stderr,
-        serialize_value_bounded,
+        MAX_ERROR_ENTRY_LEN, MAX_PARSE_BODY_LEN, MAX_SANITIZED_OUTPUT_LEN, cap_entry,
+        extract_error_message, sanitize_for_stderr, serialize_value_bounded,
     };
 
     // Tiny helper to avoid repeating `.to_string()` in every call — keeps test
@@ -1731,5 +1770,61 @@ mod sanitize_tests {
         assert!(out.len() <= 5);
         // No room for the marker; must not be present.
         assert!(!out.contains("[...truncated]"));
+    }
+
+    // MAX_PARSE_BODY_LEN gate tests — memory-amplification defense at the
+    // JSON parse step (R11 finding). serde_json::from_str::<Value> builds a
+    // full DOM that costs ~2-3x body size; the gate falls back to the
+    // byte-bounded raw-body path for oversized bodies.
+
+    #[test]
+    fn test_extract_error_message_size_gate_skips_parse_for_huge_body() {
+        // Pin: a body larger than MAX_PARSE_BODY_LEN must NOT enter the
+        // JSON-parse path even if it's syntactically valid JSON. The output
+        // is the byte-bounded raw-body fallback (cap_entry applied to
+        // body_str) so a hostile 100 MB JSON body cannot force DOM
+        // allocation.
+        let huge_valid_json = format!(
+            "{{\"errorMessages\":[\"{}\"]}}",
+            "x".repeat(MAX_PARSE_BODY_LEN)
+        );
+        assert!(huge_valid_json.len() > MAX_PARSE_BODY_LEN);
+        let out = extract_error_message(huge_valid_json.as_bytes());
+        // sanitize_for_stderr caps total output at MAX_SANITIZED_OUTPUT_LEN.
+        assert!(
+            out.len() <= MAX_SANITIZED_OUTPUT_LEN,
+            "output exceeded sanitization cap: {} > {}",
+            out.len(),
+            MAX_SANITIZED_OUTPUT_LEN
+        );
+        // The fallback path uses the raw body, NOT the extracted
+        // errorMessages array. So the output should look like the
+        // serialized JSON string itself (or a capped prefix), not
+        // the de-quoted errorMessages content.
+        assert!(out.starts_with("{"));
+    }
+
+    #[test]
+    fn test_extract_error_message_size_gate_allows_normal_body() {
+        // Pin: legitimate small JSON error responses (well under
+        // MAX_PARSE_BODY_LEN) still take the JSON-parse path and produce
+        // the friendly extracted message — no regression from the gate.
+        let normal_body = r#"{"errorMessages":["Field 'summary' is required"]}"#;
+        assert!(normal_body.len() < MAX_PARSE_BODY_LEN);
+        let out = extract_error_message(normal_body.as_bytes());
+        // The errorMessages array element should be the visible output,
+        // not the raw JSON envelope.
+        assert!(out.contains("Field 'summary' is required"));
+        // And no leading "{" — the parse succeeded.
+        assert!(!out.starts_with("{"));
+    }
+
+    #[test]
+    fn test_extract_error_message_size_gate_threshold_is_documented_value() {
+        // Pin: the 16 KiB threshold is intentional — generous for legitimate
+        // Jira errors (<1 KiB typical) yet tight enough to block the
+        // amplification vector. Future tweaks should update the doc comment
+        // and Perplexity-revalidate.
+        assert_eq!(MAX_PARSE_BODY_LEN, 16 * 1024);
     }
 }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -840,6 +840,12 @@ const MAX_ERROR_ENTRY_LEN: usize = 1024;
 /// `MAX_ERROR_ENTRY_LEN`, appending a `[...truncated, N bytes total]` marker
 /// so the operator sees that truncation happened.
 ///
+/// The marker length is reserved from the prefix budget, so the FINAL output
+/// length is guaranteed to be `<= MAX_ERROR_ENTRY_LEN` — important because
+/// the marker would otherwise push slightly-oversized inputs (e.g., 1025
+/// bytes) to an output longer than the original, defeating the cap's
+/// flood-prevention purpose.
+///
 /// Used by `extract_error_message_raw` as defense-in-depth against
 /// terminal/log flooding attacks (companion to `sanitize_for_stderr`'s
 /// control-byte escaping per CWE-117).
@@ -847,11 +853,23 @@ fn cap_entry(s: &str) -> String {
     if s.len() <= MAX_ERROR_ENTRY_LEN {
         return s.to_string();
     }
-    let mut end = MAX_ERROR_ENTRY_LEN;
+    let marker = format!(" [...truncated, {} bytes total]", s.len());
+    // Defensive: with MAX_ERROR_ENTRY_LEN = 1024 and any plausible byte
+    // count, the marker is roughly 30-50 chars and well under the cap. This
+    // branch only fires if someone shrinks MAX_ERROR_ENTRY_LEN below the
+    // marker length in the future — in that case, returning just the marker
+    // preserves the size invariant (output_len <= MAX_ERROR_ENTRY_LEN +
+    // small overhead from the marker's own len which is < 64 bytes), which
+    // is still vastly smaller than the unbounded input.
+    if marker.len() >= MAX_ERROR_ENTRY_LEN {
+        return marker;
+    }
+    let target_prefix_len = MAX_ERROR_ENTRY_LEN - marker.len();
+    let mut end = target_prefix_len;
     while !s.is_char_boundary(end) {
         end -= 1;
     }
-    format!("{} [...truncated, {} bytes total]", &s[..end], s.len())
+    format!("{}{}", &s[..end], marker)
 }
 
 /// Sanitize a server-supplied string for safe display on stderr.
@@ -1128,6 +1146,44 @@ mod sanitize_tests {
             capped.contains(&(MAX_ERROR_ENTRY_LEN + 100).to_string()),
             "expected original byte count in marker: '{capped}'"
         );
+        // Size invariant: final output (prefix + marker) MUST stay within
+        // the cap, otherwise the marker overhead defeats the flood-prevention
+        // purpose of the cap.
+        assert!(
+            capped.len() <= MAX_ERROR_ENTRY_LEN,
+            "cap_entry output {} bytes exceeds MAX_ERROR_ENTRY_LEN {} bytes",
+            capped.len(),
+            MAX_ERROR_ENTRY_LEN
+        );
+    }
+
+    #[test]
+    fn test_cap_entry_size_invariant_at_boundary_oversize() {
+        // Regression pin for the Copilot R2 finding on PR #356: inputs only
+        // slightly larger than MAX_ERROR_ENTRY_LEN (e.g., 1025 bytes) used to
+        // produce an output LONGER than the input because the truncation
+        // marker overhead exceeded what was removed. The cap now reserves
+        // marker budget from the prefix, so output_len <= MAX_ERROR_ENTRY_LEN
+        // regardless of how close the input is to the boundary.
+        for over in [1, 2, 5, 50, 100, 1000, 10000] {
+            let s = "a".repeat(MAX_ERROR_ENTRY_LEN + over);
+            let capped = cap_entry(&s);
+            assert!(
+                capped.len() <= MAX_ERROR_ENTRY_LEN,
+                "size invariant violated for input len {} (over={}): output len = {}",
+                s.len(),
+                over,
+                capped.len()
+            );
+            // And the marker must still be present so the operator sees that
+            // truncation happened.
+            assert!(
+                capped.contains("[...truncated"),
+                "marker missing for input len {} (over={})",
+                s.len(),
+                over
+            );
+        }
     }
 
     #[test]
@@ -1141,5 +1197,11 @@ mod sanitize_tests {
         let capped = cap_entry(&with_multibyte);
         // Verify it's still valid UTF-8 by re-parsing.
         let _ = capped.as_str();
+        // Size invariant must also hold for UTF-8-bordering inputs.
+        assert!(
+            capped.len() <= MAX_ERROR_ENTRY_LEN,
+            "size invariant violated for UTF-8 input: output len = {}",
+            capped.len()
+        );
     }
 }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -825,6 +825,35 @@ impl JiraClient {
     }
 }
 
+/// Maximum byte length allowed for a single server-supplied error entry
+/// before it reaches `sanitize_for_stderr` / stderr.
+///
+/// Per issue #334 acceptance criteria: "Truncate each entry to a sane limit
+/// (e.g., 1 KiB) to prevent terminal-flooding attacks". Applied per-entry by
+/// `cap_entry` at the extraction call sites (each `errorMessages` element,
+/// each `errors` map value, the `message` field, the `errorMessage` field,
+/// and the raw-body fallback). 1024 bytes leaves ample room for legitimate
+/// long error messages while cutting off pathological flood attempts.
+const MAX_ERROR_ENTRY_LEN: usize = 1024;
+
+/// Truncate a server-supplied string at a UTF-8 char boundary if it exceeds
+/// `MAX_ERROR_ENTRY_LEN`, appending a `[...truncated, N bytes total]` marker
+/// so the operator sees that truncation happened.
+///
+/// Used by `extract_error_message_raw` as defense-in-depth against
+/// terminal/log flooding attacks (companion to `sanitize_for_stderr`'s
+/// control-byte escaping per CWE-117).
+fn cap_entry(s: &str) -> String {
+    if s.len() <= MAX_ERROR_ENTRY_LEN {
+        return s.to_string();
+    }
+    let mut end = MAX_ERROR_ENTRY_LEN;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{} [...truncated, {} bytes total]", &s[..end], s.len())
+}
+
 /// Sanitize a server-supplied string for safe display on stderr.
 ///
 /// Defense against CWE-117 (Improper Output Neutralization for Logs): a hostile
@@ -840,16 +869,41 @@ impl JiraClient {
 /// This is more conservative than `str::escape_debug` (which also escapes
 /// non-ASCII as `\u{XXXX}` and would garble legitimate Unicode error text).
 ///
-/// Performance: O(n) single pass, allocates the output buffer once via
-/// `String::with_capacity`. Idempotent on already-sanitized strings.
-fn sanitize_for_stderr(input: &str) -> String {
-    let mut out = String::with_capacity(input.len());
+/// Performance:
+/// - Takes `String` by value so the clean-input fast path returns it unchanged
+///   with zero additional allocation (most legitimate Atlassian errors hit this
+///   path — control chars are vanishingly rare in real responses).
+/// - When sanitization is required, escape bytes are written directly into the
+///   output via `std::fmt::Write::write!` rather than the per-char
+///   `format!()`-then-`push_str` pattern (which allocates a new String per
+///   escaped char).
+/// - The output buffer is pre-sized to `input.len()` plus a small headroom
+///   constant (`HEADROOM`); reallocations only occur when many control bytes
+///   expand (each one grows the buffer by 3 bytes: `\x` + 2 hex digits = 4
+///   bytes for 1 source byte).
+/// - Idempotent on already-sanitized strings.
+fn sanitize_for_stderr(input: String) -> String {
+    use std::fmt::Write;
+
+    // Fast path: no control bytes → return the input String unchanged.
+    // No new allocation. Optimizes the common case (legitimate Atlassian errors).
+    if !input.bytes().any(|b| b.is_ascii_control()) {
+        return input;
+    }
+
+    // Sanitization path: control bytes present. Pre-size output buffer with
+    // some headroom (one short attack escape line worth) to keep the common
+    // small-attack case allocation-free.
+    const HEADROOM: usize = 32;
+    let mut out = String::with_capacity(input.len() + HEADROOM);
     for c in input.chars() {
         if c.is_ascii_control() {
-            // ASCII control chars (0x00-0x1F + 0x7F) are guaranteed to fit in u8.
-            // Render as visible \xNN literal so operators can debug what was sent
-            // without the terminal interpreting CR/LF/ANSI/etc.
-            out.push_str(&format!("\\x{:02x}", c as u8));
+            // Write directly into `out` via fmt::Write — avoids the per-escape
+            // String allocation that `format!()` would introduce.
+            // ASCII control chars (0x00-0x1F + 0x7F) fit in u8.
+            // write! on String is infallible; ignore the Result to avoid a
+            // distracting `expect()` in a hot loop.
+            let _ = write!(out, "\\x{:02x}", c as u8);
         } else {
             out.push(c);
         }
@@ -872,10 +926,14 @@ fn sanitize_for_stderr(input: &str) -> String {
 /// 5. Empty body → "<empty response body>"
 /// 6. Raw body as a string (fallback)
 pub fn extract_error_message(body: &[u8]) -> String {
-    sanitize_for_stderr(&extract_error_message_raw(body))
+    sanitize_for_stderr(extract_error_message_raw(body))
 }
 
 /// Internal: extract the error message WITHOUT stderr sanitization.
+///
+/// Each server-supplied entry is passed through `cap_entry` so a single
+/// pathological field can't flood the terminal/log — the per-entry 1 KiB cap
+/// is part of the CWE-117 defense-in-depth alongside `sanitize_for_stderr`.
 ///
 /// Separated from the public API so the extraction precedence logic and the
 /// sanitization layer can be tested independently. Callers OUTSIDE tests should
@@ -887,12 +945,16 @@ fn extract_error_message_raw(body: &[u8]) -> String {
 
     let body_str = match std::str::from_utf8(body) {
         Ok(s) => s,
-        Err(_) => return String::from_utf8_lossy(body).into_owned(),
+        Err(_) => return cap_entry(&String::from_utf8_lossy(body)),
     };
 
     if let Ok(json) = serde_json::from_str::<serde_json::Value>(body_str) {
         if let Some(msgs) = json.get("errorMessages").and_then(|v| v.as_array()) {
-            let messages: Vec<&str> = msgs.iter().filter_map(|m| m.as_str()).collect();
+            let messages: Vec<String> = msgs
+                .iter()
+                .filter_map(|m| m.as_str())
+                .map(cap_entry)
+                .collect();
             if !messages.is_empty() {
                 return messages.join("; ");
             }
@@ -902,11 +964,12 @@ fn extract_error_message_raw(body: &[u8]) -> String {
                 let mut pairs: Vec<String> = errors
                     .iter()
                     .map(|(k, v)| {
-                        if let Some(s) = v.as_str() {
-                            format!("{k}: {s}")
+                        let value_str = if let Some(s) = v.as_str() {
+                            cap_entry(s)
                         } else {
-                            format!("{k}: {v}")
-                        }
+                            cap_entry(&v.to_string())
+                        };
+                        format!("{k}: {value_str}")
                     })
                     .collect();
                 pairs.sort();
@@ -914,41 +977,47 @@ fn extract_error_message_raw(body: &[u8]) -> String {
             }
         }
         if let Some(msg) = json.get("message").and_then(|v| v.as_str()) {
-            return msg.to_string();
+            return cap_entry(msg);
         }
         if let Some(msg) = json.get("errorMessage").and_then(|v| v.as_str()) {
-            return msg.to_string();
+            return cap_entry(msg);
         }
     }
 
-    body_str.to_string()
+    cap_entry(body_str)
 }
 
 #[cfg(test)]
 mod sanitize_tests {
-    use super::sanitize_for_stderr;
+    use super::{MAX_ERROR_ENTRY_LEN, cap_entry, sanitize_for_stderr};
+
+    // Tiny helper to avoid repeating `.to_string()` in every call — keeps test
+    // lines compact now that `sanitize_for_stderr` takes `String` by value.
+    fn sanitize(s: &str) -> String {
+        sanitize_for_stderr(s.to_string())
+    }
 
     #[test]
     fn test_sanitize_for_stderr_passes_through_clean_ascii() {
-        assert_eq!(sanitize_for_stderr("Hello, World!"), "Hello, World!");
+        assert_eq!(sanitize("Hello, World!"), "Hello, World!");
     }
 
     #[test]
     fn test_sanitize_for_stderr_passes_through_utf8() {
         // Localized error messages (non-English Jira tenants) must survive.
-        assert_eq!(sanitize_for_stderr("résumé"), "résumé");
-        assert_eq!(sanitize_for_stderr("日本語のエラー"), "日本語のエラー");
-        assert_eq!(sanitize_for_stderr("Привет"), "Привет");
+        assert_eq!(sanitize("résumé"), "résumé");
+        assert_eq!(sanitize("日本語のエラー"), "日本語のエラー");
+        assert_eq!(sanitize("Привет"), "Привет");
     }
 
     #[test]
     fn test_sanitize_for_stderr_escapes_carriage_return() {
-        assert_eq!(sanitize_for_stderr("line1\rline2"), "line1\\x0dline2");
+        assert_eq!(sanitize("line1\rline2"), "line1\\x0dline2");
     }
 
     #[test]
     fn test_sanitize_for_stderr_escapes_line_feed() {
-        assert_eq!(sanitize_for_stderr("line1\nline2"), "line1\\x0aline2");
+        assert_eq!(sanitize("line1\nline2"), "line1\\x0aline2");
     }
 
     #[test]
@@ -956,7 +1025,7 @@ mod sanitize_tests {
         // CWE-117 attack pattern: hostile message tries to inject a fake log line
         // by ending one line and starting another with what looks like a logger prefix.
         let attack = "Issue not found\r\n[jr] CRITICAL: token leaked";
-        let sanitized = sanitize_for_stderr(attack);
+        let sanitized = sanitize(attack);
         assert_eq!(
             sanitized,
             "Issue not found\\x0d\\x0a[jr] CRITICAL: token leaked"
@@ -971,34 +1040,34 @@ mod sanitize_tests {
     fn test_sanitize_for_stderr_escapes_ansi_escape_sequence() {
         // \x1b is ESC, the prefix for ANSI escape sequences (color, cursor, etc.).
         let attack = "Error\x1b[31m red text \x1b[0m";
-        let sanitized = sanitize_for_stderr(attack);
+        let sanitized = sanitize(attack);
         assert_eq!(sanitized, "Error\\x1b[31m red text \\x1b[0m");
         assert!(!sanitized.contains('\x1b'));
     }
 
     #[test]
     fn test_sanitize_for_stderr_escapes_null_byte() {
-        assert_eq!(sanitize_for_stderr("a\0b"), "a\\x00b");
+        assert_eq!(sanitize("a\0b"), "a\\x00b");
     }
 
     #[test]
     fn test_sanitize_for_stderr_escapes_tab() {
         // Tab is ASCII control (0x09). Conservatively escape — a sequence of tabs
         // can hide text behind column boundaries in some loggers / tab-aware UIs.
-        assert_eq!(sanitize_for_stderr("a\tb"), "a\\x09b");
+        assert_eq!(sanitize("a\tb"), "a\\x09b");
     }
 
     #[test]
     fn test_sanitize_for_stderr_escapes_del_character() {
         // 0x7F (DEL) is the last ASCII control char.
-        assert_eq!(sanitize_for_stderr("a\x7fb"), "a\\x7fb");
+        assert_eq!(sanitize("a\x7fb"), "a\\x7fb");
     }
 
     #[test]
     fn test_sanitize_for_stderr_preserves_space_and_punctuation() {
         // Space (0x20) is NOT a control char. Punctuation is fine.
         assert_eq!(
-            sanitize_for_stderr("Hello, World! (with punctuation)"),
+            sanitize("Hello, World! (with punctuation)"),
             "Hello, World! (with punctuation)"
         );
     }
@@ -1006,13 +1075,71 @@ mod sanitize_tests {
     #[test]
     fn test_sanitize_for_stderr_is_idempotent() {
         // Sanitizing an already-sanitized string is a no-op (no double-escaping).
-        let once = sanitize_for_stderr("a\r\nb");
-        let twice = sanitize_for_stderr(&once);
+        let once = sanitize("a\r\nb");
+        let twice = sanitize_for_stderr(once.clone());
         assert_eq!(once, twice);
     }
 
     #[test]
     fn test_sanitize_for_stderr_empty_string() {
-        assert_eq!(sanitize_for_stderr(""), "");
+        assert_eq!(sanitize(""), "");
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_clean_input_returns_same_string() {
+        // Performance pin: the fast path returns the input String unchanged,
+        // so the legitimate-error common case avoids the sanitization allocation.
+        let input = String::from("legitimate error message with UTF-8: 日本語");
+        let original_ptr = input.as_ptr();
+        let result = sanitize_for_stderr(input);
+        assert_eq!(
+            result.as_ptr(),
+            original_ptr,
+            "fast path should reuse the same buffer"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // cap_entry tests — per-entry length cap per issue #334 acceptance criteria
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_cap_entry_passes_through_short_input() {
+        let s = "short message";
+        assert_eq!(cap_entry(s), s);
+    }
+
+    #[test]
+    fn test_cap_entry_passes_through_at_max_length() {
+        let s = "a".repeat(MAX_ERROR_ENTRY_LEN);
+        assert_eq!(cap_entry(&s), s);
+    }
+
+    #[test]
+    fn test_cap_entry_truncates_oversized_with_marker() {
+        let s = "a".repeat(MAX_ERROR_ENTRY_LEN + 100);
+        let capped = cap_entry(&s);
+        assert!(capped.len() < s.len(), "expected truncation");
+        assert!(
+            capped.contains("[...truncated"),
+            "expected truncation marker in '{capped}'"
+        );
+        assert!(
+            capped.contains(&(MAX_ERROR_ENTRY_LEN + 100).to_string()),
+            "expected original byte count in marker: '{capped}'"
+        );
+    }
+
+    #[test]
+    fn test_cap_entry_respects_utf8_char_boundary() {
+        // Build a string whose byte length exceeds the cap with a multibyte
+        // char straddling the cap boundary. The truncation must NOT split
+        // a UTF-8 char (would panic via &str[..end]).
+        let padding = "a".repeat(MAX_ERROR_ENTRY_LEN - 2);
+        let with_multibyte = format!("{padding}日本語のエラーです");
+        // Should not panic, should produce valid UTF-8.
+        let capped = cap_entry(&with_multibyte);
+        // Verify it's still valid UTF-8 by re-parsing.
+        let _ = capped.as_str();
     }
 }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -825,7 +825,44 @@ impl JiraClient {
     }
 }
 
+/// Sanitize a server-supplied string for safe display on stderr.
+///
+/// Defense against CWE-117 (Improper Output Neutralization for Logs): a hostile
+/// Atlassian response or proxy-controlled `errorMessages` array could otherwise
+/// inject CR/LF fake log lines, ANSI escape sequences (cursor movement, color
+/// codes, terminal title changes), or NUL bytes into operator-facing stderr
+/// output.
+///
+/// Strategy: pass through every printable character (including UTF-8 to preserve
+/// localized error messages from non-English Jira tenants) and replace every
+/// ASCII control character (0x00-0x1F + 0x7F) with its `\xNN` literal escape so
+/// the operator can see what was sent but the terminal cannot interpret it.
+/// This is more conservative than `str::escape_debug` (which also escapes
+/// non-ASCII as `\u{XXXX}` and would garble legitimate Unicode error text).
+///
+/// Performance: O(n) single pass, allocates the output buffer once via
+/// `String::with_capacity`. Idempotent on already-sanitized strings.
+fn sanitize_for_stderr(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for c in input.chars() {
+        if c.is_ascii_control() {
+            // ASCII control chars (0x00-0x1F + 0x7F) are guaranteed to fit in u8.
+            // Render as visible \xNN literal so operators can debug what was sent
+            // without the terminal interpreting CR/LF/ANSI/etc.
+            out.push_str(&format!("\\x{:02x}", c as u8));
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 /// Extract a human-readable error message from a Jira error response body.
+///
+/// All return paths run through `sanitize_for_stderr` (CWE-117 defense:
+/// strips ASCII control chars from server-supplied content before it reaches
+/// stderr, preventing CR/LF/ANSI injection from a hostile or proxy-controlled
+/// response). UTF-8 in legitimate localized error messages is preserved.
 ///
 /// Precedence:
 /// 1. Non-empty `errorMessages` array → joined with "; "
@@ -835,6 +872,15 @@ impl JiraClient {
 /// 5. Empty body → "<empty response body>"
 /// 6. Raw body as a string (fallback)
 pub fn extract_error_message(body: &[u8]) -> String {
+    sanitize_for_stderr(&extract_error_message_raw(body))
+}
+
+/// Internal: extract the error message WITHOUT stderr sanitization.
+///
+/// Separated from the public API so the extraction precedence logic and the
+/// sanitization layer can be tested independently. Callers OUTSIDE tests should
+/// always go through `extract_error_message`.
+fn extract_error_message_raw(body: &[u8]) -> String {
     if body.is_empty() {
         return "<empty response body>".to_string();
     }
@@ -876,4 +922,97 @@ pub fn extract_error_message(body: &[u8]) -> String {
     }
 
     body_str.to_string()
+}
+
+#[cfg(test)]
+mod sanitize_tests {
+    use super::sanitize_for_stderr;
+
+    #[test]
+    fn test_sanitize_for_stderr_passes_through_clean_ascii() {
+        assert_eq!(sanitize_for_stderr("Hello, World!"), "Hello, World!");
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_passes_through_utf8() {
+        // Localized error messages (non-English Jira tenants) must survive.
+        assert_eq!(sanitize_for_stderr("résumé"), "résumé");
+        assert_eq!(sanitize_for_stderr("日本語のエラー"), "日本語のエラー");
+        assert_eq!(sanitize_for_stderr("Привет"), "Привет");
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_escapes_carriage_return() {
+        assert_eq!(sanitize_for_stderr("line1\rline2"), "line1\\x0dline2");
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_escapes_line_feed() {
+        assert_eq!(sanitize_for_stderr("line1\nline2"), "line1\\x0aline2");
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_escapes_crlf_fake_log_injection() {
+        // CWE-117 attack pattern: hostile message tries to inject a fake log line
+        // by ending one line and starting another with what looks like a logger prefix.
+        let attack = "Issue not found\r\n[jr] CRITICAL: token leaked";
+        let sanitized = sanitize_for_stderr(attack);
+        assert_eq!(
+            sanitized,
+            "Issue not found\\x0d\\x0a[jr] CRITICAL: token leaked"
+        );
+        // Critically, the literal "\r\n" sequence is gone — the terminal can't break
+        // the line, so the operator sees the whole attack on one line.
+        assert!(!sanitized.contains('\r'));
+        assert!(!sanitized.contains('\n'));
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_escapes_ansi_escape_sequence() {
+        // \x1b is ESC, the prefix for ANSI escape sequences (color, cursor, etc.).
+        let attack = "Error\x1b[31m red text \x1b[0m";
+        let sanitized = sanitize_for_stderr(attack);
+        assert_eq!(sanitized, "Error\\x1b[31m red text \\x1b[0m");
+        assert!(!sanitized.contains('\x1b'));
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_escapes_null_byte() {
+        assert_eq!(sanitize_for_stderr("a\0b"), "a\\x00b");
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_escapes_tab() {
+        // Tab is ASCII control (0x09). Conservatively escape — a sequence of tabs
+        // can hide text behind column boundaries in some loggers / tab-aware UIs.
+        assert_eq!(sanitize_for_stderr("a\tb"), "a\\x09b");
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_escapes_del_character() {
+        // 0x7F (DEL) is the last ASCII control char.
+        assert_eq!(sanitize_for_stderr("a\x7fb"), "a\\x7fb");
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_preserves_space_and_punctuation() {
+        // Space (0x20) is NOT a control char. Punctuation is fine.
+        assert_eq!(
+            sanitize_for_stderr("Hello, World! (with punctuation)"),
+            "Hello, World! (with punctuation)"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_is_idempotent() {
+        // Sanitizing an already-sanitized string is a no-op (no double-escaping).
+        let once = sanitize_for_stderr("a\r\nb");
+        let twice = sanitize_for_stderr(&once);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_empty_string() {
+        assert_eq!(sanitize_for_stderr(""), "");
+    }
 }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1062,15 +1062,19 @@ fn serialize_value_bounded(v: &serde_json::Value, limit: usize) -> String {
 /// Strategy:
 /// - Pass through every printable character (including UTF-8 to preserve
 ///   localized error messages from non-English Jira tenants).
-/// - Replace every ASCII control character (0x00-0x1F + 0x7F) with its
-///   `\xNN` literal escape so the operator can see what was sent but the
-///   terminal cannot interpret it.
+/// - Replace every Unicode control character (per `char::is_control()`) with
+///   a visible escape so the operator can see what was sent but the terminal
+///   cannot interpret it:
+///   - ASCII controls (C0 = 0x00-0x1F, plus DEL = 0x7F) → `\xNN` (4 bytes)
+///   - C1 controls (U+0080..U+009F, including CSI U+009B and NEL U+0085) →
+///     `\u{NNNN}` (8 bytes); preserved as visible escapes for defense-in-depth
+///     against legacy/non-UTF8 terminals.
 /// - Enforce a `MAX_SANITIZED_OUTPUT_LEN` cap on the FINAL output bytes via
 ///   a byte-budget-aware char loop. Closes the gap where pre-sanitization
 ///   per-entry caps (via `cap_entry`) couldn't bound the post-sanitization
-///   output: 1024 control bytes expand to ~4096 bytes after `\xNN`
-///   escaping, so a per-entry pre-cap alone left the terminal vulnerable
-///   to floods.
+///   output: 1024 ASCII control bytes expand to ~4096 bytes after `\xNN`
+///   escaping (C1 controls have the same 4x expansion factor: 2 → 8 bytes),
+///   so a per-entry pre-cap alone left the terminal vulnerable to floods.
 ///
 /// More conservative than `str::escape_debug` (which also escapes non-ASCII
 /// as `\u{XXXX}` and would garble legitimate Unicode error text).
@@ -1125,12 +1129,16 @@ fn sanitize_for_stderr(input: String) -> String {
         //   (still 4x, preserving the 4 KiB cap's worst-case budget)
         // - Other chars: `c.len_utf8()` (1-4 bytes for any Unicode scalar)
         //
-        // C1 controls (U+0080..U+009F) are inert in modern UTF-8 terminals
-        // (rejected as invalid UTF-8 continuation bytes), so they are not
-        // a current vector — but legacy/embedded/non-UTF8 terminals could
-        // still interpret U+009B (CSI) and friends as control sequences.
-        // `char::is_control()` catches both C0 and C1 for comprehensive
-        // defense-in-depth.
+        // C1 controls (U+0080..U+009F) are valid Unicode codepoints with
+        // valid 2-byte UTF-8 encodings (e.g., U+009B = 0xC2 0x9B), but
+        // modern UTF-8 terminals generally do NOT act on them as control
+        // sequences — a single raw byte in 0x80-0x9F is treated as an
+        // invalid leading byte and dropped, and a properly-encoded
+        // codepoint is decoded but most terminals ignore the C1 semantics
+        // entirely in UTF-8 mode. Legacy/embedded/non-UTF8 terminals can
+        // still interpret U+009B (CSI) and friends as control sequences,
+        // so we escape them here for comprehensive defense-in-depth.
+        // `char::is_control()` catches both C0 and C1.
         let needed = if c.is_control() {
             if c.is_ascii() { 4 } else { 8 }
         } else {

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1048,30 +1048,58 @@ fn extract_error_message_raw(body: &[u8]) -> String {
 
     let body_str = match std::str::from_utf8(body) {
         Ok(s) => s,
-        Err(_) => return cap_entry(&String::from_utf8_lossy(body)).into_owned(),
+        Err(_) => {
+            // Memory-amplification defense (OWASP A06 / AP11, Perplexity-validated
+            // 2026-05-11): `String::from_utf8_lossy` allocates an owned String for
+            // the ENTIRE byte slice even though `cap_entry` will truncate the result
+            // to MAX_ERROR_ENTRY_LEN. A hostile server returning a massive non-UTF8
+            // body would otherwise force O(body.len()) memory allocation before the
+            // cap kicks in. Pre-cap the byte slice to a small multiple of the entry
+            // cap (allows worst-case lossy expansion via U+FFFD replacement chars
+            // at 3 bytes each) before conversion.
+            const PRE_CAP_BYTES: usize = MAX_ERROR_ENTRY_LEN * 4;
+            let bounded = &body[..body.len().min(PRE_CAP_BYTES)];
+            return cap_entry(&String::from_utf8_lossy(bounded)).into_owned();
+        }
     };
 
     if let Ok(json) = serde_json::from_str::<serde_json::Value>(body_str) {
         if let Some(msgs) = json.get("errorMessages").and_then(|v| v.as_array()) {
-            // Collect as Cow<str> so unchanged entries borrow rather than
-            // allocate. Only over-cap entries pay the allocation cost.
-            let messages: Vec<std::borrow::Cow<'_, str>> = msgs
-                .iter()
-                .filter_map(|m| m.as_str())
-                .map(cap_entry)
-                .collect();
-            if !messages.is_empty() {
-                // Build the joined string with a single allocation
-                // pre-sized to the total content length. Avoids the
-                // intermediate `Vec<&str>` + `[].join()` allocation chain.
-                let total: usize =
-                    messages.iter().map(|c| c.len()).sum::<usize>() + 2 * (messages.len() - 1);
-                let mut joined = String::with_capacity(total);
-                for (i, m) in messages.iter().enumerate() {
-                    if i > 0 {
-                        joined.push_str("; ");
-                    }
-                    joined.push_str(m.as_ref());
+            // Memory-amplification defense (OWASP A06 / AP11, Perplexity-validated
+            // 2026-05-11): even though each entry is per-entry-capped via
+            // cap_entry, the NUMBER of entries is server-controlled. A hostile
+            // response with a million entries × 1024 bytes each would force a
+            // ~1 GB allocation in the join here before `sanitize_for_stderr` later
+            // truncates to MAX_SANITIZED_OUTPUT_LEN. Stream-process instead:
+            // iterate lazily, append to a single output String pre-sized to
+            // MAX_SANITIZED_OUTPUT_LEN, and stop as soon as the budget is hit.
+            // Total memory is O(MAX_SANITIZED_OUTPUT_LEN) regardless of entry
+            // count. The downstream sanitize_for_stderr cap is retained as
+            // defense-in-depth for control-byte expansion.
+            let mut joined = String::with_capacity(MAX_SANITIZED_OUTPUT_LEN);
+            let mut first = true;
+            let mut truncated = false;
+            let mut emitted_any = false;
+
+            for m_value in msgs.iter() {
+                let Some(m) = m_value.as_str() else { continue };
+                let capped = cap_entry(m);
+                let separator_len = if first { 0 } else { 2 };
+                if joined.len() + separator_len + capped.len() > MAX_SANITIZED_OUTPUT_LEN {
+                    truncated = true;
+                    break;
+                }
+                if !first {
+                    joined.push_str("; ");
+                }
+                joined.push_str(capped.as_ref());
+                first = false;
+                emitted_any = true;
+            }
+
+            if emitted_any {
+                if truncated {
+                    joined.push_str(" [...truncated]");
                 }
                 return joined;
             }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -850,8 +850,10 @@ const MAX_ERROR_ENTRY_LEN: usize = 1024;
 /// byte becomes a 4-byte `\xNN` literal) — can still flood the terminal
 /// or log file. This cap is enforced inside `sanitize_for_stderr` itself
 /// using a byte-budget-aware char loop that stops emitting when the next
-/// char would exceed the budget, then appends a `[...truncated at N
-/// sanitized bytes; original M bytes]` marker.
+/// char would exceed the budget, then appends a `[...truncated; original
+/// M bytes]` marker (R6: marker text references only the immutable
+/// `original_len`, not `out.len()`, to avoid over-reporting after any
+/// retroactive trim).
 ///
 /// 4 KiB chosen to absorb worst-case 4x expansion of a single `MAX_ERROR_ENTRY_LEN`
 /// entry (1024 × 4 = 4096) while still leaving room for the marker via
@@ -986,22 +988,27 @@ fn sanitize_for_stderr(input: String) -> String {
     }
 
     if truncated {
-        // Build the marker with the actual sanitized-bytes value at the time
-        // of truncation (out.len() before the marker is appended) and the
-        // original input length.
-        let marker = format!(
-            " [...truncated at {} sanitized bytes; original {} bytes]",
-            out.len(),
-            original_len
-        );
+        // CWE-117 / PR #356 R6 fix: marker text intentionally does NOT
+        // reference `out.len()` — only the (immutable) `original_len`. This
+        // makes the marker's length depend solely on original_len's digit
+        // count (so the retroactive trim doesn't change the marker length)
+        // and prevents the over-reporting issue where the marker would
+        // claim a byte count that no longer matches the trimmed output.
+        // The operator gets accurate info: "original M bytes" — the actual
+        // size that was thrown away, with the final output size being
+        // exactly out.len() bytes (which they can observe directly).
+        let marker = format!(" [...truncated; original {} bytes]", original_len);
         if out.len() + marker.len() <= MAX_SANITIZED_OUTPUT_LEN {
-            // Marker fits without trimming.
+            // Marker fits without trimming — append directly.
             out.push_str(&marker);
         } else {
             // Marker would push us over: retroactively trim `out` at a UTF-8
-            // char boundary so `out + marker` fits within the cap. The trim
-            // is bounded by marker.len() (< 80 bytes for any plausible
-            // original_len) — bounded work, no quadratic blow-up.
+            // char boundary so `out + marker` fits within the cap. Bounded
+            // by marker.len() (~50 bytes for any plausible original_len), so
+            // no quadratic blow-up. The marker text is unchanged by the
+            // trim (it only references original_len), so this preserves the
+            // size invariant `out.len() + marker.len() <= cap` AFTER the
+            // trim — verified empirically by the new size-invariant tests.
             let target = MAX_SANITIZED_OUTPUT_LEN - marker.len();
             let mut end = target;
             while !out.is_char_boundary(end) {
@@ -1076,6 +1083,12 @@ fn extract_error_message_raw(body: &[u8]) -> String {
             // Total memory is O(MAX_SANITIZED_OUTPUT_LEN) regardless of entry
             // count. The downstream sanitize_for_stderr cap is retained as
             // defense-in-depth for control-byte expansion.
+            // R6 fix: reserve marker budget upfront in the budget check (the
+            // standard pattern per Perplexity 2026-05-11 — retroactive trim
+            // risks marker overflow). Marker is fixed-length so the
+            // reservation is a 15-byte constant; no recalculation needed.
+            const JOIN_MARKER: &str = " [...truncated]";
+            let content_budget_join = MAX_SANITIZED_OUTPUT_LEN.saturating_sub(JOIN_MARKER.len());
             let mut joined = String::with_capacity(MAX_SANITIZED_OUTPUT_LEN);
             let mut first = true;
             let mut truncated = false;
@@ -1085,7 +1098,7 @@ fn extract_error_message_raw(body: &[u8]) -> String {
                 let Some(m) = m_value.as_str() else { continue };
                 let capped = cap_entry(m);
                 let separator_len = if first { 0 } else { 2 };
-                if joined.len() + separator_len + capped.len() > MAX_SANITIZED_OUTPUT_LEN {
+                if joined.len() + separator_len + capped.len() > content_budget_join {
                     truncated = true;
                     break;
                 }
@@ -1099,8 +1112,9 @@ fn extract_error_message_raw(body: &[u8]) -> String {
 
             if emitted_any {
                 if truncated {
-                    joined.push_str(" [...truncated]");
+                    joined.push_str(JOIN_MARKER);
                 }
+                debug_assert!(joined.len() <= MAX_SANITIZED_OUTPUT_LEN);
                 return joined;
             }
         }
@@ -1362,6 +1376,36 @@ mod sanitize_tests {
             MAX_SANITIZED_OUTPUT_LEN
         );
         assert!(result.contains("[...truncated"));
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_truncation_marker_excludes_out_len() {
+        // R6 fix: the truncation marker must NOT reference out.len() — only
+        // `original_len`. This makes the marker length independent of any
+        // retroactive trim and prevents the over-reporting bug where the
+        // marker claimed a byte count that didn't match the trimmed output.
+        let input = "a".repeat(MAX_SANITIZED_OUTPUT_LEN + 100);
+        let original_len = input.len();
+        let result = sanitize_for_stderr(input);
+        // Marker should mention original_len (input bytes), not anything
+        // resembling out.len() (post-trim bytes).
+        assert!(
+            result.contains(&format!("original {} bytes", original_len)),
+            "marker should reference original_len; got: {result}"
+        );
+        // Negative pin: marker should NOT contain "sanitized bytes" or "at N"
+        // phrasing that would over-report after trim.
+        assert!(
+            !result.contains("sanitized bytes"),
+            "marker should not over-report sanitized byte count; got: {result}"
+        );
+        // Size invariant: final output stays within cap.
+        assert!(
+            result.len() <= MAX_SANITIZED_OUTPUT_LEN,
+            "output {} bytes exceeds cap {}",
+            result.len(),
+            MAX_SANITIZED_OUTPUT_LEN
+        );
     }
 
     #[test]

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -834,7 +834,29 @@ impl JiraClient {
 /// each `errors` map value, the `message` field, the `errorMessage` field,
 /// and the raw-body fallback). 1024 bytes leaves ample room for legitimate
 /// long error messages while cutting off pathological flood attempts.
+///
+/// Companion cap: `MAX_SANITIZED_OUTPUT_LEN` below, which bounds the FINAL
+/// stderr-bound output AFTER sanitization expansion (each ASCII control
+/// byte becomes 4 bytes via the `\xNN` escape). The per-entry cap alone
+/// is insufficient because a hostile array of `\n`-filled entries could
+/// expand 4x during sanitization.
 const MAX_ERROR_ENTRY_LEN: usize = 1024;
+
+/// Maximum byte length of the FINAL sanitized output written to stderr.
+///
+/// Even with `MAX_ERROR_ENTRY_LEN` capping each pre-sanitization entry,
+/// a hostile response containing many entries — or entries full of control
+/// bytes that expand 1→4 bytes during sanitization (each ASCII control
+/// byte becomes a 4-byte `\xNN` literal) — can still flood the terminal
+/// or log file. This cap is enforced inside `sanitize_for_stderr` itself
+/// using a byte-budget-aware char loop that stops emitting when the next
+/// char would exceed the budget, then appends a `[...truncated at N
+/// sanitized bytes; original M bytes]` marker.
+///
+/// 4 KiB chosen to absorb worst-case 4x expansion of a single `MAX_ERROR_ENTRY_LEN`
+/// entry (1024 × 4 = 4096) while still leaving room for the marker via
+/// reserved headroom inside `sanitize_for_stderr`.
+const MAX_SANITIZED_OUTPUT_LEN: usize = 4096;
 
 /// Truncate a server-supplied string at a UTF-8 char boundary if it exceeds
 /// `MAX_ERROR_ENTRY_LEN`, appending a `[...truncated, N bytes total]` marker
@@ -857,12 +879,15 @@ fn cap_entry(s: &str) -> String {
     // Defensive: with MAX_ERROR_ENTRY_LEN = 1024 and any plausible byte
     // count, the marker is roughly 30-50 chars and well under the cap. This
     // branch only fires if someone shrinks MAX_ERROR_ENTRY_LEN below the
-    // marker length in the future — in that case, returning just the marker
-    // preserves the size invariant (output_len <= MAX_ERROR_ENTRY_LEN +
-    // small overhead from the marker's own len which is < 64 bytes), which
-    // is still vastly smaller than the unbounded input.
+    // marker length in the future. To preserve the `output.len() <=
+    // MAX_ERROR_ENTRY_LEN` invariant even in that case, truncate the marker
+    // itself at a UTF-8 char boundary instead of returning it whole.
     if marker.len() >= MAX_ERROR_ENTRY_LEN {
-        return marker;
+        let mut end = MAX_ERROR_ENTRY_LEN;
+        while !marker.is_char_boundary(end) {
+            end -= 1;
+        }
+        return marker[..end].to_string();
     }
     let target_prefix_len = MAX_ERROR_ENTRY_LEN - marker.len();
     let mut end = target_prefix_len;
@@ -880,41 +905,70 @@ fn cap_entry(s: &str) -> String {
 /// codes, terminal title changes), or NUL bytes into operator-facing stderr
 /// output.
 ///
-/// Strategy: pass through every printable character (including UTF-8 to preserve
-/// localized error messages from non-English Jira tenants) and replace every
-/// ASCII control character (0x00-0x1F + 0x7F) with its `\xNN` literal escape so
-/// the operator can see what was sent but the terminal cannot interpret it.
-/// This is more conservative than `str::escape_debug` (which also escapes
-/// non-ASCII as `\u{XXXX}` and would garble legitimate Unicode error text).
+/// Strategy:
+/// - Pass through every printable character (including UTF-8 to preserve
+///   localized error messages from non-English Jira tenants).
+/// - Replace every ASCII control character (0x00-0x1F + 0x7F) with its
+///   `\xNN` literal escape so the operator can see what was sent but the
+///   terminal cannot interpret it.
+/// - Enforce a `MAX_SANITIZED_OUTPUT_LEN` cap on the FINAL output bytes via
+///   a byte-budget-aware char loop. Closes the gap where pre-sanitization
+///   per-entry caps (via `cap_entry`) couldn't bound the post-sanitization
+///   output: 1024 control bytes expand to ~4096 bytes after `\xNN`
+///   escaping, so a per-entry pre-cap alone left the terminal vulnerable
+///   to floods.
+///
+/// More conservative than `str::escape_debug` (which also escapes non-ASCII
+/// as `\u{XXXX}` and would garble legitimate Unicode error text).
 ///
 /// Performance:
-/// - Takes `String` by value so the clean-input fast path returns it unchanged
-///   with zero additional allocation (most legitimate Atlassian errors hit this
-///   path — control chars are vanishingly rare in real responses).
-/// - When sanitization is required, escape bytes are written directly into the
-///   output via `std::fmt::Write::write!` rather than the per-char
-///   `format!()`-then-`push_str` pattern (which allocates a new String per
-///   escaped char).
-/// - The output buffer is pre-sized to `input.len()` plus a small headroom
-///   constant (`HEADROOM`); reallocations only occur when many control bytes
-///   expand (each one grows the buffer by 3 bytes: `\x` + 2 hex digits = 4
-///   bytes for 1 source byte).
-/// - Idempotent on already-sanitized strings.
+/// - Takes `String` by value so the clean+small-input fast path returns it
+///   unchanged with zero additional allocation. The common case (legitimate
+///   Atlassian errors: ASCII + UTF-8, no control bytes, < 4 KiB) hits this
+///   path.
+/// - When sanitization OR truncation is required, escape bytes are written
+///   directly into the output via `std::fmt::Write::write!` rather than the
+///   per-char `format!()`-then-`push_str` pattern (which allocates a new
+///   String per escaped char).
+/// - Output buffer is pre-sized to the smaller of `input.len() + HEADROOM`
+///   and `MAX_SANITIZED_OUTPUT_LEN`, so the allocation is bounded.
+/// - Idempotent on already-sanitized strings within the size cap.
 fn sanitize_for_stderr(input: String) -> String {
     use std::fmt::Write;
 
-    // Fast path: no control bytes → return the input String unchanged.
-    // No new allocation. Optimizes the common case (legitimate Atlassian errors).
-    if !input.bytes().any(|b| b.is_ascii_control()) {
+    let needs_sanitization = input.bytes().any(|b| b.is_ascii_control());
+    let needs_truncation = input.len() > MAX_SANITIZED_OUTPUT_LEN;
+
+    // Fast path: no control bytes AND under the output cap → return the
+    // input String unchanged. No new allocation. Optimizes the common case.
+    if !needs_sanitization && !needs_truncation {
         return input;
     }
 
-    // Sanitization path: control bytes present. Pre-size output buffer with
-    // some headroom (one short attack escape line worth) to keep the common
-    // small-attack case allocation-free.
+    // Slow path: sanitize AND/OR truncate. Reserve headroom for the
+    // truncation marker so we can append it without exceeding the cap.
+    const MAX_MARKER_LEN: usize = 64;
+    let prefix_budget = MAX_SANITIZED_OUTPUT_LEN.saturating_sub(MAX_MARKER_LEN);
+    let original_len = input.len();
+
     const HEADROOM: usize = 32;
-    let mut out = String::with_capacity(input.len() + HEADROOM);
+    let mut out = String::with_capacity((input.len() + HEADROOM).min(MAX_SANITIZED_OUTPUT_LEN));
+    let mut truncated = false;
+
     for c in input.chars() {
+        // Compute the byte cost of emitting `c` BEFORE pushing it, so we can
+        // bail out cleanly if it would push us past the prefix budget.
+        // Control chars expand 1→4 bytes (`\xNN`); other chars take
+        // `c.len_utf8()` bytes (1-4 bytes for any valid Unicode scalar).
+        let needed = if c.is_ascii_control() {
+            4
+        } else {
+            c.len_utf8()
+        };
+        if out.len() + needed > prefix_budget {
+            truncated = true;
+            break;
+        }
         if c.is_ascii_control() {
             // Write directly into `out` via fmt::Write — avoids the per-escape
             // String allocation that `format!()` would introduce.
@@ -925,6 +979,19 @@ fn sanitize_for_stderr(input: String) -> String {
         } else {
             out.push(c);
         }
+    }
+
+    if truncated {
+        // The marker is bounded by MAX_MARKER_LEN (decimal byte count digits
+        // grow linearly with input.len() but stay well under 64 bytes for any
+        // plausible input — usize::MAX has 20 digits, marker template is ~50
+        // bytes total).
+        let _ = write!(
+            out,
+            " [...truncated at {} sanitized bytes; original {} bytes]",
+            out.len(),
+            original_len
+        );
     }
     out
 }
@@ -1007,7 +1074,7 @@ fn extract_error_message_raw(body: &[u8]) -> String {
 
 #[cfg(test)]
 mod sanitize_tests {
-    use super::{MAX_ERROR_ENTRY_LEN, cap_entry, sanitize_for_stderr};
+    use super::{MAX_ERROR_ENTRY_LEN, MAX_SANITIZED_OUTPUT_LEN, cap_entry, sanitize_for_stderr};
 
     // Tiny helper to avoid repeating `.to_string()` in every call — keeps test
     // lines compact now that `sanitize_for_stderr` takes `String` by value.
@@ -1184,6 +1251,59 @@ mod sanitize_tests {
                 over
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // sanitize_for_stderr post-sanitization output cap tests (PR #356 R3)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_sanitize_for_stderr_caps_post_sanitization_expansion() {
+        // Pin for PR #356 R3 finding: a long run of control bytes that expand
+        // 4x via the `\xNN` escape (1024 input bytes → ~4096 sanitized bytes)
+        // could still flood the terminal even with the per-entry pre-cap.
+        // sanitize_for_stderr now caps the FINAL output at MAX_SANITIZED_OUTPUT_LEN.
+        // Build an input with enough control bytes to blow past the post-cap
+        // if no cap were enforced.
+        let input = "\n".repeat(MAX_SANITIZED_OUTPUT_LEN); // 4096 control bytes → 16 KiB sanitized
+        let result = sanitize_for_stderr(input);
+        assert!(
+            result.len() <= MAX_SANITIZED_OUTPUT_LEN,
+            "sanitize_for_stderr output {} bytes exceeds cap {}",
+            result.len(),
+            MAX_SANITIZED_OUTPUT_LEN
+        );
+        // Truncation marker should be visible so operator can see it happened.
+        assert!(
+            result.contains("[...truncated"),
+            "expected truncation marker in output of length {}",
+            result.len()
+        );
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_caps_oversized_clean_input() {
+        // Even purely-clean inputs over the cap get truncated. UTF-8 char
+        // boundaries are respected by `c.len_utf8()` accounting.
+        let input = "a".repeat(MAX_SANITIZED_OUTPUT_LEN + 1000);
+        let result = sanitize_for_stderr(input);
+        assert!(
+            result.len() <= MAX_SANITIZED_OUTPUT_LEN,
+            "output {} bytes exceeds cap {}",
+            result.len(),
+            MAX_SANITIZED_OUTPUT_LEN
+        );
+        assert!(result.contains("[...truncated"));
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_under_cap_no_truncation() {
+        // Inputs that sanitize to a string within the cap pass through without
+        // truncation markers.
+        let input = "Error\r\nmessage".to_string();
+        let result = sanitize_for_stderr(input);
+        assert_eq!(result, "Error\\x0d\\x0amessage");
+        assert!(!result.contains("[...truncated"));
     }
 
     #[test]

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -907,6 +907,82 @@ fn cap_entry(s: &str) -> std::borrow::Cow<'_, str> {
     std::borrow::Cow::Owned(format!("{}{}", &s[..end], marker))
 }
 
+/// Bounded JSON serialization of a `serde_json::Value`.
+///
+/// Defense-in-depth against memory-amplification DoS (OWASP A06 / AP11) for the
+/// non-string-value branch of `extract_error_message_raw`. `Value::to_string()`
+/// (or `serde_json::to_string`) fully serializes the input into a `String`
+/// BEFORE `cap_entry` can truncate it — a hostile response with a deeply
+/// nested or large server-controlled value would force an unbounded allocation
+/// even though the final stderr output is capped.
+///
+/// We serialize into a byte-bounded writer that returns `WriteZero` once
+/// `limit` is reached. `serde_json::to_writer` propagates the error and stops,
+/// so total memory is bounded to `limit` bytes regardless of input size/depth.
+/// The partial prefix is returned for the standard `cap_entry` pipeline; UTF-8
+/// is repaired lossily because the cutoff may land mid-codepoint.
+///
+/// `limit` is chosen as `MAX_ERROR_ENTRY_LEN` — `cap_entry` will then pass the
+/// (already-bounded) prefix through with zero further allocation. Tighter than
+/// the typical 1 MB serialization cap recommended by general guidance, but
+/// appropriate for this domain (stderr error messages, not data interchange).
+fn serialize_value_bounded(v: &serde_json::Value, limit: usize) -> String {
+    /// Writer that accepts up to `limit` bytes then refuses further writes.
+    struct Bounded {
+        buf: Vec<u8>,
+        limit: usize,
+    }
+    impl std::io::Write for Bounded {
+        fn write(&mut self, src: &[u8]) -> std::io::Result<usize> {
+            let remaining = self.limit.saturating_sub(self.buf.len());
+            if remaining == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::WriteZero,
+                    "bounded JSON writer reached byte limit",
+                ));
+            }
+            let take = src.len().min(remaining);
+            self.buf.extend_from_slice(&src[..take]);
+            if take < src.len() {
+                // Partial write — propagate to serde_json so it stops.
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::WriteZero,
+                    "bounded JSON writer reached byte limit mid-write",
+                ));
+            }
+            Ok(take)
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let mut w = Bounded {
+        buf: Vec::with_capacity(limit.min(256)),
+        limit,
+    };
+    // Result intentionally ignored: WriteZero on overflow is the expected
+    // bounded-truncation signal. The (possibly partial) prefix in `w.buf` is
+    // what we want for the downstream cap_entry pipeline.
+    let _ = serde_json::to_writer(&mut w, v);
+    // Lossy because serde_json may have written a partial multi-byte UTF-8
+    // codepoint when the writer cut off mid-string.
+    let mut s = String::from_utf8_lossy(&w.buf).into_owned();
+    // Lossy replacement can expand the string by a few bytes (one U+FFFD = 3
+    // bytes replacing 1-2 trailing invalid bytes when a multibyte char was
+    // cut mid-codepoint). Re-cap at a UTF-8 char boundary so the function
+    // strictly satisfies `out.len() <= limit` — callers (and the cap_entry
+    // pipeline) rely on this invariant.
+    if s.len() > limit {
+        let mut end = limit;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        s.truncate(end);
+    }
+    s
+}
+
 /// Sanitize a server-supplied string for safe display on stderr.
 ///
 /// Defense against CWE-117 (Improper Output Neutralization for Logs): a hostile
@@ -1126,32 +1202,50 @@ fn extract_error_message_raw(body: &[u8]) -> String {
         if let Some(errors) = json.get("errors").and_then(|v| v.as_object()) {
             if !errors.is_empty() {
                 // Memory-amplification defense (OWASP A06 / AP11, same threat
-                // class as the errorMessages streaming join earlier): the
-                // errors map's key count is server-controlled. A hostile
-                // response with 1M keys × 100-byte values would force ~100 MB
-                // allocation in the `pairs` Vec before sanitize_for_stderr
-                // truncates. Bound the entry count BEFORE collect/sort:
+                // class as the errorMessages streaming join earlier). Three
+                // server-controlled vectors are bounded here:
+                //
+                // 1. Entry count — `take(MAX_ERROR_PAIRS)` before collect/sort
+                //    so a hostile response with 1M keys cannot force a 1M-entry
+                //    intermediate Vec.
+                //
+                // 2. Key length — each key passes through `cap_entry` BEFORE
+                //    format!. Without this cap, a hostile response with a
+                //    small number of pathologically large keys (e.g., 1 MB
+                //    key name) would amplify intermediate allocations in the
+                //    formatted pair string even with the entry-count cap.
+                //
+                // 3. Non-string value size/depth — `serialize_value_bounded`
+                //    serializes via a byte-limited writer instead of
+                //    `Value::to_string()`. A hostile response with deeply
+                //    nested or huge non-string values cannot force a full
+                //    serialization allocation before cap_entry truncates.
                 //
                 // MAX_ERROR_PAIRS = 256 is generous (legitimate Jira responses
-                // have 1-10 field-level errors) yet bounds memory at
-                // 256 × MAX_ERROR_ENTRY_LEN = 256 KiB worst case for the
-                // intermediate Vec. The downstream streaming join further
-                // bounds the OUTPUT to MAX_SANITIZED_OUTPUT_LEN.
+                // have 1-10 field-level errors). Per-pair memory is bounded
+                // by 2 × MAX_ERROR_ENTRY_LEN (capped key + capped value) plus
+                // ~4 bytes of format overhead, so the intermediate Vec is
+                // bounded at roughly 256 × 2 × 1024 ≈ 512 KiB worst case.
+                // The downstream streaming join further bounds OUTPUT to
+                // MAX_SANITIZED_OUTPUT_LEN.
                 const MAX_ERROR_PAIRS: usize = 256;
                 let total_keys = errors.len();
                 let mut pairs: Vec<String> = errors
                     .iter()
                     .take(MAX_ERROR_PAIRS)
                     .map(|(k, v)| {
+                        // Cap server-controlled key length BEFORE format!
+                        // (R9 defense — see comment block above).
+                        let k_capped = cap_entry(k);
                         if let Some(s) = v.as_str() {
                             // String value: borrow via Cow when no truncation.
-                            format!("{k}: {}", cap_entry(s))
+                            format!("{}: {}", k_capped, cap_entry(s))
                         } else {
-                            // Non-string value: must materialize once to apply
-                            // the cap, then format. v.to_string() is a temp
-                            // that doesn't outlive the Cow, so own immediately.
-                            let serialized = v.to_string();
-                            format!("{k}: {}", cap_entry(&serialized))
+                            // Non-string value: bounded serialization avoids
+                            // full Value::to_string() allocation against
+                            // hostile deeply-nested / huge values (R9 defense).
+                            let serialized = serialize_value_bounded(v, MAX_ERROR_ENTRY_LEN);
+                            format!("{}: {}", k_capped, cap_entry(&serialized))
                         }
                     })
                     .collect();
@@ -1198,7 +1292,10 @@ fn extract_error_message_raw(body: &[u8]) -> String {
 
 #[cfg(test)]
 mod sanitize_tests {
-    use super::{MAX_ERROR_ENTRY_LEN, MAX_SANITIZED_OUTPUT_LEN, cap_entry, sanitize_for_stderr};
+    use super::{
+        MAX_ERROR_ENTRY_LEN, MAX_SANITIZED_OUTPUT_LEN, cap_entry, sanitize_for_stderr,
+        serialize_value_bounded,
+    };
 
     // Tiny helper to avoid repeating `.to_string()` in every call — keeps test
     // lines compact now that `sanitize_for_stderr` takes `String` by value.
@@ -1476,5 +1573,80 @@ mod sanitize_tests {
             "size invariant violated for UTF-8 input: output len = {}",
             capped.len()
         );
+    }
+
+    // serialize_value_bounded tests — memory-amplification defense for
+    // non-string `errors`-map values (R9 finding).
+
+    #[test]
+    fn test_serialize_value_bounded_small_value_fits_under_limit() {
+        // Small values should serialize fully and identically to Value::to_string().
+        let v = serde_json::json!({"code": 42, "msg": "hello"});
+        let out = serialize_value_bounded(&v, 1024);
+        assert_eq!(out, v.to_string());
+    }
+
+    #[test]
+    fn test_serialize_value_bounded_caps_oversized_value() {
+        // Pin: a value that serializes to ~10 KiB MUST NOT exceed the byte
+        // limit. This is the core memory-amplification defense — without
+        // bounded serialization, Value::to_string() would allocate 10 KiB
+        // before cap_entry could truncate.
+        let big_string = "x".repeat(10_000);
+        let v = serde_json::json!({"oversized": big_string});
+        let out = serialize_value_bounded(&v, MAX_ERROR_ENTRY_LEN);
+        assert!(
+            out.len() <= MAX_ERROR_ENTRY_LEN,
+            "bounded output exceeded limit: {} > {}",
+            out.len(),
+            MAX_ERROR_ENTRY_LEN
+        );
+        // Output should be a valid prefix of the full serialization.
+        assert!(out.starts_with("{\"oversized\":\""));
+    }
+
+    #[test]
+    fn test_serialize_value_bounded_caps_deeply_nested_value() {
+        // Pin: a deeply nested value MUST also be bounded — the prior
+        // Value::to_string() path would have allocated full serialization
+        // proportional to depth before cap_entry could truncate.
+        let mut v = serde_json::Value::Null;
+        for _ in 0..1000 {
+            v = serde_json::json!([v]);
+        }
+        let out = serialize_value_bounded(&v, MAX_ERROR_ENTRY_LEN);
+        assert!(
+            out.len() <= MAX_ERROR_ENTRY_LEN,
+            "bounded output exceeded limit for deeply nested value: {} > {}",
+            out.len(),
+            MAX_ERROR_ENTRY_LEN
+        );
+    }
+
+    #[test]
+    fn test_serialize_value_bounded_produces_valid_utf8() {
+        // Pin: even when the underlying writer cuts off mid-codepoint,
+        // String::from_utf8_lossy must produce valid UTF-8 (no panics from
+        // downstream str ops). This is critical because `cap_entry` indexes
+        // via `is_char_boundary` on the bounded output.
+        // A long string with multibyte chars maximizes the chance of a
+        // mid-codepoint cutoff.
+        let big_utf8 = "日本語のエラー".repeat(500);
+        let v = serde_json::json!({"k": big_utf8});
+        let out = serialize_value_bounded(&v, MAX_ERROR_ENTRY_LEN);
+        // Must be valid UTF-8 (would panic on assert otherwise).
+        assert!(out.is_char_boundary(out.len()));
+        // And bounded.
+        assert!(out.len() <= MAX_ERROR_ENTRY_LEN);
+    }
+
+    #[test]
+    fn test_serialize_value_bounded_handles_zero_limit_safely() {
+        // Edge case: a zero limit returns empty without panicking. Not used
+        // in production (limit is always MAX_ERROR_ENTRY_LEN > 0), but pins
+        // the contract for future callers.
+        let v = serde_json::json!({"a": 1});
+        let out = serialize_value_bounded(&v, 0);
+        assert_eq!(out, "");
     }
 }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -922,20 +922,31 @@ fn cap_entry(s: &str) -> std::borrow::Cow<'_, str> {
 /// The partial prefix is returned for the standard `cap_entry` pipeline; UTF-8
 /// is repaired lossily because the cutoff may land mid-codepoint.
 ///
+/// When overflow is detected, the function appends a visible
+/// `[...truncated]` marker so callers/operators see that the JSON is a
+/// truncated prefix rather than a malformed-but-silently-incomplete fragment.
+/// Marker bytes are reserved upfront from the byte budget so the function
+/// strictly satisfies `out.len() <= limit` even with the marker appended.
+///
 /// `limit` is chosen as `MAX_ERROR_ENTRY_LEN` — `cap_entry` will then pass the
 /// (already-bounded) prefix through with zero further allocation. Tighter than
 /// the typical 1 MB serialization cap recommended by general guidance, but
 /// appropriate for this domain (stderr error messages, not data interchange).
 fn serialize_value_bounded(v: &serde_json::Value, limit: usize) -> String {
     /// Writer that accepts up to `limit` bytes then refuses further writes.
+    /// Sets `overflowed` so the caller can append a truncation marker —
+    /// without this flag, a hostile response would silently produce a partial
+    /// JSON prefix with no indication to operators that data was cut off.
     struct Bounded {
         buf: Vec<u8>,
         limit: usize,
+        overflowed: bool,
     }
     impl std::io::Write for Bounded {
         fn write(&mut self, src: &[u8]) -> std::io::Result<usize> {
             let remaining = self.limit.saturating_sub(self.buf.len());
             if remaining == 0 {
+                self.overflowed = true;
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::WriteZero,
                     "bounded JSON writer reached byte limit",
@@ -945,6 +956,7 @@ fn serialize_value_bounded(v: &serde_json::Value, limit: usize) -> String {
             self.buf.extend_from_slice(&src[..take]);
             if take < src.len() {
                 // Partial write — propagate to serde_json so it stops.
+                self.overflowed = true;
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::WriteZero,
                     "bounded JSON writer reached byte limit mid-write",
@@ -957,14 +969,28 @@ fn serialize_value_bounded(v: &serde_json::Value, limit: usize) -> String {
         }
     }
 
+    // Reserve marker bytes upfront so the final output (prefix + marker)
+    // strictly fits within `limit`. If `limit` is too small to even hold the
+    // marker (degenerate case — limit < ~16 bytes), serialize without a marker
+    // and rely on the post-hoc trim below to enforce the byte cap.
+    const TRUNCATION_MARKER: &str = " [...truncated]";
+    let writer_limit = limit.saturating_sub(TRUNCATION_MARKER.len());
+    // If reserving the marker would leave no room for content, fall back to
+    // raw-bounded mode (no marker). This degenerate path applies only when
+    // `limit` is smaller than the marker itself.
+    let reserve_marker = writer_limit > 0;
+    let effective_limit = if reserve_marker { writer_limit } else { limit };
+
     let mut w = Bounded {
-        buf: Vec::with_capacity(limit.min(256)),
-        limit,
+        buf: Vec::with_capacity(effective_limit.min(256)),
+        limit: effective_limit,
+        overflowed: false,
     };
     // Result intentionally ignored: WriteZero on overflow is the expected
     // bounded-truncation signal. The (possibly partial) prefix in `w.buf` is
     // what we want for the downstream cap_entry pipeline.
     let _ = serde_json::to_writer(&mut w, v);
+    let overflowed = w.overflowed;
     // Lossy because serde_json may have written a partial multi-byte UTF-8
     // codepoint when the writer cut off mid-string.
     let mut s = String::from_utf8_lossy(&w.buf).into_owned();
@@ -972,13 +998,20 @@ fn serialize_value_bounded(v: &serde_json::Value, limit: usize) -> String {
     // bytes replacing 1-2 trailing invalid bytes when a multibyte char was
     // cut mid-codepoint). Re-cap at a UTF-8 char boundary so the function
     // strictly satisfies `out.len() <= limit` — callers (and the cap_entry
-    // pipeline) rely on this invariant.
-    if s.len() > limit {
-        let mut end = limit;
+    // pipeline) rely on this invariant. Use `effective_limit` so the marker
+    // (if appended below) still fits within `limit`.
+    if s.len() > effective_limit {
+        let mut end = effective_limit;
         while end > 0 && !s.is_char_boundary(end) {
             end -= 1;
         }
         s.truncate(end);
+    }
+    // Append the truncation marker so consumers see that JSON is incomplete
+    // rather than a malformed-but-silently-truncated fragment (R10 finding).
+    // Only when we actually overflowed AND we reserved budget for the marker.
+    if overflowed && reserve_marker {
+        s.push_str(TRUNCATION_MARKER);
     }
     s
 }
@@ -1603,6 +1636,12 @@ mod sanitize_tests {
         );
         // Output should be a valid prefix of the full serialization.
         assert!(out.starts_with("{\"oversized\":\""));
+        // R10 pin: truncated output MUST end with a visible marker so
+        // operators see the JSON is incomplete rather than malformed.
+        assert!(
+            out.ends_with(" [...truncated]"),
+            "expected truncation marker on overflow; got: {out:?}"
+        );
     }
 
     #[test]
@@ -1648,5 +1687,49 @@ mod sanitize_tests {
         let v = serde_json::json!({"a": 1});
         let out = serialize_value_bounded(&v, 0);
         assert_eq!(out, "");
+    }
+
+    #[test]
+    fn test_serialize_value_bounded_no_marker_when_no_overflow() {
+        // R10 pin: when the value fits comfortably within the limit, the
+        // truncation marker must NOT be appended (otherwise legitimate
+        // small responses would look truncated).
+        let v = serde_json::json!({"code": 42, "msg": "hello"});
+        let out = serialize_value_bounded(&v, 1024);
+        assert!(
+            !out.ends_with(" [...truncated]"),
+            "marker should not appear for non-overflowing values: {out:?}"
+        );
+        assert!(!out.contains("[...truncated]"));
+    }
+
+    #[test]
+    fn test_serialize_value_bounded_marker_fits_within_limit_for_oversized() {
+        // R10 pin: even WITH the marker appended, the function strictly
+        // satisfies `out.len() <= limit` — marker bytes are reserved upfront
+        // from the byte budget so the prefix-plus-marker total fits.
+        let big = "x".repeat(10_000);
+        let v = serde_json::json!({"k": big});
+        let out = serialize_value_bounded(&v, MAX_ERROR_ENTRY_LEN);
+        assert!(
+            out.len() <= MAX_ERROR_ENTRY_LEN,
+            "marker pushed output past limit: {} > {}",
+            out.len(),
+            MAX_ERROR_ENTRY_LEN
+        );
+        assert!(out.ends_with(" [...truncated]"));
+    }
+
+    #[test]
+    fn test_serialize_value_bounded_no_marker_for_tiny_limit_below_marker_len() {
+        // R10 degenerate case: if `limit` is smaller than the marker itself
+        // (~15 bytes), the function falls back to raw-bounded mode without
+        // a marker rather than producing a marker-only output. Useful pin
+        // for future callers who might pass a tiny limit.
+        let v = serde_json::json!({"a": 1});
+        let out = serialize_value_bounded(&v, 5);
+        assert!(out.len() <= 5);
+        // No room for the marker; must not be present.
+        assert!(!out.contains("[...truncated]"));
     }
 }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -851,9 +851,10 @@ const MAX_ERROR_ENTRY_LEN: usize = 1024;
 /// or log file. This cap is enforced inside `sanitize_for_stderr` itself
 /// using a byte-budget-aware char loop that stops emitting when the next
 /// char would exceed the budget, then appends a `[...truncated; original
-/// M bytes]` marker (R6: marker text references only the immutable
-/// `original_len`, not `out.len()`, to avoid over-reporting after any
-/// retroactive trim).
+/// M bytes]` marker. The marker text references only the immutable
+/// `original_len`, not `out.len()`, so the retroactive trim path doesn't
+/// change the marker length — preserves the size invariant after trim
+/// and avoids over-reporting retained bytes.
 ///
 /// 4 KiB chosen to absorb worst-case 4x expansion of a single `MAX_ERROR_ENTRY_LEN`
 /// entry (1024 × 4 = 4096) while still leaving room for the marker via
@@ -988,15 +989,14 @@ fn sanitize_for_stderr(input: String) -> String {
     }
 
     if truncated {
-        // CWE-117 / PR #356 R6 fix: marker text intentionally does NOT
-        // reference `out.len()` — only the (immutable) `original_len`. This
-        // makes the marker's length depend solely on original_len's digit
-        // count (so the retroactive trim doesn't change the marker length)
-        // and prevents the over-reporting issue where the marker would
-        // claim a byte count that no longer matches the trimmed output.
-        // The operator gets accurate info: "original M bytes" — the actual
-        // size that was thrown away, with the final output size being
-        // exactly out.len() bytes (which they can observe directly).
+        // CWE-117 defense: marker text intentionally references only the
+        // (immutable) `original_len`, NOT `out.len()`. This makes the
+        // marker's length depend solely on original_len's digit count, so
+        // the retroactive trim below doesn't change the marker length —
+        // preserving the size invariant `out + marker <= cap` AFTER any
+        // trim. Operator gets accurate info: "original M bytes" reflects
+        // the actual source size; the final retained size is exactly
+        // out.len() bytes (directly observable).
         let marker = format!(" [...truncated; original {} bytes]", original_len);
         if out.len() + marker.len() <= MAX_SANITIZED_OUTPUT_LEN {
             // Marker fits without trimming — append directly.
@@ -1024,9 +1024,11 @@ fn sanitize_for_stderr(input: String) -> String {
 /// Extract a human-readable error message from a Jira error response body.
 ///
 /// All return paths run through `sanitize_for_stderr` (CWE-117 defense:
-/// strips ASCII control chars from server-supplied content before it reaches
-/// stderr, preventing CR/LF/ANSI injection from a hostile or proxy-controlled
-/// response). UTF-8 in legitimate localized error messages is preserved.
+/// escapes ASCII control chars from server-supplied content as visible
+/// `\xNN` literals before they reach stderr, preventing CR/LF/ANSI
+/// injection from a hostile or proxy-controlled response while keeping
+/// the byte information visible to the operator). UTF-8 in legitimate
+/// localized error messages is preserved.
 ///
 /// Precedence:
 /// 1. Non-empty `errorMessages` array → joined with "; "
@@ -1083,9 +1085,10 @@ fn extract_error_message_raw(body: &[u8]) -> String {
             // Total memory is O(MAX_SANITIZED_OUTPUT_LEN) regardless of entry
             // count. The downstream sanitize_for_stderr cap is retained as
             // defense-in-depth for control-byte expansion.
-            // R6 fix: reserve marker budget upfront in the budget check (the
-            // standard pattern per Perplexity 2026-05-11 — retroactive trim
-            // risks marker overflow). Marker is fixed-length so the
+            // Reserve marker budget upfront in the budget check (the standard
+            // pattern for fixed-output sanitization — matches Rust std::fmt
+            // buffer sizing and log-crate truncation conventions; retroactive
+            // trim risks marker overflow). Marker is fixed-length so the
             // reservation is a 15-byte constant; no recalculation needed.
             const JOIN_MARKER: &str = " [...truncated]";
             let content_budget_join = MAX_SANITIZED_OUTPUT_LEN.saturating_sub(JOIN_MARKER.len());
@@ -1308,11 +1311,10 @@ mod sanitize_tests {
 
     #[test]
     fn test_cap_entry_size_invariant_at_boundary_oversize() {
-        // Regression pin for the Copilot R2 finding on PR #356: inputs only
-        // slightly larger than MAX_ERROR_ENTRY_LEN (e.g., 1025 bytes) used to
-        // produce an output LONGER than the input because the truncation
-        // marker overhead exceeded what was removed. The cap now reserves
-        // marker budget from the prefix, so output_len <= MAX_ERROR_ENTRY_LEN
+        // Regression pin: inputs only slightly larger than MAX_ERROR_ENTRY_LEN
+        // (e.g., 1025 bytes) must NOT produce output longer than the input
+        // due to the truncation marker overhead. cap_entry reserves marker
+        // budget from the prefix so output_len <= MAX_ERROR_ENTRY_LEN
         // regardless of how close the input is to the boundary.
         for over in [1, 2, 5, 50, 100, 1000, 10000] {
             let s = "a".repeat(MAX_ERROR_ENTRY_LEN + over);
@@ -1336,15 +1338,15 @@ mod sanitize_tests {
     }
 
     // -----------------------------------------------------------------------
-    // sanitize_for_stderr post-sanitization output cap tests (PR #356 R3)
+    // sanitize_for_stderr post-sanitization output cap tests
     // -----------------------------------------------------------------------
 
     #[test]
     fn test_sanitize_for_stderr_caps_post_sanitization_expansion() {
-        // Pin for PR #356 R3 finding: a long run of control bytes that expand
-        // 4x via the `\xNN` escape (1024 input bytes → ~4096 sanitized bytes)
-        // could still flood the terminal even with the per-entry pre-cap.
-        // sanitize_for_stderr now caps the FINAL output at MAX_SANITIZED_OUTPUT_LEN.
+        // Pin: a long run of control bytes that expand 4x via the `\xNN`
+        // escape (1024 input bytes → ~4096 sanitized bytes) must NOT flood
+        // the terminal even with the per-entry pre-cap.
+        // sanitize_for_stderr caps the FINAL output at MAX_SANITIZED_OUTPUT_LEN.
         // Build an input with enough control bytes to blow past the post-cap
         // if no cap were enforced.
         let input = "\n".repeat(MAX_SANITIZED_OUTPUT_LEN); // 4096 control bytes → 16 KiB sanitized
@@ -1380,10 +1382,10 @@ mod sanitize_tests {
 
     #[test]
     fn test_sanitize_for_stderr_truncation_marker_excludes_out_len() {
-        // R6 fix: the truncation marker must NOT reference out.len() — only
+        // Pin: the truncation marker must NOT reference out.len() — only
         // `original_len`. This makes the marker length independent of any
-        // retroactive trim and prevents the over-reporting bug where the
-        // marker claimed a byte count that didn't match the trimmed output.
+        // retroactive trim and prevents over-reporting (a marker that
+        // claims a byte count not matching the trimmed output).
         let input = "a".repeat(MAX_SANITIZED_OUTPUT_LEN + 100);
         let original_len = input.len();
         let result = sanitize_for_stderr(input);

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -857,8 +857,10 @@ const MAX_ERROR_ENTRY_LEN: usize = 1024;
 /// and avoids over-reporting retained bytes.
 ///
 /// 4 KiB chosen to absorb worst-case 4x expansion of a single `MAX_ERROR_ENTRY_LEN`
-/// entry (1024 × 4 = 4096) while still leaving room for the marker via
-/// reserved headroom inside `sanitize_for_stderr`.
+/// entry (1024 × 4 = 4096). When truncation occurs and the marker would push
+/// the output past this cap, `sanitize_for_stderr` retroactively trims `out`
+/// at a UTF-8 char boundary to make room — the marker text references only
+/// the immutable `original_len` so its length doesn't shift under the trim.
 const MAX_SANITIZED_OUTPUT_LEN: usize = 4096;
 
 /// Truncate a server-supplied string at a UTF-8 char boundary if it exceeds
@@ -1123,12 +1125,23 @@ fn extract_error_message_raw(body: &[u8]) -> String {
         }
         if let Some(errors) = json.get("errors").and_then(|v| v.as_object()) {
             if !errors.is_empty() {
-                // Per-entry formatting always allocates the "{k}: {v}" pair
-                // string, so the per-entry cap_entry being Cow doesn't avoid
-                // that — but it does avoid the prior to_string() copy for
-                // unchanged values (which are the common case).
+                // Memory-amplification defense (OWASP A06 / AP11, same threat
+                // class as the errorMessages streaming join earlier): the
+                // errors map's key count is server-controlled. A hostile
+                // response with 1M keys × 100-byte values would force ~100 MB
+                // allocation in the `pairs` Vec before sanitize_for_stderr
+                // truncates. Bound the entry count BEFORE collect/sort:
+                //
+                // MAX_ERROR_PAIRS = 256 is generous (legitimate Jira responses
+                // have 1-10 field-level errors) yet bounds memory at
+                // 256 × MAX_ERROR_ENTRY_LEN = 256 KiB worst case for the
+                // intermediate Vec. The downstream streaming join further
+                // bounds the OUTPUT to MAX_SANITIZED_OUTPUT_LEN.
+                const MAX_ERROR_PAIRS: usize = 256;
+                let total_keys = errors.len();
                 let mut pairs: Vec<String> = errors
                     .iter()
+                    .take(MAX_ERROR_PAIRS)
                     .map(|(k, v)| {
                         if let Some(s) = v.as_str() {
                             // String value: borrow via Cow when no truncation.
@@ -1143,7 +1156,33 @@ fn extract_error_message_raw(body: &[u8]) -> String {
                     })
                     .collect();
                 pairs.sort();
-                return pairs.join("; ");
+                let pairs_truncated = total_keys > MAX_ERROR_PAIRS;
+
+                // Streaming join with upfront marker reservation (same pattern
+                // as the errorMessages path above).
+                const JOIN_MARKER: &str = " [...truncated]";
+                let content_budget_join =
+                    MAX_SANITIZED_OUTPUT_LEN.saturating_sub(JOIN_MARKER.len());
+                let mut joined = String::with_capacity(MAX_SANITIZED_OUTPUT_LEN);
+                let mut first = true;
+                let mut join_truncated = false;
+                for p in &pairs {
+                    let separator_len = if first { 0 } else { 2 };
+                    if joined.len() + separator_len + p.len() > content_budget_join {
+                        join_truncated = true;
+                        break;
+                    }
+                    if !first {
+                        joined.push_str("; ");
+                    }
+                    joined.push_str(p);
+                    first = false;
+                }
+                if join_truncated || pairs_truncated {
+                    joined.push_str(JOIN_MARKER);
+                }
+                debug_assert!(joined.len() <= MAX_SANITIZED_OUTPUT_LEN);
+                return joined;
             }
         }
         if let Some(msg) = json.get("message").and_then(|v| v.as_str()) {

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1043,7 +1043,7 @@ fn serialize_value_bounded(v: &serde_json::Value, limit: usize) -> String {
         s.truncate(end);
     }
     // Append the truncation marker so consumers see that JSON is incomplete
-    // rather than a malformed-but-silently-truncated fragment (R10 finding).
+    // rather than a malformed-but-silently-truncated fragment.
     // Only when we actually overflowed AND we reserved budget for the marker.
     if overflowed && reserve_marker {
         s.push_str(TRUNCATION_MARKER);
@@ -1090,17 +1090,14 @@ fn serialize_value_bounded(v: &serde_json::Value, limit: usize) -> String {
 fn sanitize_for_stderr(input: String) -> String {
     use std::fmt::Write;
 
-    // Fast-path check: scan bytes for ASCII controls. Bytes alone can't
-    // detect C1 controls (U+0080..U+009F) since those are 2-byte UTF-8
-    // sequences (0xc2 0x80..0xc2 0x9f); we'd risk false positives on
-    // valid 2-byte UTF-8. Cheap path checks ASCII controls only; C1
-    // detection is then handled in the char loop. The slow path triggers
-    // only if ASCII controls OR oversized input is present — C1-only
-    // input falls through to the fast return below, which is fine
-    // because C1 chars in modern UTF-8 terminals are inert (R14 finding
-    // notes they're invalid UTF-8 continuation bytes and get dropped).
-    // For defense-in-depth against legacy/non-UTF8 terminals, we still
-    // escape C1 chars when we go through the slow path.
+    // Fast-path check: char-level scan for Unicode control chars (both
+    // ASCII C0+DEL and C1 U+0080..U+009F). `char::is_control()` covers
+    // the full control set; byte-level scanning is insufficient because
+    // C1 controls are 2-byte UTF-8 sequences (0xc2 0x80..0xc2 0x9f) that
+    // a raw byte scan can't distinguish from valid multi-byte text.
+    // Char decoding costs more than byte iteration but is required for
+    // comprehensive defense-in-depth against legacy/non-UTF8 terminals
+    // that may still interpret C1 codepoints as control sequences.
     let needs_sanitization = input.chars().any(|c| c.is_control());
     let needs_truncation = input.len() > MAX_SANITIZED_OUTPUT_LEN;
 
@@ -1128,12 +1125,12 @@ fn sanitize_for_stderr(input: String) -> String {
         //   (still 4x, preserving the 4 KiB cap's worst-case budget)
         // - Other chars: `c.len_utf8()` (1-4 bytes for any Unicode scalar)
         //
-        // R14 hardening (Perplexity-validated 2026-05-11): C1 controls are
-        // inert in modern UTF-8 terminals (rejected as invalid UTF-8
-        // continuation bytes) so this is not a current vector, but
-        // legacy/embedded/non-UTF8 terminals could still interpret U+009B
-        // (CSI) and friends as control sequences. `char::is_control()`
-        // catches both C0 and C1 for comprehensive defense-in-depth.
+        // C1 controls (U+0080..U+009F) are inert in modern UTF-8 terminals
+        // (rejected as invalid UTF-8 continuation bytes), so they are not
+        // a current vector — but legacy/embedded/non-UTF8 terminals could
+        // still interpret U+009B (CSI) and friends as control sequences.
+        // `char::is_control()` catches both C0 and C1 for comprehensive
+        // defense-in-depth.
         let needed = if c.is_control() {
             if c.is_ascii() { 4 } else { 8 }
         } else {
@@ -1240,7 +1237,7 @@ fn extract_error_message_raw(body: &[u8]) -> String {
             // at 3 bytes each) before conversion.
             //
             // Use a custom marker that records the ORIGINAL body.len() rather than
-            // relying on `cap_entry`'s default marker (R12 finding): cap_entry's
+            // relying on `cap_entry`'s default marker: cap_entry's
             // marker reports the *post-pre-cap* string length, which can never
             // exceed PRE_CAP_BYTES (~4096 bytes). When operators are diagnosing a
             // resource-exhaustion / flood attempt, they need to see that the
@@ -1278,7 +1275,7 @@ fn extract_error_message_raw(body: &[u8]) -> String {
     };
 
     // Memory-amplification defense at the JSON parse step (OWASP API4:2023 (Unrestricted Resource Consumption) / CWE-770 (Allocation of Resources Without Limits or Throttling),
-    // Perplexity-validated 2026-05-11, R11 finding). `serde_json::from_str::<Value>`
+    // Perplexity-validated 2026-05-11). `serde_json::from_str::<Value>`
     // materializes a full DOM that costs roughly 2-3x the body size in memory.
     // Even though every downstream cap (cap_entry, serialize_value_bounded,
     // sanitize_for_stderr) bounds OUTPUT, none of them prevent the INPUT DOM
@@ -1382,7 +1379,7 @@ fn extract_error_message_raw(body: &[u8]) -> String {
                     .take(MAX_ERROR_PAIRS)
                     .map(|(k, v)| {
                         // Cap server-controlled key length BEFORE format!
-                        // (R9 defense — see comment block above).
+                        // (see comment block above).
                         let k_capped = cap_entry(k);
                         if let Some(s) = v.as_str() {
                             // String value: borrow via Cow when no truncation.
@@ -1390,7 +1387,7 @@ fn extract_error_message_raw(body: &[u8]) -> String {
                         } else {
                             // Non-string value: bounded serialization avoids
                             // full Value::to_string() allocation against
-                            // hostile deeply-nested / huge values (R9 defense).
+                            // hostile deeply-nested / huge values.
                             let serialized = serialize_value_bounded(v, MAX_ERROR_ENTRY_LEN);
                             format!("{}: {}", k_capped, cap_entry(&serialized))
                         }
@@ -1723,7 +1720,7 @@ mod sanitize_tests {
     }
 
     // serialize_value_bounded tests — memory-amplification defense for
-    // non-string `errors`-map values (R9 finding).
+    // non-string `errors`-map values.
 
     #[test]
     fn test_serialize_value_bounded_small_value_fits_under_limit() {
@@ -1750,7 +1747,7 @@ mod sanitize_tests {
         );
         // Output should be a valid prefix of the full serialization.
         assert!(out.starts_with("{\"oversized\":\""));
-        // R10 pin: truncated output MUST end with a visible marker so
+        // Pin: truncated output MUST end with a visible marker so
         // operators see the JSON is incomplete rather than malformed.
         assert!(
             out.ends_with(" [...truncated]"),
@@ -1805,7 +1802,7 @@ mod sanitize_tests {
 
     #[test]
     fn test_serialize_value_bounded_no_marker_when_no_overflow() {
-        // R10 pin: when the value fits comfortably within the limit, the
+        // Pin: when the value fits comfortably within the limit, the
         // truncation marker must NOT be appended (otherwise legitimate
         // small responses would look truncated).
         let v = serde_json::json!({"code": 42, "msg": "hello"});
@@ -1819,7 +1816,7 @@ mod sanitize_tests {
 
     #[test]
     fn test_serialize_value_bounded_marker_fits_within_limit_for_oversized() {
-        // R10 pin: even WITH the marker appended, the function strictly
+        // Pin: even WITH the marker appended, the function strictly
         // satisfies `out.len() <= limit` — marker bytes are reserved upfront
         // from the byte budget so the prefix-plus-marker total fits.
         let big = "x".repeat(10_000);
@@ -1836,7 +1833,7 @@ mod sanitize_tests {
 
     #[test]
     fn test_serialize_value_bounded_no_marker_for_tiny_limit_below_marker_len() {
-        // R10 degenerate case: if `limit` is smaller than the marker itself
+        // Degenerate case: if `limit` is smaller than the marker itself
         // (~15 bytes), the function falls back to raw-bounded mode without
         // a marker rather than producing a marker-only output. Useful pin
         // for future callers who might pass a tiny limit.
@@ -1848,7 +1845,7 @@ mod sanitize_tests {
     }
 
     // MAX_PARSE_BODY_LEN gate tests — memory-amplification defense at the
-    // JSON parse step (R11 finding). serde_json::from_str::<Value> builds a
+    // JSON parse step. serde_json::from_str::<Value> builds a
     // full DOM that costs ~2-3x body size; the gate falls back to the
     // byte-bounded raw-body path for oversized bodies.
 
@@ -1903,7 +1900,7 @@ mod sanitize_tests {
         assert_eq!(MAX_PARSE_BODY_LEN, 16 * 1024);
     }
 
-    // R12 pins — std::io::Write contract compliance + non-UTF8 marker accuracy.
+    // Pins — std::io::Write contract compliance + non-UTF8 marker accuracy.
 
     #[test]
     fn test_serialize_value_bounded_returns_marker_with_correct_data_on_partial_write() {
@@ -1926,7 +1923,7 @@ mod sanitize_tests {
 
     #[test]
     fn test_extract_error_message_non_utf8_marker_reports_true_body_size() {
-        // R12 pin: the non-UTF8 fallback marker MUST report the actual
+        // Pin: the non-UTF8 fallback marker MUST report the actual
         // body.len(), not the pre-capped lossy-string length. Operators
         // diagnosing a flood attempt need to see "5000000 bytes total",
         // not "4096 bytes total" which would silently under-report.
@@ -1944,7 +1941,7 @@ mod sanitize_tests {
         assert!(out.len() <= MAX_SANITIZED_OUTPUT_LEN);
     }
 
-    // R14 pins — Unicode C1 control coverage (defense-in-depth against
+    // Pins — Unicode C1 control coverage (defense-in-depth against
     // legacy/non-UTF8 terminals; modern UTF-8 terminals drop these as
     // invalid continuation bytes but is_control() future-proofs).
 
@@ -1975,7 +1972,7 @@ mod sanitize_tests {
 
     #[test]
     fn test_sanitize_for_stderr_preserves_non_control_unicode_above_ascii() {
-        // R14 anti-regression: only U+0080..U+009F are CONTROL chars
+        // Anti-regression: only U+0080..U+009F are CONTROL chars
         // above ASCII. Other code points in the U+00A0+ range (e.g.,
         // non-breaking space U+00A0, é U+00E9, 日 U+65E5) MUST pass
         // through unchanged — char::is_control() returns false for them.
@@ -1990,7 +1987,7 @@ mod sanitize_tests {
 
     #[test]
     fn test_extract_error_message_non_utf8_small_body_no_marker() {
-        // R12 pin: a small non-UTF8 body that fits in MAX_ERROR_ENTRY_LEN
+        // Pin: a small non-UTF8 body that fits in MAX_ERROR_ENTRY_LEN
         // skips the marker (the fast path). No regression for legitimate
         // tiny non-UTF8 responses.
         let body = vec![0xffu8; 16];

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1090,11 +1090,22 @@ fn serialize_value_bounded(v: &serde_json::Value, limit: usize) -> String {
 fn sanitize_for_stderr(input: String) -> String {
     use std::fmt::Write;
 
-    let needs_sanitization = input.bytes().any(|b| b.is_ascii_control());
+    // Fast-path check: scan bytes for ASCII controls. Bytes alone can't
+    // detect C1 controls (U+0080..U+009F) since those are 2-byte UTF-8
+    // sequences (0xc2 0x80..0xc2 0x9f); we'd risk false positives on
+    // valid 2-byte UTF-8. Cheap path checks ASCII controls only; C1
+    // detection is then handled in the char loop. The slow path triggers
+    // only if ASCII controls OR oversized input is present — C1-only
+    // input falls through to the fast return below, which is fine
+    // because C1 chars in modern UTF-8 terminals are inert (R14 finding
+    // notes they're invalid UTF-8 continuation bytes and get dropped).
+    // For defense-in-depth against legacy/non-UTF8 terminals, we still
+    // escape C1 chars when we go through the slow path.
+    let needs_sanitization = input.chars().any(|c| c.is_control());
     let needs_truncation = input.len() > MAX_SANITIZED_OUTPUT_LEN;
 
-    // Fast path: no control bytes AND under the output cap → return the
-    // input String unchanged. No new allocation. Optimizes the common case.
+    // Fast path: no control chars (C0, DEL, OR C1) AND under the output
+    // cap → return the input String unchanged. No new allocation.
     if !needs_sanitization && !needs_truncation {
         return input;
     }
@@ -1111,11 +1122,20 @@ fn sanitize_for_stderr(input: String) -> String {
     let mut truncated = false;
 
     for c in input.chars() {
-        // Compute the byte cost of emitting `c` BEFORE pushing it. Control
-        // chars expand 1→4 bytes (`\xNN`); other chars take `c.len_utf8()`
-        // bytes (1-4 bytes for any valid Unicode scalar).
-        let needed = if c.is_ascii_control() {
-            4
+        // Compute the byte cost of emitting `c` BEFORE pushing it.
+        // - ASCII controls (C0 + DEL): expand 1→4 bytes via `\xNN`
+        // - C1 controls (U+0080..U+009F): expand 2→8 bytes via `\u{NNNN}`
+        //   (still 4x, preserving the 4 KiB cap's worst-case budget)
+        // - Other chars: `c.len_utf8()` (1-4 bytes for any Unicode scalar)
+        //
+        // R14 hardening (Perplexity-validated 2026-05-11): C1 controls are
+        // inert in modern UTF-8 terminals (rejected as invalid UTF-8
+        // continuation bytes) so this is not a current vector, but
+        // legacy/embedded/non-UTF8 terminals could still interpret U+009B
+        // (CSI) and friends as control sequences. `char::is_control()`
+        // catches both C0 and C1 for comprehensive defense-in-depth.
+        let needed = if c.is_control() {
+            if c.is_ascii() { 4 } else { 8 }
         } else {
             c.len_utf8()
         };
@@ -1123,12 +1143,18 @@ fn sanitize_for_stderr(input: String) -> String {
             truncated = true;
             break;
         }
-        if c.is_ascii_control() {
+        if c.is_control() {
             // Write directly into `out` via fmt::Write — avoids the per-escape
             // String allocation that `format!()` would introduce.
             // write! on String is infallible; ignore the Result to avoid a
             // distracting `expect()` in a hot loop.
-            let _ = write!(out, "\\x{:02x}", c as u8);
+            if c.is_ascii() {
+                let _ = write!(out, "\\x{:02x}", c as u8);
+            } else {
+                // C1 control: emit visible `\u{NNNN}` form so operators can
+                // see WHICH control was injected (e.g., \u{009b} = CSI).
+                let _ = write!(out, "\\u{{{:04x}}}", c as u32);
+            }
         } else {
             out.push(c);
         }
@@ -1916,6 +1942,50 @@ mod sanitize_tests {
         assert!(out.contains("non-UTF8 body"));
         // And still respect the post-sanitization output cap.
         assert!(out.len() <= MAX_SANITIZED_OUTPUT_LEN);
+    }
+
+    // R14 pins — Unicode C1 control coverage (defense-in-depth against
+    // legacy/non-UTF8 terminals; modern UTF-8 terminals drop these as
+    // invalid continuation bytes but is_control() future-proofs).
+
+    #[test]
+    fn test_sanitize_for_stderr_escapes_unicode_csi_c1_control() {
+        // U+009B is the Control Sequence Introducer (CSI) — semantically
+        // equivalent to "ESC [" in 8-bit/legacy modes. Must be escaped
+        // rather than passed through.
+        let input = "before\u{009b}31mafter".to_string();
+        let result = sanitize(&input);
+        assert!(result.contains("\\u{009b}"));
+        // The non-control text must survive unchanged.
+        assert!(result.contains("before"));
+        assert!(result.contains("31mafter"));
+        // No raw CSI byte in the output.
+        assert!(!result.contains('\u{009b}'));
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_escapes_unicode_nel_c1_control() {
+        // U+0085 is NEL (Next Line) — interpreted as a line break in
+        // some 8-bit terminal modes. Escape rather than emit raw.
+        let input = "line1\u{0085}line2".to_string();
+        let result = sanitize(&input);
+        assert!(result.contains("\\u{0085}"));
+        assert!(!result.contains('\u{0085}'));
+    }
+
+    #[test]
+    fn test_sanitize_for_stderr_preserves_non_control_unicode_above_ascii() {
+        // R14 anti-regression: only U+0080..U+009F are CONTROL chars
+        // above ASCII. Other code points in the U+00A0+ range (e.g.,
+        // non-breaking space U+00A0, é U+00E9, 日 U+65E5) MUST pass
+        // through unchanged — char::is_control() returns false for them.
+        let input = "résumé 日本語のエラー\u{00a0}end".to_string();
+        let result = sanitize_for_stderr(input.clone());
+        // No escape sequences inserted.
+        assert!(!result.contains("\\u{"));
+        assert!(!result.contains("\\x"));
+        // String preserved bit-for-bit.
+        assert_eq!(result, input);
     }
 
     #[test]

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -865,8 +865,10 @@ const MAX_SANITIZED_OUTPUT_LEN: usize = 4096;
 
 /// Maximum byte length of an error response body that will be parsed as JSON.
 ///
-/// Defense against memory-amplification at the JSON parse step (OWASP A06 /
-/// AP11, Perplexity-validated 2026-05-11). `serde_json::from_str::<Value>`
+/// Defense against memory-amplification at the JSON parse step (OWASP
+/// API4:2023 — Unrestricted Resource Consumption / CWE-770 — Allocation of
+/// Resources Without Limits or Throttling, Perplexity-validated 2026-05-11).
+/// `serde_json::from_str::<Value>`
 /// builds a full DOM that costs roughly 2-3x the body size in memory; a
 /// hostile server returning a valid 100 MB JSON body would force 200-300 MB
 /// of DOM allocation even though every downstream cap (`cap_entry`,
@@ -928,7 +930,7 @@ fn cap_entry(s: &str) -> std::borrow::Cow<'_, str> {
 
 /// Bounded JSON serialization of a `serde_json::Value`.
 ///
-/// Defense-in-depth against memory-amplification DoS (OWASP A06 / AP11) for the
+/// Defense-in-depth against memory-amplification DoS (OWASP API4:2023 (Unrestricted Resource Consumption) / CWE-770 (Allocation of Resources Without Limits or Throttling)) for the
 /// non-string-value branch of `extract_error_message_raw`. `Value::to_string()`
 /// (or `serde_json::to_string`) fully serializes the input into a `String`
 /// BEFORE `cap_entry` can truncate it — a hostile response with a deeply
@@ -1202,7 +1204,7 @@ fn extract_error_message_raw(body: &[u8]) -> String {
     let body_str = match std::str::from_utf8(body) {
         Ok(s) => s,
         Err(_) => {
-            // Memory-amplification defense (OWASP A06 / AP11, Perplexity-validated
+            // Memory-amplification defense (OWASP API4:2023 (Unrestricted Resource Consumption) / CWE-770 (Allocation of Resources Without Limits or Throttling), Perplexity-validated
             // 2026-05-11): `String::from_utf8_lossy` allocates an owned String for
             // the ENTIRE byte slice even though `cap_entry` will truncate the result
             // to MAX_ERROR_ENTRY_LEN. A hostile server returning a massive non-UTF8
@@ -1249,7 +1251,7 @@ fn extract_error_message_raw(body: &[u8]) -> String {
         }
     };
 
-    // Memory-amplification defense at the JSON parse step (OWASP A06 / AP11,
+    // Memory-amplification defense at the JSON parse step (OWASP API4:2023 (Unrestricted Resource Consumption) / CWE-770 (Allocation of Resources Without Limits or Throttling),
     // Perplexity-validated 2026-05-11, R11 finding). `serde_json::from_str::<Value>`
     // materializes a full DOM that costs roughly 2-3x the body size in memory.
     // Even though every downstream cap (cap_entry, serialize_value_bounded,
@@ -1271,7 +1273,7 @@ fn extract_error_message_raw(body: &[u8]) -> String {
 
     if let Ok(json) = serde_json::from_str::<serde_json::Value>(body_str) {
         if let Some(msgs) = json.get("errorMessages").and_then(|v| v.as_array()) {
-            // Memory-amplification defense (OWASP A06 / AP11, Perplexity-validated
+            // Memory-amplification defense (OWASP API4:2023 (Unrestricted Resource Consumption) / CWE-770 (Allocation of Resources Without Limits or Throttling), Perplexity-validated
             // 2026-05-11): even though each entry is per-entry-capped via
             // cap_entry, the NUMBER of entries is server-controlled. A hostile
             // response with a million entries × 1024 bytes each would force a
@@ -1320,7 +1322,7 @@ fn extract_error_message_raw(body: &[u8]) -> String {
         }
         if let Some(errors) = json.get("errors").and_then(|v| v.as_object()) {
             if !errors.is_empty() {
-                // Memory-amplification defense (OWASP A06 / AP11, same threat
+                // Memory-amplification defense (OWASP API4:2023 (Unrestricted Resource Consumption) / CWE-770 (Allocation of Resources Without Limits or Throttling), same threat
                 // class as the errorMessages streaming join earlier). Three
                 // server-controlled vectors are bounded here:
                 //

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -862,6 +862,11 @@ const MAX_SANITIZED_OUTPUT_LEN: usize = 4096;
 /// `MAX_ERROR_ENTRY_LEN`, appending a `[...truncated, N bytes total]` marker
 /// so the operator sees that truncation happened.
 ///
+/// Returns `Cow::Borrowed(s)` when no truncation is needed (the common case
+/// for legitimate Atlassian error entries — most are <<1 KiB) so the caller
+/// can join without per-entry allocation. Only allocates a new `String` when
+/// the input actually exceeds the cap.
+///
 /// The marker length is reserved from the prefix budget, so the FINAL output
 /// length is guaranteed to be `<= MAX_ERROR_ENTRY_LEN` — important because
 /// the marker would otherwise push slightly-oversized inputs (e.g., 1025
@@ -871,9 +876,9 @@ const MAX_SANITIZED_OUTPUT_LEN: usize = 4096;
 /// Used by `extract_error_message_raw` as defense-in-depth against
 /// terminal/log flooding attacks (companion to `sanitize_for_stderr`'s
 /// control-byte escaping per CWE-117).
-fn cap_entry(s: &str) -> String {
+fn cap_entry(s: &str) -> std::borrow::Cow<'_, str> {
     if s.len() <= MAX_ERROR_ENTRY_LEN {
-        return s.to_string();
+        return std::borrow::Cow::Borrowed(s);
     }
     let marker = format!(" [...truncated, {} bytes total]", s.len());
     // Defensive: with MAX_ERROR_ENTRY_LEN = 1024 and any plausible byte
@@ -887,14 +892,14 @@ fn cap_entry(s: &str) -> String {
         while !marker.is_char_boundary(end) {
             end -= 1;
         }
-        return marker[..end].to_string();
+        return std::borrow::Cow::Owned(marker[..end].to_string());
     }
     let target_prefix_len = MAX_ERROR_ENTRY_LEN - marker.len();
     let mut end = target_prefix_len;
     while !s.is_char_boundary(end) {
         end -= 1;
     }
-    format!("{}{}", &s[..end], marker)
+    std::borrow::Cow::Owned(format!("{}{}", &s[..end], marker))
 }
 
 /// Sanitize a server-supplied string for safe display on stderr.
@@ -945,34 +950,33 @@ fn sanitize_for_stderr(input: String) -> String {
         return input;
     }
 
-    // Slow path: sanitize AND/OR truncate. Reserve headroom for the
-    // truncation marker so we can append it without exceeding the cap.
-    const MAX_MARKER_LEN: usize = 64;
-    let prefix_budget = MAX_SANITIZED_OUTPUT_LEN.saturating_sub(MAX_MARKER_LEN);
+    // Slow path: sanitize AND/OR truncate. Allow output to grow up to the
+    // FULL `MAX_SANITIZED_OUTPUT_LEN` — only when the cap is actually
+    // breached do we retroactively trim back to make room for the truncation
+    // marker. This avoids premature truncation of messages that would
+    // otherwise fit in the cap (e.g., a clean 4090-byte input shouldn't
+    // lose 64 bytes to a marker that never gets appended).
     let original_len = input.len();
-
     const HEADROOM: usize = 32;
     let mut out = String::with_capacity((input.len() + HEADROOM).min(MAX_SANITIZED_OUTPUT_LEN));
     let mut truncated = false;
 
     for c in input.chars() {
-        // Compute the byte cost of emitting `c` BEFORE pushing it, so we can
-        // bail out cleanly if it would push us past the prefix budget.
-        // Control chars expand 1→4 bytes (`\xNN`); other chars take
-        // `c.len_utf8()` bytes (1-4 bytes for any valid Unicode scalar).
+        // Compute the byte cost of emitting `c` BEFORE pushing it. Control
+        // chars expand 1→4 bytes (`\xNN`); other chars take `c.len_utf8()`
+        // bytes (1-4 bytes for any valid Unicode scalar).
         let needed = if c.is_ascii_control() {
             4
         } else {
             c.len_utf8()
         };
-        if out.len() + needed > prefix_budget {
+        if out.len() + needed > MAX_SANITIZED_OUTPUT_LEN {
             truncated = true;
             break;
         }
         if c.is_ascii_control() {
             // Write directly into `out` via fmt::Write — avoids the per-escape
             // String allocation that `format!()` would introduce.
-            // ASCII control chars (0x00-0x1F + 0x7F) fit in u8.
             // write! on String is infallible; ignore the Result to avoid a
             // distracting `expect()` in a hot loop.
             let _ = write!(out, "\\x{:02x}", c as u8);
@@ -982,16 +986,30 @@ fn sanitize_for_stderr(input: String) -> String {
     }
 
     if truncated {
-        // The marker is bounded by MAX_MARKER_LEN (decimal byte count digits
-        // grow linearly with input.len() but stay well under 64 bytes for any
-        // plausible input — usize::MAX has 20 digits, marker template is ~50
-        // bytes total).
-        let _ = write!(
-            out,
+        // Build the marker with the actual sanitized-bytes value at the time
+        // of truncation (out.len() before the marker is appended) and the
+        // original input length.
+        let marker = format!(
             " [...truncated at {} sanitized bytes; original {} bytes]",
             out.len(),
             original_len
         );
+        if out.len() + marker.len() <= MAX_SANITIZED_OUTPUT_LEN {
+            // Marker fits without trimming.
+            out.push_str(&marker);
+        } else {
+            // Marker would push us over: retroactively trim `out` at a UTF-8
+            // char boundary so `out + marker` fits within the cap. The trim
+            // is bounded by marker.len() (< 80 bytes for any plausible
+            // original_len) — bounded work, no quadratic blow-up.
+            let target = MAX_SANITIZED_OUTPUT_LEN - marker.len();
+            let mut end = target;
+            while !out.is_char_boundary(end) {
+                end -= 1;
+            }
+            out.truncate(end);
+            out.push_str(&marker);
+        }
     }
     out
 }
@@ -1030,31 +1048,53 @@ fn extract_error_message_raw(body: &[u8]) -> String {
 
     let body_str = match std::str::from_utf8(body) {
         Ok(s) => s,
-        Err(_) => return cap_entry(&String::from_utf8_lossy(body)),
+        Err(_) => return cap_entry(&String::from_utf8_lossy(body)).into_owned(),
     };
 
     if let Ok(json) = serde_json::from_str::<serde_json::Value>(body_str) {
         if let Some(msgs) = json.get("errorMessages").and_then(|v| v.as_array()) {
-            let messages: Vec<String> = msgs
+            // Collect as Cow<str> so unchanged entries borrow rather than
+            // allocate. Only over-cap entries pay the allocation cost.
+            let messages: Vec<std::borrow::Cow<'_, str>> = msgs
                 .iter()
                 .filter_map(|m| m.as_str())
                 .map(cap_entry)
                 .collect();
             if !messages.is_empty() {
-                return messages.join("; ");
+                // Build the joined string with a single allocation
+                // pre-sized to the total content length. Avoids the
+                // intermediate `Vec<&str>` + `[].join()` allocation chain.
+                let total: usize =
+                    messages.iter().map(|c| c.len()).sum::<usize>() + 2 * (messages.len() - 1);
+                let mut joined = String::with_capacity(total);
+                for (i, m) in messages.iter().enumerate() {
+                    if i > 0 {
+                        joined.push_str("; ");
+                    }
+                    joined.push_str(m.as_ref());
+                }
+                return joined;
             }
         }
         if let Some(errors) = json.get("errors").and_then(|v| v.as_object()) {
             if !errors.is_empty() {
+                // Per-entry formatting always allocates the "{k}: {v}" pair
+                // string, so the per-entry cap_entry being Cow doesn't avoid
+                // that — but it does avoid the prior to_string() copy for
+                // unchanged values (which are the common case).
                 let mut pairs: Vec<String> = errors
                     .iter()
                     .map(|(k, v)| {
-                        let value_str = if let Some(s) = v.as_str() {
-                            cap_entry(s)
+                        if let Some(s) = v.as_str() {
+                            // String value: borrow via Cow when no truncation.
+                            format!("{k}: {}", cap_entry(s))
                         } else {
-                            cap_entry(&v.to_string())
-                        };
-                        format!("{k}: {value_str}")
+                            // Non-string value: must materialize once to apply
+                            // the cap, then format. v.to_string() is a temp
+                            // that doesn't outlive the Cow, so own immediately.
+                            let serialized = v.to_string();
+                            format!("{k}: {}", cap_entry(&serialized))
+                        }
                     })
                     .collect();
                 pairs.sort();
@@ -1062,14 +1102,14 @@ fn extract_error_message_raw(body: &[u8]) -> String {
             }
         }
         if let Some(msg) = json.get("message").and_then(|v| v.as_str()) {
-            return cap_entry(msg);
+            return cap_entry(msg).into_owned();
         }
         if let Some(msg) = json.get("errorMessage").and_then(|v| v.as_str()) {
-            return cap_entry(msg);
+            return cap_entry(msg).into_owned();
         }
     }
 
-    cap_entry(body_str)
+    cap_entry(body_str).into_owned()
 }
 
 #[cfg(test)]
@@ -1315,8 +1355,8 @@ mod sanitize_tests {
         let with_multibyte = format!("{padding}日本語のエラーです");
         // Should not panic, should produce valid UTF-8.
         let capped = cap_entry(&with_multibyte);
-        // Verify it's still valid UTF-8 by re-parsing.
-        let _ = capped.as_str();
+        // Verify it's still valid UTF-8 by re-parsing through Cow's str view.
+        let _ = capped.as_ref();
         // Size invariant must also hold for UTF-8-bordering inputs.
         assert!(
             capped.len() <= MAX_ERROR_ENTRY_LEN,

--- a/tests/api_client.rs
+++ b/tests/api_client.rs
@@ -378,7 +378,9 @@ fn test_extract_error_message_sanitizes_null_byte_in_errors_object_value() {
 #[test]
 fn test_extract_error_message_preserves_utf8_in_sanitized_path() {
     // Localized error messages (non-English Jira tenants) must survive the
-    // sanitization layer intact — only ASCII control bytes are escaped.
+    // sanitization layer intact — only control characters (ASCII C0/DEL and
+    // Unicode C1) are escaped; printable Unicode (CJK, Latin extended, etc.)
+    // passes through unchanged.
     let body = r#"{"errorMessages":["問題が見つかりません"]}"#;
     let result = extract_error_message(body.as_bytes());
     assert_eq!(result, "問題が見つかりません");

--- a/tests/api_client.rs
+++ b/tests/api_client.rs
@@ -343,7 +343,8 @@ fn test_extract_error_message_empty_body() {
 
 // CWE-117 sanitization is wired into extract_error_message — these integration tests
 // exercise the public API to confirm hostile/proxy-injected control chars in any of
-// the precedence paths get rendered as `\xNN` literals before reaching stderr.
+// the precedence paths get rendered as visible escape sequences (ASCII controls as
+// `\xNN`, Unicode C1 controls U+0080..U+009F as `\u{NNNN}`) before reaching stderr.
 
 #[test]
 fn test_extract_error_message_sanitizes_crlf_in_error_messages_array() {

--- a/tests/api_client.rs
+++ b/tests/api_client.rs
@@ -341,6 +341,49 @@ fn test_extract_error_message_empty_body() {
     assert_eq!(result, "<empty response body>");
 }
 
+// CWE-117 sanitization is wired into extract_error_message — these integration tests
+// exercise the public API to confirm hostile/proxy-injected control chars in any of
+// the precedence paths get rendered as `\xNN` literals before reaching stderr.
+
+#[test]
+fn test_extract_error_message_sanitizes_crlf_in_error_messages_array() {
+    // CWE-117 attack: hostile errorMessages payload tries to inject a fake log line.
+    let body = br#"{"errorMessages":["Issue not found\r\n[jr] CRITICAL: fake log"]}"#;
+    let result = extract_error_message(body);
+    assert_eq!(result, "Issue not found\\x0d\\x0a[jr] CRITICAL: fake log");
+    assert!(!result.contains('\r'));
+    assert!(!result.contains('\n'));
+}
+
+#[test]
+fn test_extract_error_message_sanitizes_ansi_escape_in_message_field() {
+    // CWE-117 attack: ANSI escape sequence in the `message` field would change
+    // terminal color / cursor / title if rendered literally.
+    let body = br#"{"message":"Error\u001b[31mRED\u001b[0m"}"#;
+    let result = extract_error_message(body);
+    assert_eq!(result, "Error\\x1b[31mRED\\x1b[0m");
+    assert!(!result.contains('\x1b'));
+}
+
+#[test]
+fn test_extract_error_message_sanitizes_null_byte_in_errors_object_value() {
+    // CWE-117 attack: NUL byte in a field-level error value could truncate
+    // C-string-based loggers or break some terminals.
+    let body = br#"{"errorMessages":[],"errors":{"summary":"bad\u0000value"}}"#;
+    let result = extract_error_message(body);
+    assert_eq!(result, "summary: bad\\x00value");
+    assert!(!result.contains('\0'));
+}
+
+#[test]
+fn test_extract_error_message_preserves_utf8_in_sanitized_path() {
+    // Localized error messages (non-English Jira tenants) must survive the
+    // sanitization layer intact — only ASCII control bytes are escaped.
+    let body = r#"{"errorMessages":["問題が見つかりません"]}"#;
+    let result = extract_error_message(body.as_bytes());
+    assert_eq!(result, "問題が見つかりません");
+}
+
 #[tokio::test]
 async fn test_send_raw_returns_response_for_2xx() {
     let server = MockServer::start().await;


### PR DESCRIPTION
## Summary

Sanitize Atlassian server-supplied error content at the `extract_error_message` boundary to prevent CWE-117 (log injection / terminal-escape injection) and bound memory amplification via hostile responses. Closes #334.

## The risk

`extract_error_message` joins `errorMessages` array, `errors` map values, `message` field, and `errorMessage` field — all server-controlled — into a single string that gets printed to stderr by callers. A hostile or proxy-controlled response could inject:

- `\r\n[jr] CRITICAL: fake log` (CR/LF fake log lines)
- `\x1b[31m...` (ANSI color/cursor/title changes)
- `\x00` (NUL byte — breaks some loggers/terminals)
- Arbitrarily large bodies / errorMessages arrays (memory amplification DoS)

## Fix (final design after 5 Copilot rounds)

### Sanitization layer

- New `sanitize_for_stderr(input: String) -> String` (by-value signature lets the clean+small-input fast path return the input unchanged with zero allocation).
- Escapes ASCII control bytes (0x00-0x1F + 0x7F) as visible `\xNN` literals; preserves UTF-8 so localized error messages survive.
- Caps FINAL output at `MAX_SANITIZED_OUTPUT_LEN = 4096` bytes via a byte-budget-aware char loop that accounts for the 1→4 byte expansion of control bytes. Retroactive trim at UTF-8 char boundary if marker would overflow.

### Per-entry cap layer (defense-in-depth)

- `cap_entry(s: &str) -> Cow<'_, str>` (Cow per Rust API Guidelines C-COST: zero-cost when no truncation, owned only when over-cap).
- Caps each pre-sanitization entry at `MAX_ERROR_ENTRY_LEN = 1024` bytes per issue #334 acceptance criteria.

### Memory-amplification defense (PR R5)

- Non-UTF8 fallback pre-caps the byte slice to `MAX_ERROR_ENTRY_LEN * 4` BEFORE `String::from_utf8_lossy` to bound the lossy-conversion allocation. (OWASP A06/AP11 Resource Exhaustion mitigation.)
- `errorMessages` join is streaming: pre-sized to `MAX_SANITIZED_OUTPUT_LEN`, iterates lazily, stops as soon as the budget is hit (with `[...truncated]` marker). Bounded memory regardless of server-controlled entry count.

### Why not `str::escape_debug`?

Empirically verified Rust 1.85 behavior: `{:?}` for `&str` DOES escape `\r\n\0\t\x1b` via `str::escape_debug`. However it ALSO escapes non-ASCII as `\u{XXXX}`, which would garble localized error messages from non-English Jira tenants. The custom sanitizer preserves Unicode while escaping only the ASCII control bytes that are the actual attack vector.

## Test plan

- [x] 21 inline sanitize unit tests (`mod sanitize_tests`): clean ASCII passthrough, UTF-8 in 3 scripts, CR/LF/ANSI/NUL/TAB/DEL escaping, CRLF/ANSI attack patterns, idempotency, empty string, fast-path pointer-equality (zero-copy), per-entry cap with truncation marker, size invariant at boundary oversize, UTF-8 char boundary respect, post-sanitization expansion cap, oversized clean input cap, under-cap no-truncation.
- [x] 4 new integration tests in `tests/api_client.rs`: hostile JSON payloads in different precedence paths (errorMessages CRLF, message ANSI, errors-map NUL), UTF-8 preservation. All 22 existing api_client tests pass unchanged.
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, full `cargo test`: all green (60 suites).

## Threat model

- Hostile Atlassian endpoint (compromise or spoof)
- JR_BASE_URL-controlled MitM proxy in test scenarios
- CWE-117 (log injection)
- OWASP A06 (memory-amplification DoS via response body or entry count)
