### PR TITLE
docs(spec): backport has_more guard-abort trigger to public spec snippet (PR #362 follow-up)

### DIFF
--- a/docs/specs/2026-05-13-search-issue-keys.md
+++ b/docs/specs/2026-05-13-search-issue-keys.md
@@ -67,9 +67,20 @@ Alternatives considered and rejected:
 /// Rust-SDK precedent surveyed in
 /// `.factory/research/issue-350-search-issue-keys-design.md`.
 ///
-/// `has_more` is `true` iff the caller's `limit` was hit AND the upstream
-/// API still had more rows available; pure cursor exhaustion always
-/// returns `has_more = false`. (Same semantics as `SearchResult::has_more`.)
+/// `has_more` is set to `true` in two cases:
+///
+/// 1. **Caller limit hit:** the caller supplied a `limit` and upstream still
+///    had rows available beyond that limit.
+/// 2. **JRACLOUD-94632 guard abort:** the anti-loop guard fired (upstream
+///    returned the same `nextPageToken` twice), pagination was aborted with
+///    a stderr warning, and results may be incomplete due to a server bug.
+///
+/// Pure cursor exhaustion (no limit set, upstream returns `isLast: true`)
+/// always returns `has_more = false`. Callers that need completeness
+/// guarantees should treat `has_more = true` as "results may be truncated"
+/// regardless of whether a `limit` was supplied.
+///
+/// Traces to BC-2.6.050.
 #[derive(Debug, Clone, PartialEq)]
 pub struct KeySearchResult {
     pub keys: Vec<String>,
@@ -184,7 +195,7 @@ The `+1` lookahead is preserved so the exact-count error message is unchanged. T
 ### Doc and spec fallout
 
 - **CLAUDE.md** — one-line update to the `src/api/jira/issues.rs` blurb (currently "search, get, create, edit, list comments") to note `search_issue_keys` exists alongside `search_issues`.
-- **`.factory/specs/prd/bc-2-issue-read.md`** — add BC-2.6.050 in subdomain 2.6 (API layer), after BC-2.6.049. Suggested text: *"`client.search_issue_keys(jql, limit)` posts `/rest/api/3/search/jql` with body `fields: ["key"]` and deserializes only the top-level `key` field; returns `KeySearchResult { keys, has_more }` where `has_more` reflects caller-side truncation."* Also bump the file's frontmatter `definitional_count` from 49 → 50.
+- **`.factory/specs/prd/bc-2-issue-read.md`** — add BC-2.6.050 in subdomain 2.6 (API layer), after BC-2.6.049. Suggested text: *"`client.search_issue_keys(jql, limit)` posts `/rest/api/3/search/jql` with body `fields: ["key"]` and deserializes only the top-level `key` field; returns `KeySearchResult { keys, has_more }` where `has_more` is `true` on caller-side truncation OR JRACLOUD-94632 guard abort, and `false` on pure cursor exhaustion."* Also bump the file's frontmatter `definitional_count` from 49 → 50.
 - **`.factory/specs/prd/BC-INDEX.md`** — bump frontmatter `total_bcs` from 545 → 546 AND update the `sections:` line for `bc-2-issue-read.md` from `49 individually-bodied` → `50 individually-bodied`. Both counts must stay aligned with each other and with `bc-2-issue-read.md`'s `definitional_count`.
 - **`scripts/check-spec-counts.sh`** — run as a verification (exit 0 required) before committing the spec changes. The script enforces frontmatter ↔ body count alignment per DRIFT-001 mitigation.
 
@@ -219,7 +230,7 @@ None required. The new method is a thin wrapper over the HTTP surface; its seman
 
 - **Inconclusive: `fields{}` echo (Validated API Facts §6).** Mitigated by reading only top-level `key`. If Jira ever inverts this, tests 2/3/8 fail loudly with a serde "missing field `key`" deserialization error (NOT empty-string keys — IssueKeyRow.key has no #[serde(default)]).
 - **JRACLOUD-94632 false positives (addendum §Q4).** The inherited warning text overclaims "server bug" but is correct ~95 % of the time; live-data-drift false positives exist (JRACLOUD-95368). This PR inherits the existing text verbatim and files a separate follow-up to tighten the wording. Not blocking.
-- **`has_more` semantic drift.** If a future caller assumes `has_more = true` means "API has more pages" (rather than "caller-side truncation only"), they could mis-paginate. Mitigated by explicit rustdoc on the struct + test 5 pinning the contract.
+- **`has_more` semantic drift.** `has_more = true` has two distinct truthy triggers: caller-side truncation (limit hit) OR JRACLOUD-94632 guard abort (incomplete results due to server bug). If a future caller assumes only one trigger is possible, they could mis-paginate or miss the guard-abort signal. Mitigated by explicit rustdoc on the struct (two numbered cases) + test 5 pinning the truncation contract + test 4 pinning the guard-abort path.
 - **Length-strict array enforcement on `fields`.** `wiremock::body_partial_json` is subset-matching, so the strictness assertion lives in the test body (`received_requests()` + `assert_eq!`), not in the matcher. The addendum §Q3 claim that `body_partial_json` was length-strict is retracted in this spec — see Tests §1 note. A negative `.expect(0)` mock is not needed because the explicit `assert_eq!` is stronger.
 
 ## Backwards Compatibility


### PR DESCRIPTION
## Summary

- Aligns the `search_issue_keys` public spec rustdoc snippet (`docs/specs/2026-05-13-search-issue-keys.md`) with the actual code rustdoc shipped in PR #362.
- PR #362 Copilot R1 (commit `2e32195`) introduced a BC-2.6.050 §4 contract refinement: `has_more` now has **two** truthy triggers (caller-side truncation OR JRACLOUD-94632 guard-abort), not one. R2 (commit `4c6332b`) updated the code rustdoc. This PR closes the remaining doc-fallout: the public spec's rustdoc CODE SAMPLE still showed the old single-trigger wording.
- Factory-artifacts (BC body + story AC + sidecar-learning entry + STATE.md Drift Items) were updated separately in commit `cf9ddd4` on the factory-artifacts branch.

## Reference

- Parent feature PR: #362 (merged)
- Copilot R1 refinement commit: `2e32195`
- Code rustdoc fix commit: `4c6332b`
- Factory-artifacts update commit: `cf9ddd4`
- STATE.md entry: DRIFT-005

## Why this is a follow-up

Copilot review in PR #362 introduced a real contract refinement mid-flight. The code rustdoc and factory artifacts were updated in that PR's R2 cycle. However the **public spec's rustdoc snippet** — which is a verbatim copy of the code comment intended to stay in sync — was not updated before merge. DRIFT-005 in STATE.md captures this as a known doc-fallout item from the post-Copilot review pattern: when a reviewer introduces a contract refinement, all three artefacts (code rustdoc, spec snippet, factory BC) must move together. This PR closes the remaining gap.

## Files changed

- `docs/specs/2026-05-13-search-issue-keys.md` — spec rustdoc snippet updated to match code; two related sentences in §Risks and §Doc-fallout updated.

## Test plan

- [ ] CI passes (no code changed — only `docs/specs/*.md` touched; clippy/fmt/test suites are unaffected by this file)
- [ ] Spot-check: `git diff origin/develop...HEAD -- docs/specs/2026-05-13-search-issue-keys.md` shows only the `has_more` wording change (two truthy triggers instead of one) and the two sentence updates in §Risks and §Doc-fallout
- [ ] No `src/` files modified — confirmed by `git show --stat 44eb3ce`

_Adversarial review (F5) not required — docs-only single-file edit aligning spec with already-merged code. Copilot review + CI green is sufficient per quick-dev-routing compressed Feature Mode._