### PR TITLE
chore: bump version to 0.5.0-dev.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to jr will be documented here.
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## [0.5.0-dev.10] - 2026-05-26
+
+### Added
+
 - `issue edit`: new `--field NAME=VALUE` flag (repeatable) for setting arbitrary custom
   fields on an existing issue. Supports string, number, single-select (option), date,
   datetime, and user field types. Single-select options are resolved from `editmeta`
@@ -28,6 +36,20 @@ All notable changes to jr will be documented here.
   **MUST re-consent** (`jr auth refresh` or `jr auth login`) to gain the new scope
   before JSM request creation will work. Existing access tokens continue working with
   old scopes until expiry; re-consent is triggered on the next token mint. (Issue #288)
+- `jr issue create --request-type` and `jr issue create` (JSM path) now emit
+  auth-aware 401 error hints. When a 401 occurs against `/rest/servicedeskapi/*`,
+  the error message distinguishes between OAuth scope gaps (`write:servicedesk-request`
+  missing) and API-token expiry, with actionable next-step guidance. (Issue #384)
+- JSM input validation and UX polish for `jr issue create --request-type`: empty
+  `--request-type` value is rejected at parse time (exit 64); combining
+  `--markdown` with `--field description=` is rejected with a conflict error;
+  using platform-only flags (`--type`, `--team`, `--sprint`, etc.) on the JSM
+  path now emits a per-flag warning to stderr listing the ignored flags. (Issue #385)
+- `jr issue edit --type` now emits an enriched error message when the transition
+  is rejected with HTTP 400, including the target type name, the current hierarchy
+  level, and a hint that cross-hierarchy type changes are not supported by Jira
+  Cloud. `--no-parent` with a non-existent parent ID now surfaces a clear
+  fake-endpoint hint instead of a raw 404. (Issue #388)
 
 ### Fixed
 
@@ -36,6 +58,13 @@ All notable changes to jr will be documented here.
   `--label` routing fork calls a labels-only handler that does not accept custom-field pairs;
   the `--label` mutual-exclusion block now rejects this combination before any HTTP call.
   (FIX-F5-001, follow-up to issue #396)
+
+### Dependencies
+
+- `rand` bumped from 0.9.4 to 0.10.1. No user-visible behavior change; `jr` uses only
+  the OS CSPRNG path (unaffected by the soundness fix in GHSA-cq8v-f236-94qc /
+  RUSTSEC-2026-0097, which applies to `ThreadRng` with the `log` feature — neither of
+  which `jr` enables). Dependency hygiene update. (Issue #413)
 
 ### BREAKING CHANGE (v0.6)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.5.0-dev.9"
+version = "0.5.0-dev.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.5.0-dev.9"
+version = "0.5.0-dev.10"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary

Release-prep PR: bumps version to `0.5.0-dev.10`. Changes are limited to `Cargo.toml`, `Cargo.lock`, and `CHANGELOG.md` — no source or test code modified.

### User-visible changes in this release

**Added**
- `jr issue create --request-type <NAME|ID>`: full JSM request-type support via `POST /rest/servicedeskapi/request`; `--field`, `--on-behalf-of`, and `write:servicedesk-request` OAuth scope (re-consent required for existing OAuth users). (Issue #288)
- `issue edit --field NAME=VALUE`: arbitrary custom-field editing on a single issue; multi-key bulk path rejects `--field`. (Issue #396)
- `jr issue edit` / `jr issue create` now echo changed/set fields on success; `--output json` gains a `changed_fields` object. (Issue #398)
- JSM 401 auth-aware error hints: distinguishes OAuth scope gap vs. API-token expiry on `servicedeskapi` 401s. (Issue #384)
- JSM input validation + UX polish: empty `--request-type` rejected at parse time; `--markdown` + `--field description=` conflict guard; per-flag warnings for ignored platform-only flags on JSM path. (Issue #385)
- `issue edit --type` enriched HTTP 400 error + `--no-parent` fake-endpoint hint. (Issue #388)

**Fixed**
- `jr issue edit --label ... --field ...` now exits 64 instead of silently dropping the `--field` write. (FIX-F5-001)

**Dependencies**
- `rand` 0.9.4 → 0.10.1: no user-visible behavior change; `jr` is not affected by GHSA-cq8v-f236-94qc / RUSTSEC-2026-0097 (no ThreadRng, no log feature). Pure dependency hygiene. (Issue #413)

## Post-merge steps (for maintainer)

After CI passes and this PR is merged to `develop`:

1. Pull the merge commit SHA: `git pull --ff-only origin develop`
2. Create an annotated tag on the merge commit:
   ```bash
   git tag -a v0.5.0-dev.10 -m "$(cat <<'TAGEOF'
   v0.5.0-dev.10

   Features: JSM request-type support, issue edit --field, JSM 401 auth-aware hints,
   cross-hierarchy edit --type enrichment, changed-fields echo on create/edit.
   Fix: --label + --field silent-drop guard (FIX-F5-001).
   Dependencies: rand 0.10.1 (hygiene, no behavioral change).
   TAGEOF
   )"
   ```
3. Push the tag to trigger `.github/workflows/release.yml`:
   ```bash
   git push origin v0.5.0-dev.10
   ```

## CI note

This is a release-prep PR; CI runs normally (lint, test, build). No code changes beyond the three listed files.