### PR TITLE
fix(ci): explicit rustup target add for release.yml cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Ensure cross-target installed (defensive)
+        if: ${{ !matrix.use_cross }}
+        run: rustup target add ${{ matrix.target }}
+
       - name: Install cross
         if: matrix.use_cross
         run: cargo install cross --git https://github.com/cross-rs/cross


### PR DESCRIPTION
## Root cause

The `dtolnay/rust-toolchain` SHA bump in #326 (`29eef336...` → `c93f4f9c...`) silently stopped honoring the `targets:` parameter when cross-compiling across host architectures. `macos-latest` runners are now Apple Silicon (arm64), so building `x86_64-apple-darwin` requires the target's libcore/libstd to be present on the host toolchain. The new action SHA does not install it, so the build fails immediately with:

```
error[E0463]: can't find crate for 'core'
  --> ...cfg-if-1.0.4/src/lib.rs
  = note: the `x86_64-apple-darwin` target may not be installed
```

Failed run: https://github.com/Zious11/jira-cli/actions/runs/26476350682

The `v0.5.0-dev.9` tag (used the old SHA) succeeded. `v0.5.0-dev.10` (new SHA) failed on `Build x86_64-apple-darwin`; the other 3 legs were cancelled by fail-fast. No GH Release was published; no binaries uploaded.

## Fix

Add a defensive `rustup target add ${{ matrix.target }}` step immediately after `Install Rust`. The step:

- Is skipped (`if: !matrix.use_cross`) for the `aarch64-unknown-linux-gnu` leg, where `cross` runs cargo inside its own container and a host-side `rustup target add` is a no-op.
- Is idempotent — if the action ever starts honoring `targets:` again, the step is a silent no-op.
- Does **not** change the action SHA (`c93f4f9c...`); the fix is agnostic to action behavior.

## Recovery plan

After this PR merges, the orchestrator will:
1. Force-delete the `v0.5.0-dev.10` tag (local + remote — only ~30 min old, no consumers).
2. Re-create it on the merge commit.
3. Push → triggers the fixed `release.yml` run.