### PR TITLE
fix(main): unblock CI — clippy 1.95 sort_by_key + rustls-webpki advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,9 +1793,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/src/api/jira/fields.rs
+++ b/src/api/jira/fields.rs
@@ -73,7 +73,7 @@ pub fn filter_story_points_fields(fields: &[Field]) -> Vec<(String, String)> {
         })
         .collect();
 
-    matches.sort_by(|a, b| b.2.cmp(&a.2));
+    matches.sort_by_key(|m| std::cmp::Reverse(m.2));
     matches
         .into_iter()
         .map(|(id, name, _)| (id, name))


### PR DESCRIPTION
Closes #419.

## Summary

Backports the one-line source-code change from develop's 7c68b0e (PR #183) to main. Rust 1.95.0 introduced `clippy::unnecessary_sort_by`, which fails CI on every push to main until applied.

## What's in this PR

```
 src/api/jira/fields.rs | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

-    matches.sort_by(|a, b| b.2.cmp(&a.2));
+    matches.sort_by_key(|m| std::cmp::Reverse(m.2));
```

Same change as 7c68b0e's source diff, with the lambda binder renamed `a, b` → `m` to match what already shipped on develop (cosmetic; pure rename).

## What's NOT in this PR

The doc-accuracy parts of 7c68b0e (markdown edits to `docs/superpowers/specs/2026-04-16-verbose-request-body-logging-design.md` and `docs/superpowers/plans/2026-04-16-verbose-request-body-logging.md`) reference files that landed on develop after the last main release and do not exist on main. They have nothing to backport against.

## Test plan

Verified locally on macOS arm64 + rustc 1.95.0:

- [x] `cargo clippy --all --all-features --tests -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo build` — succeeds
- [x] `cargo test --lib` — passes (no behavior change; `sort_by_key` with `Reverse` is semantically identical to the prior `sort_by(|a, b| b.2.cmp(&a.2))` because `bool` ordering puts `true > false`)

## Notes

The branch is from `ArcavenAE/jira-cli` (a fork). Opening this from the fork because direct push access to Zious11 is via HTTPS-only here; no special collaboration arrangement implied.

---

## Additional fix — rustls-webpki advisories (added on top)

Same PR also bumps `rustls-webpki` 0.103.10 → 0.103.13 to clear the `Deny (licenses + vulnerabilities)` job's three failing advisories. Bundled here because they're the same root cause (main is behind develop on routine maintenance) and clearing them is required to get a green CI on main.

Cargo.lock-only update. `rustls-webpki` is a transitive dep via `rustls` → `reqwest`; no Cargo.toml change required.

| Advisory | Title |
|---|---|
| [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098) | Name constraints for URI names were incorrectly accepted |
| [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099) | Name constraints were accepted for certificates asserting a wildcard name (cousin of CVE-2025-61727) |
| [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) | Reachable panic in certificate revocation list parsing |

0.103.13 is the lowest version satisfying all three (`>=0.103.12` for the first two, `>=0.103.13` for the CRL panic). Cargo's resolver picked it under the project's MSRV pin (1.85).

Additional verification:

- [x] `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok`