### PR TITLE
test(echo): harden #398 echo tests — de-vacuize dry-run + bulk guards (S-400-A)

### DIFF
--- a/tests/issue_create_echo.rs
+++ b/tests/issue_create_echo.rs
@@ -770,7 +770,7 @@ async fn test_bc_3_4_014_create_assignee_account_id_echo() {
 
 // ---------------------------------------------------------------------------
 // Test 21 — AC-014: JSM `--request-type` path never emits field echo lines
-// BC-3.4.014 EC-014; VP-398-AC-014.
+// BC-3.4.014 EC-014; AC-014.
 //
 // `handle_jsm_create` is entered when `--request-type` is set. The `create_echo`
 // BTreeMap is declared structurally AFTER the dispatch fork, so `handle_jsm_create`
@@ -911,5 +911,66 @@ async fn test_bc_3_4_014_create_jsm_request_type_path_no_field_echo() {
     assert!(
         !stderr.contains("  priority \u{2192}"),
         "AC-014: 'priority →' must not appear on JSM path; stderr={stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 22 — TH-398-4: create --description-stdin echoes `(updated)` marker
+// BC-3.4.014 invariant 2; parity with edit-side
+// test_bc_3_4_013_description_stdin_trailing_newline_preserved_in_changed_fields.
+//
+// The create side must echo `  description → (updated)` (table mode) when
+// description is supplied via stdin. The stdin content must NOT appear in stderr.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_bc_3_4_014_create_description_stdin_echo_is_updated_marker() {
+    let server = MockServer::start().await;
+    mount_post_201(&server, "PROJ-1").await;
+
+    let output = Command::cargo_bin("jr")
+        .unwrap()
+        .env("JR_BASE_URL", server.uri())
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .args([
+            "--no-input",
+            "issue",
+            "create",
+            "--project",
+            "PROJ",
+            "--type",
+            "Task",
+            "--summary",
+            "X",
+            "--description-stdin",
+        ])
+        .write_stdin("Some stdin description\n")
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "Expected exit 0; stderr={stderr} stdout={stdout}"
+    );
+
+    // Must echo the (updated) marker — BC-3.4.014 invariant 2
+    assert!(
+        stderr.contains("  description \u{2192} (updated)"),
+        "Expected 'description → (updated)' in stderr; stderr={stderr}"
+    );
+
+    // Must NOT echo the stdin content — BC-3.4.014 invariant 2
+    assert!(
+        !stderr.contains("Some stdin description"),
+        "Stdin description content must NOT appear in stderr; stderr={stderr}"
+    );
+
+    // stdout must be empty in table mode
+    assert!(
+        stdout.is_empty(),
+        "stdout must be empty in table mode; stdout={stdout}"
     );
 }

--- a/tests/issue_create_echo.rs
+++ b/tests/issue_create_echo.rs
@@ -928,10 +928,10 @@ async fn test_bc_3_4_014_create_description_stdin_echo_is_updated_marker() {
     let server = MockServer::start().await;
     mount_post_201(&server, "PROJ-1").await;
 
-    let output = Command::cargo_bin("jr")
-        .unwrap()
-        .env("JR_BASE_URL", server.uri())
-        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    let output = jr_cmd_with_xdg(&server.uri(), cache_dir.path(), config_dir.path())
         .args([
             "--no-input",
             "issue",

--- a/tests/issue_edit_echo.rs
+++ b/tests/issue_edit_echo.rs
@@ -648,16 +648,39 @@ fn test_bc_3_4_012_edit_echo_does_not_fire_on_dry_run() {
         .output()
         .unwrap();
 
+    let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    // dry-run exits non-zero (no keys to resolve) or exits 0 with planned output
-    // but in EITHER case, no `→` field-echo lines from the changed-fields echo
-    // of this contract must appear.
-    // Note: --dry-run requires a JQL or multiple keys; single key exits before PUT.
-    // The guarantee: no field-echo `  <field> → <value>` lines must appear.
+    // POSITIVE guard: prove the dry-run path actually executed (not an error
+    // path that vacuously satisfies the negative checks). Single-key `--dry-run`
+    // exits 0 and writes the planned-changes PREVIEW to *stdout*:
+    //   "DRY RUN — no changes will be made." + "  summary → X"
+    // (see src/cli/issue/create.rs handle_edit dry-run block — println!, stdout).
+    assert!(
+        output.status.success(),
+        "single-key --dry-run must exit 0; status={:?} stderr={stderr}",
+        output.status.code()
+    );
+    assert!(
+        stdout.contains("DRY RUN") && stdout.contains("summary \u{2192} X"),
+        "dry-run preview (planned changes) must appear on stdout; stdout={stdout}"
+    );
+
+    // NEGATIVE guard: the post-success changed-fields ECHO must NOT fire on
+    // dry-run. The success confirmation `Updated TEST-1` is emitted to stderr
+    // via output::print_success ONLY on the live PUT path; dry-run `return`s
+    // before reaching it. Asserting its absence on BOTH streams catches a
+    // regression where dry-run falls through to the live success/echo path.
+    assert!(
+        !stdout.contains("Updated TEST-1") && !stderr.contains("Updated TEST-1"),
+        "dry-run must not reach the success confirmation path; stdout={stdout} stderr={stderr}"
+    );
+    // The post-success echo writes `  <field> → <value>` to stderr; it must be
+    // absent (the identical-looking line on stdout is the dry-run PREVIEW, a
+    // different code path on a different stream).
     assert!(
         !stderr.contains("  summary \u{2192} X"),
-        "echo must not fire on dry-run; stderr={stderr}"
+        "post-success echo (stderr) must not fire on dry-run; stderr={stderr}"
     );
 }
 
@@ -674,15 +697,52 @@ fn test_bc_3_4_012_edit_echo_does_not_fire_on_dry_run() {
 async fn test_bc_3_4_012_edit_echo_excluded_for_bulk_multi_key() {
     let server = MockServer::start().await;
 
-    // Bulk edit issues two or more keys — the bulk path is used
+    // Two-key edit routes through handle_edit_bulk_fields → POST
+    // /rest/api/3/bulk/issues/fields, NOT through PUT /rest/api/3/issue/{key}.
+    // Mount the PUT mocks as `.expect(0)` sentinels to assert they are never called.
     Mock::given(method("PUT"))
         .and(path("/rest/api/3/issue/TEST-1"))
         .respond_with(ResponseTemplate::new(204))
+        .expect(0)
         .mount(&server)
         .await;
     Mock::given(method("PUT"))
         .and(path("/rest/api/3/issue/TEST-2"))
         .respond_with(ResponseTemplate::new(204))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    // Bulk submit: POST /rest/api/3/bulk/issues/fields returns 200 with taskId.
+    // Body shape matches BulkSubmitResponse (taskId deserialized from camelCase).
+    Mock::given(method("POST"))
+        .and(path("/rest/api/3/bulk/issues/fields"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "taskId": "task-bulk-echo-001",
+            "status": "ENQUEUED",
+            "progressPercent": 0,
+            "totalIssueCount": 0,
+            "processedAccessibleIssues": [],
+            "failedAccessibleIssues": {},
+            "invalidOrInaccessibleIssueCount": 0
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Task poll: GET /rest/api/3/bulk/queue/task-bulk-echo-001 returns COMPLETE.
+    // Body shape matches BulkOperationProgress (processedAccessibleIssues, status).
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/bulk/queue/task-bulk-echo-001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "taskId": "task-bulk-echo-001",
+            "status": "COMPLETE",
+            "progressPercent": 100,
+            "totalIssueCount": 2,
+            "processedAccessibleIssues": ["TEST-1", "TEST-2"],
+            "failedAccessibleIssues": {},
+            "invalidOrInaccessibleIssueCount": 0
+        })))
         .mount(&server)
         .await;
 
@@ -700,6 +760,12 @@ async fn test_bc_3_4_012_edit_echo_excluded_for_bulk_multi_key() {
         .unwrap();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // The bulk path must succeed (exit 0)
+    assert!(
+        output.status.success(),
+        "Expected exit 0 for bulk path; stderr={stderr}"
+    );
 
     // bulk path must never emit changed-fields echo lines
     assert!(

--- a/tests/issue_edit_echo.rs
+++ b/tests/issue_edit_echo.rs
@@ -746,6 +746,7 @@ async fn test_bc_3_4_012_edit_echo_excluded_for_bulk_multi_key() {
             "failedAccessibleIssues": {},
             "invalidOrInaccessibleIssueCount": 0
         })))
+        .expect(1)
         .mount(&server)
         .await;
 

--- a/tests/issue_edit_echo.rs
+++ b/tests/issue_edit_echo.rs
@@ -641,6 +641,8 @@ fn test_bc_3_4_012_edit_echo_does_not_fire_on_dry_run() {
         .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
         .args([
             "--no-input",
+            "--output",
+            "table",
             "issue",
             "edit",
             "TEST-1",

--- a/tests/issue_edit_echo.rs
+++ b/tests/issue_edit_echo.rs
@@ -716,18 +716,13 @@ async fn test_bc_3_4_012_edit_echo_excluded_for_bulk_multi_key() {
         .mount(&server)
         .await;
 
-    // Bulk submit: POST /rest/api/3/bulk/issues/fields returns 200 with taskId.
-    // Body shape matches BulkSubmitResponse (taskId deserialized from camelCase).
+    // Bulk submit: POST /rest/api/3/bulk/issues/fields returns 200. Only `taskId`
+    // is deserialized into BulkSubmitResponse (src/types/jira/bulk.rs); the body is
+    // trimmed to exactly that field.
     Mock::given(method("POST"))
         .and(path("/rest/api/3/bulk/issues/fields"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "taskId": "task-bulk-echo-001",
-            "status": "ENQUEUED",
-            "progressPercent": 0,
-            "totalIssueCount": 0,
-            "processedAccessibleIssues": [],
-            "failedAccessibleIssues": {},
-            "invalidOrInaccessibleIssueCount": 0
+            "taskId": "task-bulk-echo-001"
         })))
         .expect(1)
         .mount(&server)

--- a/tests/issue_edit_echo.rs
+++ b/tests/issue_edit_echo.rs
@@ -633,8 +633,11 @@ async fn test_bc_3_4_013_no_points_key_is_points_not_no_points() {
 
 #[test]
 fn test_bc_3_4_012_edit_echo_does_not_fire_on_dry_run() {
+    // --dry-run exits before any HTTP call, so no real server is needed.
+    // JR_BASE_URL must still be set to satisfy config loading (exit 78 otherwise).
     let output = Command::cargo_bin("jr")
         .unwrap()
+        .env("JR_BASE_URL", "http://127.0.0.1:19999")
         .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
         .args([
             "--no-input",


### PR DESCRIPTION
## Summary

Hardens four `#398` echo tests (TH-398-1..4) identified in issue #400. This is a **test-only** change — no `src/` modifications, no new `#[allow]`, and all 9+ sibling tests are untouched.

- **TH-398-1:** The dry-run echo-exclusion test was near-vacuous — it asserted absence of the echo marker on `stderr` while the dry-run preview actually prints to `stdout`. The test now asserts `exit 0` + the `DRY RUN` preview present on `stdout` + `Updated TEST-1` success-confirmation absent from **both** streams.
- **TH-398-2:** The bulk-exclusion test passed vacuously on a `404` — the mounted `PUT` mocks were never hit because multi-key edit routes through `POST /rest/api/3/bulk/issues/fields` + task polling. The test now drives the real bulk path to `exit 0` with `.expect(0)` PUT sentinels / `.expect(1)` bulk POST / `COMPLETE` poll, then asserts no field-echo line appears.
- **TH-398-3:** Comment typo fix: `VP-398-AC-014` → `AC-014`.
- **TH-398-4:** New create-side `--description-stdin` echo test covering the stdin path in `issue_create_echo.rs`.

**Part of #400.** This PR does NOT close #400 — Story B (PG-398-1 count-guard extension) and the engine-scoped items (PG-398-4/5) remain open.

## Scope

- Files changed: `tests/issue_edit_echo.rs`, `tests/issue_create_echo.rs`
- No `src/` changes
- No production behaviour modified
- No new `#[allow]` suppressions introduced
- All pre-existing sibling tests untouched

## Spec Traceability

```
BC-3.4.012 / BC-3.4.013 (issue #398 echo asymmetry)
  → TH-398-1: dry-run echo exclusion (issue_edit_echo.rs)
  → TH-398-2: bulk-edit echo exclusion (issue_edit_echo.rs)
  → TH-398-3: comment typo fix (issue_edit_echo.rs)
  → TH-398-4: create --description-stdin echo (issue_create_echo.rs)
```

## Test Evidence

- `cargo test` — full suite green (no failures, no regressions)
- `cargo clippy -- -D warnings` — zero warnings
- `cargo fmt --all -- --check` — clean
- Per-story adversarial convergence: 3 consecutive CLEAN passes on the final diff (4 fresh-context reviews total; one earlier round caught a stream-mismatch in TH-398-1 which was fixed before convergence)

## Demo Evidence

N/A — test-only change, no user-facing behaviour modified.

## Security Review

N/A — test-only change, no new network paths, no new auth logic, no user input handling.

## Risk Assessment

- **Blast radius:** Zero production risk. Test files only.
- **Regression risk:** Low — existing sibling tests are pinned and untouched; new tests add coverage without modifying existing assertions.
- **Performance impact:** None.

## Pre-Merge Checklist

- [x] PR description matches actual diff
- [x] Test-only change confirmed (no `src/` modifications)
- [x] `cargo test` green
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] Issue reference is "Part of #400" (not "Closes #400") — remaining items tracked
- [x] Branch targets `develop`

## AI Pipeline Metadata

- Pipeline mode: Supervised TDD + adversarial review
- Story: S-400-A
- Branch: `test/S-400-A-echo-test-hardening`
- HEAD: `f369d71`
