### PR TITLE
chore: bump version to 0.5.0-dev.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.5.0-dev.10"
+version = "0.5.0-dev.11"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.5.0-dev.10"
+version = "0.5.0-dev.11"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Dev release v0.5.0-dev.11

Version bump for the next dev pre-release. Tag `v0.5.0-dev.11` will be pushed to `develop` after this merges, triggering the Release workflow to build and publish pre-release binaries.

### Changes since v0.5.0-dev.10 (7 commits)
- test(echo): harden #398 echo tests — de-vacuize dry-run + bulk guards (S-400-A) (#431)
- fix(auth): extract resolve_cloud_id + rewrite disambiguation tests #4/#5/#6 in-process (#430)
- fix(field_resolve): two-stage i64-first parsing eliminates boundary saturation (#427)
- refactor(field_resolve): extract parsed_number_to_wire_value helper; replace tautological test 38 (#418)
- docs: re-anchor 2 stale CLAUDE.md citations to symbol-form + adopt convention (#417)
- [StepSecurity] Apply security best practices (#368)
- fix(test): gate keychain-touching tests behind JR_RUN_KEYRING_TESTS=1 (#416)

### Verification (local)
- `cargo check` — clean; Cargo.lock updated to 0.5.0-dev.11
- `cargo fmt --all` — clean
- `cargo clippy -- -D warnings` — zero warnings
- `cargo test` — full suite green (0 failed)

### Scope
- Files changed: `Cargo.toml`, `Cargo.lock` (version line only)
- No code changes