### PR TITLE
chore: release v0.5.0-dev.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to jr will be documented here.
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## [0.5.0-dev.12] - 2026-06-01
+
+### Added
+
 - Live-Jira E2E test suite (`tests/e2e_live.rs`) plus a non-blocking CI workflow
   (`.github/workflows/e2e.yml`) that exercises `jr` against a real Jira Cloud site.
   Gated behind `JR_RUN_E2E=1` (a complete no-op in normal `cargo test`); runs on push
@@ -14,11 +22,27 @@ All notable changes to jr will be documented here.
   optional) and a create→verify→edit→comment→worklog→transition write flow on a dedicated
   `E2E` project, with run-scoped labels and guaranteed close-only teardown. No `src/`
   changes; auth via the existing debug-only `JR_AUTH_HEADER`/`JR_BASE_URL` test seams.
-  (S-E2E-1)
+  Includes enhancements from follow-up rounds: deeper assertions, new coverage (label
+  add/remove, typed issue link/unlink, remote-link), error-path and robustness/ops
+  hardening, an orphan-cleanup sweeper, and first-live-run fixes (empty-status default,
+  sprint non-scrum skip). (S-E2E-1..5, #433, #434, #440, #441, #442)
+- Offline CLI-surface guard (`tests/e2e_cli_surface_guard.rs`) that validates every `jr`
+  subcommand path and flag referenced in `tests/e2e_live.rs` against `jr --help` at CI
+  time, without requiring `JR_RUN_E2E` or any network access. Catches assumed-surface
+  defects before live runs. (E2E-PG-1, #443)
+- Live E2E coverage for label add/remove, `issue link/unlink --type`, and
+  `issue remote-link`. (E2E-PG-4, #445)
 
 ### Fixed
 
-### Changed
+- **`jr issue edit --label add:X / remove:Y` now works against real Jira Cloud.**
+  Both single-key and multi-key label editing were previously broken end-to-end
+  (returning HTTP 400 / failing to parse responses) and had only mock-test coverage.
+  Single-key now uses `PUT /rest/api/3/issue/{key}` with the `update.labels` payload
+  (bare string values; synchronous 204); multi-key now uses the correct `labelsFields`
+  schema for the bulk endpoint, with `{"name":"<label>"}` objects per action element.
+  Bulk poll responses also now tolerate Jira returning `taskId` and issue IDs as JSON
+  integers rather than strings. (#447, #448, #449, #450; closes #446, BUG-LABEL-400)
 
 ## [0.5.0-dev.10] - 2026-05-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.5.0-dev.11"
+version = "0.5.0-dev.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.5.0-dev.11"
+version = "0.5.0-dev.12"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Dev release v0.5.0-dev.12

Bumps `0.5.0-dev.11` → `0.5.0-dev.12`. 11 commits since the last release.

### Headline (user-facing)

- **`jr issue edit --label add:X / remove:Y` now works against real Jira Cloud.** Single-key and multi-key label editing were broken end-to-end (HTTP 400 / response-parse failures) under mock-only coverage. Fixed across #447 (single-key → `PUT issue update.labels`), #448 (multi-key → `labelsFields` schema, closes #446), #449 (integer `taskId`), #450 (numeric issue IDs). Caught by the new live E2E suite.

### Also included

- Live-Jira E2E suite + nightly non-blocking workflow + enhancements + orphan sweeper (S-E2E-1..5: #433, #434, #440, #441, #442).
- Offline CLI-surface guard (#443) and live label/link/remote-link coverage (#445).

### Release mechanics

- Version bumped in `Cargo.toml` + `Cargo.lock`; CHANGELOG rolled `[Unreleased]` → `[0.5.0-dev.12] - 2026-06-01`.
- Pre-PR local checks green: `cargo fmt --check`, `cargo clippy -D warnings` (0 warnings), full test suite (0 failures).
- After merge: annotated tag `v0.5.0-dev.12` → triggers the pre-release binary build workflow.