### PR TITLE
ci(e2e): wire JR_E2E_ISSUE_TYPE_ALT into live E2E workflow (#331)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,6 +78,10 @@ jobs:
           # Optional: override status names for sites with non-default workflow names
           JR_E2E_STATUS_DONE: ${{ vars.JR_E2E_STATUS_DONE }}
           JR_E2E_STATUS_IN_PROGRESS: ${{ vars.JR_E2E_STATUS_IN_PROGRESS }}
+          # Optional: alternate issue type for the multi-key `issue edit --type` bulk
+          # round-trip test (#331). Test clean-skips if unset. Must name a real issue
+          # type in the E2E project's scheme, distinct from JR_E2E_ISSUE_TYPE (seed type).
+          JR_E2E_ISSUE_TYPE_ALT: ${{ vars.JR_E2E_ISSUE_TYPE_ALT }}
           # Individual secrets for auth header composition (composed in-script below)
           JR_E2E_EMAIL: ${{ secrets.JR_E2E_EMAIL }}
           JR_E2E_API_TOKEN: ${{ secrets.JR_E2E_API_TOKEN }}


### PR DESCRIPTION
## Summary

Wires the `JR_E2E_ISSUE_TYPE_ALT` environment variable into the live E2E workflow so the gated test `test_e2e_issue_edit_issuetype_multikey_bulk_roundtrip` (added for #331) actually runs against real Jira instead of clean-skipping.

The test seeds two issues with the default type (`JR_E2E_ISSUE_TYPE`, default `Task`) and bulk-edits both to `JR_E2E_ISSUE_TYPE_ALT`, validating the project-scoped `issueType` → `issueTypeId` resolution and the verified bulk wire schema merged in #453.

## Change
One line in `.github/workflows/e2e.yml` (main test step env block):
```yaml
JR_E2E_ISSUE_TYPE_ALT: ${{ vars.JR_E2E_ISSUE_TYPE_ALT }}
```

## Environment config (done)
- `JR_E2E_ISSUE_TYPE_ALT = Bug` set as a Variable in the `jira-e2e` environment.
- `Bug` confirmed present in project `ES`; seed type `Task` ≠ `Bug`, so the flip is observable.
- 'Make bulk changes' permission already granted (priority/label bulk E2E tests run live-green via the same endpoint).

## Notes
- CLAUDE.md already documents this var (added in #453). No doc change needed.
- Safe-by-construction: if the Variable were unset, the test clean-skips — no failure.
- Validation: the next nightly `e2e.yml` run (or a manual dispatch) should show the test running (not `SKIP: JR_E2E_ISSUE_TYPE_ALT not set`) and passing.

## Test plan
- [x] YAML one-line addition, env block placement verified
- [ ] Nightly/dispatch e2e.yml run shows the issueType bulk test executing + green