### PR TITLE
fix(bulk): correct createmeta issuetypes response schema — issueTypes + offset pagination (#331)

### DIFF
--- a/src/api/jira/issues.rs
+++ b/src/api/jira/issues.rs
@@ -680,7 +680,7 @@ impl JiraClient {
         let mut all: Vec<IssueTypeEntry> = Vec::new();
         let mut start_at: u32 = 0;
         loop {
-            let response: CreametaIssueTypesResponse = self
+            let response: CreatemetaIssueTypesResponse = self
                 .get(&format!(
                     "/rest/api/3/issue/createmeta/{}/issuetypes?startAt={}&maxResults={}",
                     urlencoding::encode(project_key),
@@ -726,7 +726,7 @@ pub(crate) struct IssueTypeEntry {
 /// developer.atlassian.com (issue #331; see
 /// `.factory/research/issue-331-createmeta-response-schema.md`).
 #[derive(Debug, serde::Deserialize)]
-struct CreametaIssueTypesResponse {
+struct CreatemetaIssueTypesResponse {
     #[serde(rename = "issueTypes", default)]
     pub issue_types: Vec<IssueTypeEntry>,
     /// Total number of issue types across all pages. Defaults to 0 if absent
@@ -782,7 +782,7 @@ mod tests {
     /// jira.js client and developer.atlassian.com. See issue #331 and
     /// `.factory/research/issue-331-createmeta-response-schema.md`.
     #[test]
-    fn test_creatameta_response_deserializes_issuetypes_field() {
+    fn test_createmeta_response_deserializes_issuetypes_field() {
         // This is the REAL shape returned by
         // GET /rest/api/3/issue/createmeta/{projectKey}/issuetypes.
         // It uses the top-level key `issueTypes` — NOT `values`.
@@ -796,8 +796,8 @@ mod tests {
                 {"id": "10002", "name": "Story"}
             ]
         }"#;
-        let resp: CreametaIssueTypesResponse = serde_json::from_str(json)
-            .expect("CreametaIssueTypesResponse must deserialize from real Jira API shape");
+        let resp: CreatemetaIssueTypesResponse = serde_json::from_str(json)
+            .expect("CreatemetaIssueTypesResponse must deserialize from real Jira API shape");
         assert_eq!(resp.issue_types.len(), 2, "Expected 2 issue types");
         assert_eq!(resp.issue_types[0].id, "10001");
         assert_eq!(resp.issue_types[0].name, "Bug");

--- a/src/api/jira/issues.rs
+++ b/src/api/jira/issues.rs
@@ -653,8 +653,15 @@ impl JiraClient {
 
     /// Resolve the available issue types for a project via the createmeta issuetypes endpoint.
     ///
-    /// Calls `GET /rest/api/3/issue/createmeta/{projectKey}/issuetypes` and paginates until
-    /// `isLast` is `true`, returning all `IssueTypeEntry` values (id + name).
+    /// Calls `GET /rest/api/3/issue/createmeta/{projectKey}/issuetypes` and paginates by
+    /// offset until `startAt + page_len >= total` (or an empty page), returning all
+    /// `IssueTypeEntry` values (id + name).
+    ///
+    /// `PageOfCreateMetaIssueTypes` uses OFFSET pagination (`startAt`/`maxResults`/`total`).
+    /// There is NO `isLast` field — that belongs to the generic `PageBean<T>` family, not
+    /// the specialized `PageOf...` types. Verified against the Atlassian OpenAPI-derived
+    /// `jira.js` client (issue #331; see
+    /// `.factory/research/issue-331-createmeta-response-schema.md`).
     ///
     /// # Usage
     /// - No cache — one or more HTTP calls per `--type` bulk invocation.
@@ -662,8 +669,6 @@ impl JiraClient {
     ///   is a correctness guard for large enterprise type schemes.
     /// - Project-scoped: the same type name can have different IDs in different projects.
     /// - Call site: `handle_edit_bulk_fields` in `src/cli/issue/create.rs` only.
-    ///
-    /// Source: Atlassian createmeta issuetypes endpoint docs (issue #331, I-1 fix).
     pub(crate) async fn get_issue_types_for_project(
         &self,
         project_key: &str,
@@ -683,10 +688,12 @@ impl JiraClient {
                     page_size,
                 ))
                 .await?;
-            let is_last = response.is_last;
-            let page_len = response.values.len() as u32;
-            all.extend(response.values);
-            if is_last || page_len == 0 {
+            let total = response.total;
+            let page_len = response.issue_types.len() as u32;
+            all.extend(response.issue_types);
+            // Offset termination: stop on empty page or once we've consumed `total`.
+            // (`PageOfCreateMetaIssueTypes` has no `isLast`; total drives the loop.)
+            if page_len == 0 || start_at + page_len >= total {
                 break;
             }
             start_at += page_len;
@@ -711,21 +718,21 @@ pub(crate) struct IssueTypeEntry {
 
 /// Response wrapper for `GET /rest/api/3/issue/createmeta/{projectKey}/issuetypes`.
 ///
-/// The endpoint is paginated and returns `{values, startAt, maxResults, total, isLast}`.
-/// `isLast: true` signals the final page; we stop paginating when it is true or when
-/// the page is empty (defensive guard for endpoints that omit `isLast` on the last page).
+/// `PageOfCreateMetaIssueTypes` uses OFFSET pagination: `{issueTypes, startAt,
+/// maxResults, total}`. There is NO `values` field and NO `isLast` field — those
+/// belong to the generic `PageBean<T>` family, NOT to the specialized `PageOf...`
+/// types. Termination is `startAt + issueTypes.len() >= total` (or an empty page).
+/// Verified against the Atlassian OpenAPI-derived `jira.js` client and
+/// developer.atlassian.com (issue #331; see
+/// `.factory/research/issue-331-createmeta-response-schema.md`).
 #[derive(Debug, serde::Deserialize)]
 struct CreametaIssueTypesResponse {
-    pub values: Vec<IssueTypeEntry>,
-    /// `true` when this is the last page. Defaults to `true` defensively if absent.
-    /// The JSON field is camelCase `isLast` — renamed explicitly since the struct does
-    /// not use `#[serde(rename_all = "camelCase")]`.
-    #[serde(rename = "isLast", default = "default_true")]
-    pub is_last: bool,
-}
-
-fn default_true() -> bool {
-    true
+    #[serde(rename = "issueTypes", default)]
+    pub issue_types: Vec<IssueTypeEntry>,
+    /// Total number of issue types across all pages. Defaults to 0 if absent
+    /// (defensive — drives the offset-termination check).
+    #[serde(default)]
+    pub total: u32,
 }
 
 #[cfg(test)]
@@ -762,5 +769,40 @@ mod tests {
         let json = r#"{"count": 0}"#;
         let resp: ApproximateCountResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.count, 0);
+    }
+
+    /// Regression-pin: `PageOfCreateMetaIssueTypes` uses `issueTypes` (NOT `values`),
+    /// offset pagination (`startAt`/`maxResults`/`total`), and NO `isLast` field.
+    ///
+    /// This test MUST FAIL before the fix (current struct requires `values`) and
+    /// MUST PASS after the fix (struct renames field to `issueTypes`).
+    ///
+    /// Bug source: live E2E `test_e2e_issue_edit_issuetype_multikey_bulk_roundtrip`
+    /// failed with "missing field `values`". Verified against Atlassian OpenAPI-derived
+    /// jira.js client and developer.atlassian.com. See issue #331 and
+    /// `.factory/research/issue-331-createmeta-response-schema.md`.
+    #[test]
+    fn test_creatameta_response_deserializes_issuetypes_field() {
+        // This is the REAL shape returned by
+        // GET /rest/api/3/issue/createmeta/{projectKey}/issuetypes.
+        // It uses the top-level key `issueTypes` — NOT `values`.
+        // There is no `isLast` field (offset pagination only).
+        let json = r#"{
+            "startAt": 0,
+            "maxResults": 200,
+            "total": 2,
+            "issueTypes": [
+                {"id": "10001", "name": "Bug"},
+                {"id": "10002", "name": "Story"}
+            ]
+        }"#;
+        let resp: CreametaIssueTypesResponse = serde_json::from_str(json)
+            .expect("CreametaIssueTypesResponse must deserialize from real Jira API shape");
+        assert_eq!(resp.issue_types.len(), 2, "Expected 2 issue types");
+        assert_eq!(resp.issue_types[0].id, "10001");
+        assert_eq!(resp.issue_types[0].name, "Bug");
+        assert_eq!(resp.issue_types[1].id, "10002");
+        assert_eq!(resp.issue_types[1].name, "Story");
+        assert_eq!(resp.total, 2, "Expected total=2");
     }
 }

--- a/tests/issue_bulk_pr2.rs
+++ b/tests/issue_bulk_pr2.rs
@@ -1604,10 +1604,15 @@ async fn test_multi_key_type_update_body_uses_issue_type_id() {
 
     // Mock GET /rest/api/3/issue/createmeta/FOO/issuetypes — name→id resolution.
     // The fix must call this endpoint to resolve "Bug" → id "10001".
+    // Real shape: PageOfCreateMetaIssueTypes uses `issueTypes` (NOT `values`),
+    // offset pagination (startAt/maxResults/total), no `isLast` field.
     Mock::given(method("GET"))
         .and(path("/rest/api/3/issue/createmeta/FOO/issuetypes"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "values": [{"id": "10001", "name": "Bug"}, {"id": "10002", "name": "Task"}]
+            "issueTypes": [{"id": "10001", "name": "Bug"}, {"id": "10002", "name": "Task"}],
+            "total": 2,
+            "startAt": 0,
+            "maxResults": 200
         })))
         .expect(1)
         .mount(&server)
@@ -1716,10 +1721,15 @@ async fn test_bulk_issuetype_body_uses_issuetype_id_not_name() {
     let server = MockServer::start().await;
 
     // Mock GET createmeta/FOO/issuetypes — returns Bug (id 10001) and Task (id 10002).
+    // Real shape: PageOfCreateMetaIssueTypes uses `issueTypes` (NOT `values`),
+    // offset pagination (startAt/maxResults/total), no `isLast` field.
     Mock::given(method("GET"))
         .and(path("/rest/api/3/issue/createmeta/FOO/issuetypes"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "values": [{"id": "10001", "name": "Bug"}, {"id": "10002", "name": "Task"}]
+            "issueTypes": [{"id": "10001", "name": "Bug"}, {"id": "10002", "name": "Task"}],
+            "total": 2,
+            "startAt": 0,
+            "maxResults": 200
         })))
         .expect(1)
         .mount(&server)
@@ -1825,11 +1835,15 @@ async fn test_bulk_issuetype_resolves_type_name_case_insensitively() {
     let server = MockServer::start().await;
 
     // createmeta returns title-case "Bug"; user supplies lowercase "bug".
+    // Real shape: PageOfCreateMetaIssueTypes uses `issueTypes` (NOT `values`),
+    // offset pagination (startAt/maxResults/total), no `isLast` field.
     Mock::given(method("GET"))
         .and(path("/rest/api/3/issue/createmeta/FOO/issuetypes"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "values": [{"id": "10001", "name": "Bug"}, {"id": "10002", "name": "Task"}],
-            "isLast": true
+            "issueTypes": [{"id": "10001", "name": "Bug"}, {"id": "10002", "name": "Task"}],
+            "total": 2,
+            "startAt": 0,
+            "maxResults": 200
         })))
         .expect(1)
         .mount(&server)
@@ -2093,10 +2107,15 @@ async fn test_bulk_issuetype_unknown_type_name_exits_non_zero() {
     let server = MockServer::start().await;
 
     // Mock createmeta returning only "Bug" — "Nonexistent" is not in the list.
+    // Real shape: PageOfCreateMetaIssueTypes uses `issueTypes` (NOT `values`),
+    // offset pagination (startAt/maxResults/total), no `isLast` field.
     Mock::given(method("GET"))
         .and(path("/rest/api/3/issue/createmeta/FOO/issuetypes"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "values": [{"id": "10001", "name": "Bug"}]
+            "issueTypes": [{"id": "10001", "name": "Bug"}],
+            "total": 1,
+            "startAt": 0,
+            "maxResults": 200
         })))
         .mount(&server)
         .await;
@@ -2152,8 +2171,14 @@ async fn test_bulk_issuetype_unknown_type_name_exits_non_zero() {
 /// `jr issue edit FOO-1 FOO-2 --type Story --no-input`
 /// where "Story" only appears on the second page of the createmeta response.
 ///
-/// Verifies that get_issue_types_for_project paginates until isLast=true,
-/// so types beyond the first page are discoverable (I-1 fix).
+/// Verifies that get_issue_types_for_project paginates using offset termination
+/// (`startAt + page_len >= total`), so types beyond the first page are discoverable.
+///
+/// Uses the REAL `PageOfCreateMetaIssueTypes` shape: `issueTypes` (NOT `values`),
+/// offset pagination (`startAt`/`maxResults`/`total`), NO `isLast` field.
+/// Page 1: startAt=0, total=2, issueTypes=[Bug].
+/// Page 2: startAt=1, total=2, issueTypes=[Story]. Loop terminates because
+/// `1 + 1 >= 2`.
 ///
 /// Also pins that the request includes query params (startAt/maxResults),
 /// verifiable because wiremock records received_requests with full URL.
@@ -2163,31 +2188,29 @@ async fn test_bulk_issuetype_resolution_paginates_to_second_page() {
 
     let server = MockServer::start().await;
 
-    // Page 1: isLast=false, contains only "Bug".
+    // Page 1: offset model, contains only "Bug". total=2 → not done (0 + 1 < 2).
     Mock::given(method("GET"))
         .and(path("/rest/api/3/issue/createmeta/FOO/issuetypes"))
         .and(query_param("startAt", "0"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "values": [{"id": "10001", "name": "Bug"}],
+            "issueTypes": [{"id": "10001", "name": "Bug"}],
             "startAt": 0,
             "maxResults": 200,
-            "total": 2,
-            "isLast": false
+            "total": 2
         })))
         .expect(1)
         .mount(&server)
         .await;
 
-    // Page 2: isLast=true, contains "Story".
+    // Page 2: offset model, contains "Story". Loop terminates: 1 + 1 >= 2.
     Mock::given(method("GET"))
         .and(path("/rest/api/3/issue/createmeta/FOO/issuetypes"))
         .and(query_param("startAt", "1"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "values": [{"id": "10002", "name": "Story"}],
+            "issueTypes": [{"id": "10002", "name": "Story"}],
             "startAt": 1,
             "maxResults": 200,
-            "total": 2,
-            "isLast": true
+            "total": 2
         })))
         .expect(1)
         .mount(&server)


### PR DESCRIPTION
## Summary

Fix a live-E2E-discovered schema mismatch in the createmeta issueTypes resolver. The issueType bulk fix merged in #453, but the first live E2E run (run 26777755130) failed immediately with `Error: missing field \`values\``.

**Root cause:** `get_issue_types_for_project` deserialized `GET /rest/api/3/issue/createmeta/{proj}/issuetypes` assuming the array was under `values` with an `isLast` cursor field. That is the `PageBean<T>` shape — the actual endpoint uses the specialized `PageOfCreateMetaIssueTypes` shape. The wiremock tests passed because they mocked our wrong shape, providing false confidence.

**Verified correct schema** (Perplexity + Atlassian OpenAPI-derived `jira.js` client; see `.factory/research/issue-331-createmeta-response-schema.md`):

| Field | Wrong (pre-fix) | Correct (post-fix) |
|---|---|---|
| Array key | `values` | `issueTypes` |
| Termination signal | `isLast: true` | `startAt + page_len >= total` |
| `isLast` field | present (default `true`) | absent — offset pagination only |

The `default_true` fallback for `isLast` was also a latent under-pagination bug (always terminated on first page, hiding types on subsequent pages).

## Changes

**`src/api/jira/issues.rs`**

- `CreametaIssueTypesResponse`: replaced `values: Vec<IssueTypeEntry>` + `isLast: bool` with `#[serde(rename = "issueTypes")] issue_types` + `total: u32`
- Deleted the `default_true()` helper function
- Pagination loop: termination changed from `is_last || page_len == 0` to `page_len == 0 || start_at + page_len >= total`
- Updated rustdoc to reference the verified schema and research artifact

**`tests/issue_bulk_pr2.rs`**

- Corrected all 5 createmeta mock bodies from the wrong `{values, isLast}` shape to the verified `{issueTypes, total, startAt, maxResults}` shape
- Rewrote the pagination test (`test_bulk_issuetype_resolution_paginates_to_second_page`) to the offset model: page 1 has `total=2`, terminates when `1 + 1 >= 2`
- Added comments on each mock body explaining the real API shape

**`src/api/jira/issues.rs` (tests module)**

- Added `test_creatameta_response_deserializes_issuetypes_field`: regression pin that deserializes the real Jira API shape `{issueTypes, total}` and asserts field values; designed to fail on the pre-fix struct and pass after

## Architecture Changes

```mermaid
graph TD
    A[handle_edit_bulk_fields] --> B[get_issue_types_for_project]
    B --> C[GET /issue/createmeta/{proj}/issuetypes]
    C -->|Response: PageOfCreateMetaIssueTypes| D[issueTypes array + total]
    D --> E[Offset loop: startAt + page_len >= total]
    E --> F[IssueTypeEntry{id, name}]
    F --> G[name→id resolution via partial_match]
```

## Story Dependencies

```mermaid
graph LR
    PR453["#453 issueType bulk fix (POST schema)"] --> PR["This PR (GET response schema)"]
    PR454["#454 e2e JR_E2E_ISSUE_TYPE_ALT"] --> PR
```

## Spec Traceability

```mermaid
flowchart LR
    BC["BC: bulk issue edit --type resolves to issueTypeId"] --> AC["AC: createmeta endpoint returns issueTypes array"]
    AC --> Test["test_creatameta_response_deserializes_issuetypes_field\ntest_bulk_issuetype_resolution_paginates_to_second_page"]
    Test --> Impl["CreametaIssueTypesResponse::issue_types + offset loop"]
```

## Test Evidence

| Check | Status |
|---|---|
| `cargo fmt --check` | PASS |
| `cargo clippy -- -D warnings` | PASS (0 warnings) |
| `cargo test` | PASS (760+ tests, 0 failures) |
| Deserialize regression pin (`test_creatameta_response_deserializes_issuetypes_field`) | PASS — confirms failure on pre-fix struct |
| Corrected mock bodies (5 tests) | PASS |
| Pagination offset model test | PASS |
| Mutation testing | N/A — `issues.rs` is outside the mutants glob per `cargo-mutants-policy.md` |

**Note:** The POST wire shape (#453) is unchanged and already correct. This PR only fixes the resolver's response parsing.

## Post-Merge Validation

Live E2E re-run via `e2e.yml` on `develop` after merge. The previously-failing test `test_e2e_issue_edit_issuetype_multikey_bulk_roundtrip` (run 26777755130 failure: `missing field \`values\``) should now pass.

- [ ] Live E2E re-run on `develop` passes `test_e2e_issue_edit_issuetype_multikey_bulk_roundtrip`

## Security Review

No security-sensitive changes. This PR modifies only a serde deserialization struct and pagination loop. No auth, token, or credential paths touched.

## Risk Assessment

- **Blast radius:** Narrow — affects only `--type` in bulk `issue edit`. All other `issue edit` paths are unchanged.
- **Regression risk:** Low — five existing tests corrected to the verified schema; one new deserialize regression pin added.
- **Performance impact:** None. The offset pagination correctly terminates on `startAt + page_len >= total`, matching prior behavior for single-page responses.

## Pre-Merge Checklist

- [x] Release gate: `cargo fmt`, `cargo clippy -D warnings`, `cargo test` all pass
- [x] Deserialize regression pin added (`test_creatameta_response_deserializes_issuetypes_field`)
- [x] All 5 createmeta mock bodies corrected to verified Atlassian schema
- [x] Pagination test rewritten to offset model
- [x] Rustdoc updated with verified schema reference and research artifact citation
- [x] No unsafe code introduced
- [x] No lint suppressions added
- [ ] Live E2E re-run on `develop` post-merge (validation step — cannot run before merge)

## Closes

Fixes the live E2E failure from run 26777755130 (follow-up to #453, part of #331 epic).
