### PR TITLE
fix(adf): conform listItem content model to ADF spec (#470)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ All notable changes to jr will be documented here.
   (recursively), headings are downconverted to paragraphs (inline marks preserved),
   tables are flattened to one paragraph per row, and rules are dropped. Jira rendered the
   old out-of-spec shapes leniently, but they were fragile to renderer changes and
-  cross-product round-trips. (docs/specs/adf-listitem-content-model.md)
+  cross-product round-trips. (BC-7.2.006, docs/specs/adf-listitem-content-model.md)
 
 - **JSM E2E self-close teardown (S-JSM-E2E-2):** the comment-visibility and
   create-request live tests now self-close their EJ tickets by dynamically discovering a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,16 @@ All notable changes to jr will be documented here.
 
 ### Fixed
 
+- **`markdown_to_adf` listItem content-model conformance (#470):** markdown like
+  `- > quote`, `- # heading`, `- ---`, and indented tables inside list items no longer
+  emit `blockquote`/`heading`/`table`/`rule` nodes as direct `listItem` children, which
+  violates the ADF `listItem` content model (only `paragraph`, `bulletList`,
+  `orderedList`, `codeBlock`, `mediaSingle` are permitted). Blockquotes are unwrapped
+  (recursively), headings are downconverted to paragraphs (inline marks preserved),
+  tables are flattened to one paragraph per row, and rules are dropped. Jira rendered the
+  old out-of-spec shapes leniently, but they were fragile to renderer changes and
+  cross-product round-trips. (docs/specs/adf-listitem-content-model.md)
+
 - **JSM E2E self-close teardown (S-JSM-E2E-2):** the comment-visibility and
   create-request live tests now self-close their EJ tickets by dynamically discovering a
   closing transition (`statusCategory.key == "done"`, preferring Resolved/Closed/Done)

--- a/docs/specs/adf-listitem-content-model.md
+++ b/docs/specs/adf-listitem-content-model.md
@@ -1,0 +1,107 @@
+# `markdown_to_adf` — `listItem` content-model conformance
+
+**Issue:** [#470](https://github.com/Zious11/jira-cli/issues/470)
+**Module:** `src/adf.rs`
+
+## Problem
+
+`markdown_to_adf` emits ADF `listItem` nodes whose `content` may contain
+`blockquote`, `heading`, `table`, and `rule` child nodes. Per the official
+Atlassian Document Format spec, the `listItem` content model permits **only**:
+
+- `paragraph` (no marks)
+- `bulletList`
+- `orderedList`
+- `codeBlock` (no marks)
+- `mediaSingle`
+
+`blockquote`, `heading`, `table`, and `rule` are valid **top-level** block
+nodes but are **not** valid children of `listItem`. The current code's existing
+comment acknowledges this ("Jira's renderer handles the latter shape
+leniently") — but renderer leniency is not contractual. A renderer tightening,
+an editor round-trip, or reuse in another Atlassian surface (e.g. Confluence)
+can drop, reflow, or reject the content.
+
+pulldown-cmark legitimately emits all four node kinds inside `Item` for inputs
+such as `- > quoted`, `- # heading`, `- item\n\n  ---`, and a loose list item
+containing an indented GFM table. All four shapes were confirmed reachable.
+
+## Atlassian constraint (validated)
+
+Confirmed via the Atlassian `listItem` node reference page
+(`developer.atlassian.com/cloud/jira/platform/apis/document/nodes/listItem/`,
+verified 2026-06-08, Perplexity-cited): `listItem.content` is restricted to the
+five node types above. Note the asymmetry that caused the original bug —
+`tableCell`/`tableHeader` *do* permit rich block content (`blockquote`,
+`heading`, `table`, etc.); `listItem` does not. The code generalized the cell
+content model to list items.
+
+## Design
+
+When assembling a `listItem`, run a normalization pass over its children that
+transforms every disallowed block into the permitted set. The pass runs
+**before** `wrap_inlines_as_blocks`, because simply removing the disallowed
+types from that function's allowlist would cause loose inline runs adjacent to
+them to be mis-grouped and the disallowed blocks themselves to be wrapped into a
+`paragraph` (producing `paragraph > blockquote`, the *other* invalid shape).
+
+### Normalization rules
+
+| Disallowed child | Normalization | Rationale |
+|---|---|---|
+| `blockquote` | **Unwrap** — splice the blockquote's own child blocks directly into the listItem, **recursively** normalized | Lossless; preserves paragraph structure and inline marks. `blockquote`'s children are themselves block-level (paragraphs etc.), all listItem-legal after recursion. |
+| `heading` | **Convert to `paragraph`**, preserving the heading's inline `content` (text nodes + marks) verbatim; drop the `level` attr | In-spec; text and inline emphasis preserved. No added `strong` mark (predictable, lossless). |
+| `table` | **Flatten** — render the table via `adf_to_text` and emit **one `paragraph` per non-empty output line** (`\| a \| b \|` row text) | No data loss; text nodes stay newline-free (each row → its own paragraph). Extreme edge case (requires loose list + indented table). |
+| `rule` | **Drop** | A `rule` is an empty leaf with no content and no meaning inside a list item. |
+
+Permitted children (`paragraph`, `bulletList`, `orderedList`, `codeBlock`,
+`mediaSingle`) and any loose inline nodes pass through untouched; the existing
+`wrap_inlines_as_blocks` then groups remaining inline runs into paragraphs using
+the **five-type allowlist**.
+
+An empty resulting listItem still yields a single empty `paragraph`, preserving
+ADF's "at least one block" requirement (existing `wrap_inlines_as_blocks`
+behavior).
+
+### Recursion
+
+Normalization is recursive only through `blockquote` unwrapping (e.g.
+`- > # heading` → unwrap blockquote → heading → paragraph). Nested
+`bulletList`/`orderedList` children are already produced by recursive
+`listItem` assembly and need no re-processing.
+
+## Behavior changes
+
+- `- > quoted text` now yields `listItem > paragraph` (was `listItem >
+  blockquote > paragraph`). The existing test
+  `test_markdown_blockquote_inside_list_item_is_nested_not_paragraph_wrapped`
+  asserted the old out-of-spec shape and is updated to assert the in-spec shape
+  (requirements changed to spec compliance, per CLAUDE.md test-modification
+  policy).
+- `- # heading` now yields `listItem > paragraph` (was `listItem > heading`).
+- `- item\n\n  ---` now yields `listItem > paragraph` only (rule dropped).
+- A table inside a list item now yields `listItem > paragraph(+)` (flattened
+  rows) instead of `listItem > table`.
+
+No change to top-level (non-listItem) `blockquote`, `heading`, `table`, `rule`
+handling. No change to `tableCell`/`tableHeader` content (which legitimately
+allows rich blocks).
+
+## Out of scope
+
+- Task lists, footnotes, bare-URL autolinks, and other missing markdown
+  constructs (tracked separately: #471, #472, #473, #474).
+- E2E coverage of the read/render path (#475).
+
+## Test plan
+
+Unit tests in `src/adf.rs` (`cargo test --lib adf`):
+
+- [ ] `- > quoted text` → `listItem > paragraph[text "quoted text"]`, no `blockquote` node anywhere
+- [ ] `- # Heading text` → `listItem > paragraph[text "Heading text"]`, no `heading` node, no `level` attr
+- [ ] `- ### deep **bold** head` → `listItem > paragraph` preserving the `strong` mark on "bold"
+- [ ] `- > # quoted heading` (recursive) → `listItem > paragraph`, no `blockquote`/`heading`
+- [ ] `- item\n\n  ---` → `listItem` with the paragraph kept and **no** `rule` node
+- [ ] table inside a list item → `listItem` with one `paragraph` per row line, no `table` node, cell text preserved
+- [ ] regression: a plain `- a\n- b` bullet list and nested `- a\n  - b` still produce correct `paragraph`/`bulletList` shapes
+- [ ] regression: top-level `> quote`, `# heading`, `---`, and a standalone table are unchanged

--- a/docs/specs/adf-listitem-content-model.md
+++ b/docs/specs/adf-listitem-content-model.md
@@ -2,6 +2,7 @@
 
 **Issue:** [#470](https://github.com/Zious11/jira-cli/issues/470)
 **Module:** `src/adf.rs`
+**Behavioral contract:** BC-7.2.006 (`.factory/specs/prd/bc-7-output-render.md`)
 
 ## Problem
 
@@ -57,7 +58,17 @@ them to be mis-grouped and the disallowed blocks themselves to be wrapped into a
 Permitted children (`paragraph`, `bulletList`, `orderedList`, `codeBlock`,
 `mediaSingle`) and any loose inline nodes pass through untouched; the existing
 `wrap_inlines_as_blocks` then groups remaining inline runs into paragraphs using
-the **five-type allowlist**.
+the **five-type allowlist**. Nested `bulletList`/`orderedList` items are
+normalized independently at their own `listItem` boundary, so the invariant holds
+recursively.
+
+`flatten_table_to_paragraphs` splices each cell's **inline** children into the
+row paragraph. For markdown-reachable tables every cell block is a `paragraph`;
+defensively, a non-`paragraph` cell block (which the ADF `tableCell` schema
+permits but pulldown-cmark never emits in GFM cells) is rendered to a
+newline-free plain-text node rather than spliced as a block, keeping the output
+valid. An all-empty source row collapses to bare `| | |` separators — valid ADF,
+emitted as-is.
 
 An empty resulting listItem still yields a single empty `paragraph`, preserving
 ADF's "at least one block" requirement (existing `wrap_inlines_as_blocks`
@@ -97,11 +108,17 @@ allows rich blocks).
 
 Unit tests in `src/adf.rs` (`cargo test --lib adf`):
 
-- [ ] `- > quoted text` → `listItem > paragraph[text "quoted text"]`, no `blockquote` node anywhere
-- [ ] `- # Heading text` → `listItem > paragraph[text "Heading text"]`, no `heading` node, no `level` attr
-- [ ] `- ### deep **bold** head` → `listItem > paragraph` preserving the `strong` mark on "bold"
-- [ ] `- > # quoted heading` (recursive) → `listItem > paragraph`, no `blockquote`/`heading`
-- [ ] `- item\n\n  ---` → `listItem` with the paragraph kept and **no** `rule` node
-- [ ] table inside a list item → `listItem` with one `paragraph` per row, no `table` node, cell text preserved, and a marked cell keeps its ADF mark (e.g. `strong`)
-- [ ] regression: a plain `- a\n- b` bullet list and nested `- a\n  - b` still produce correct `paragraph`/`bulletList` shapes
-- [ ] regression: top-level `> quote`, `# heading`, `---`, and a standalone table are unchanged
+- [x] `- > quoted text` → `listItem > paragraph[text "quoted text"]`, no `blockquote` node anywhere
+- [x] `- # Heading text` → `listItem > paragraph[text "Heading text"]`, no `heading` node, no `level` attr
+- [x] `- ### deep **bold** head` → `listItem > paragraph` preserving the `strong` mark on "bold"
+- [x] `- > # quoted heading` (recursive) → `listItem > paragraph`, no `blockquote`/`heading`
+- [x] `- item\n\n  ---` → `listItem` with the paragraph kept and **no** `rule` node
+- [x] rule-only item (`-   \n\n    ---`) → `listItem` with a single empty `paragraph`, no `rule` node
+- [x] table inside a list item → `listItem` with one `paragraph` per row, no `table` node, cell text preserved, and a marked cell keeps its ADF mark (e.g. `strong`)
+- [x] `codeBlock` and nested `orderedList` inside a list item pass through unmodified (permitted children)
+- [x] regression: a plain `- a\n- b` bullet list and nested `- a\n  - b` still produce correct `paragraph`/`bulletList` shapes
+- [x] regression: top-level `> quote`, `# heading`, `---`, and a standalone table are unchanged
+
+Negative assertions use a structural `contains_node_type()` walk over the ADF
+tree (not serialized-string `contains`), so a text node whose literal text
+contains a type name cannot false-positive.

--- a/docs/specs/adf-listitem-content-model.md
+++ b/docs/specs/adf-listitem-content-model.md
@@ -51,7 +51,7 @@ them to be mis-grouped and the disallowed blocks themselves to be wrapped into a
 |---|---|---|
 | `blockquote` | **Unwrap** — splice the blockquote's own child blocks directly into the listItem, **recursively** normalized | Lossless; preserves paragraph structure and inline marks. `blockquote`'s children are themselves block-level (paragraphs etc.), all listItem-legal after recursion. |
 | `heading` | **Convert to `paragraph`**, preserving the heading's inline `content` (text nodes + marks) verbatim; drop the `level` attr | In-spec; text and inline emphasis preserved. No added `strong` mark (predictable, lossless). |
-| `table` | **Flatten** — render the table via `adf_to_text` and emit **one `paragraph` per non-empty output line** (`\| a \| b \|` row text) | No data loss; text nodes stay newline-free (each row → its own paragraph). Extreme edge case (requires loose list + indented table). |
+| `table` | **Flatten** — emit **one `paragraph` per `tableRow`**, joining cells in `\| a \| b \|` form by splicing each cell's inline nodes in directly (`flatten_table_to_paragraphs`) | Cell text and inline **marks are preserved** (real ADF `strong`/`em`/`link` nodes — NOT routed through `adf_to_text`, which would emit literal `**`/`[]()` markdown that Jira shows verbatim). The table **grid structure is lost** — no ADF node nests a table inside a listItem. Extreme edge case (requires loose list + indented table). |
 | `rule` | **Drop** | A `rule` is an empty leaf with no content and no meaning inside a list item. |
 
 Permitted children (`paragraph`, `bulletList`, `orderedList`, `codeBlock`,
@@ -102,6 +102,6 @@ Unit tests in `src/adf.rs` (`cargo test --lib adf`):
 - [ ] `- ### deep **bold** head` → `listItem > paragraph` preserving the `strong` mark on "bold"
 - [ ] `- > # quoted heading` (recursive) → `listItem > paragraph`, no `blockquote`/`heading`
 - [ ] `- item\n\n  ---` → `listItem` with the paragraph kept and **no** `rule` node
-- [ ] table inside a list item → `listItem` with one `paragraph` per row line, no `table` node, cell text preserved
+- [ ] table inside a list item → `listItem` with one `paragraph` per row, no `table` node, cell text preserved, and a marked cell keeps its ADF mark (e.g. `strong`)
 - [ ] regression: a plain `- a\n- b` bullet list and nested `- a\n  - b` still produce correct `paragraph`/`bulletList` shapes
 - [ ] regression: top-level `> quote`, `# heading`, `---`, and a standalone table are unchanged

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -400,16 +400,32 @@ fn flatten_table_to_paragraphs(table: &Value) -> Vec<Value> {
         for cell in cells {
             let sep = if content.is_empty() { "| " } else { " | " };
             content.push(json!({ "type": "text", "text": sep }));
-            // A cell's content is block-level (paragraphs); splice each block's
-            // inline children in, preserving their marks.
+            // For markdown tables a cell's content is always `paragraph` blocks,
+            // so we splice their inline children in, preserving marks. The ADF
+            // `tableCell` schema also permits richer blocks (bulletList, codeBlock,
+            // …); a non-paragraph block must NOT be spliced as inline — that would
+            // emit invalid `paragraph > <block>`. Render any such block to a
+            // newline-free plain-text node instead. This branch is unreachable from
+            // `markdown_to_adf` today (pulldown-cmark emits only inline events in
+            // GFM cells) but keeps the function total and ADF-valid.
             if let Some(blocks) = cell.get("content").and_then(|c| c.as_array()) {
                 for block in blocks {
-                    if let Some(inlines) = block.get("content").and_then(|c| c.as_array()) {
-                        content.extend(inlines.iter().cloned());
+                    if block.get("type").and_then(Value::as_str) == Some("paragraph") {
+                        if let Some(inlines) = block.get("content").and_then(|c| c.as_array()) {
+                            content.extend(inlines.iter().cloned());
+                        }
+                    } else {
+                        let doc = json!({ "type": "doc", "version": 1, "content": [block] });
+                        let text = adf_to_text(&doc).trim_end().replace('\n', " ");
+                        if !text.is_empty() {
+                            content.push(json!({ "type": "text", "text": text }));
+                        }
                     }
                 }
             }
         }
+        // An all-empty row collapses to bare separators (`| | |`) — valid ADF, and
+        // a faithful (if sparse) rendering of an empty source row; emitted as-is.
         if content.is_empty() {
             continue; // a row with no cells contributes nothing
         }
@@ -1176,6 +1192,69 @@ mod tests {
             bold_a["marks"][0]["type"], "strong",
             "bold cell text must retain its strong mark: {bold_a}"
         );
+    }
+
+    #[test]
+    fn test_markdown_rule_only_list_item_yields_empty_paragraph() {
+        // A list item whose only content is a rule: the rule is dropped, leaving
+        // the item empty, so `wrap_inlines_as_blocks` supplies a single empty
+        // paragraph to satisfy ADF's "at least one block" rule (BC-7.2.006 edge
+        // case). No `rule` node survives.
+        let adf = markdown_to_adf("-   \n\n    ---");
+        let item = &adf["content"][0]["content"][0];
+        assert_eq!(item["type"], "listItem");
+        let children = item["content"].as_array().unwrap();
+        assert_eq!(children.len(), 1, "expected exactly one child: {item}");
+        assert_eq!(children[0]["type"], "paragraph");
+        assert_eq!(
+            children[0]["content"].as_array().map(Vec::len),
+            Some(0),
+            "the fallback paragraph must be empty: {item}"
+        );
+        assert!(
+            !contains_node_type(&adf, "rule"),
+            "rule must not survive inside listItem: {adf}"
+        );
+    }
+
+    #[test]
+    fn test_markdown_codeblock_inside_list_item_passes_through() {
+        // `codeBlock` is a permitted listItem child and must pass through the
+        // normalization untouched (BC-7.2.006).
+        let adf = markdown_to_adf("- ```\n  let x = 1;\n  ```");
+        let item = &adf["content"][0]["content"][0];
+        assert_eq!(item["type"], "listItem");
+        let code = &item["content"][0];
+        assert_eq!(code["type"], "codeBlock");
+        assert!(
+            code["content"][0]["text"]
+                .as_str()
+                .is_some_and(|t| t.contains("let x = 1;")),
+            "codeBlock content must be preserved verbatim: {item}"
+        );
+    }
+
+    #[test]
+    fn test_markdown_ordered_list_inside_list_item_passes_through() {
+        // A nested `orderedList` is a permitted listItem child and passes through;
+        // its own items are normalized at their own listItem boundary.
+        let adf = markdown_to_adf("- outer\n  1. a\n  2. b");
+        let item = &adf["content"][0]["content"][0];
+        assert_eq!(item["type"], "listItem");
+        let nested = item["content"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["type"] == "orderedList")
+            .expect("expected a nested orderedList child");
+        let inner_items = nested["content"].as_array().unwrap();
+        assert_eq!(
+            inner_items.len(),
+            2,
+            "nested ordered list must keep both items"
+        );
+        assert_eq!(inner_items[0]["type"], "listItem");
+        assert_eq!(inner_items[0]["content"][0]["type"], "paragraph");
     }
 
     #[test]

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -342,8 +342,9 @@ fn wrap_inlines_as_blocks(children: Vec<Value>, block_types: &[&str]) -> Vec<Val
 ///   normalized (handles e.g. `- > # heading`).
 /// - `heading` → converted to `paragraph`, preserving inline content and dropping
 ///   the `level` attr.
-/// - `table` → flattened to one `paragraph` per rendered row line via
-///   `adf_to_text` (keeps each text node newline-free).
+/// - `table` → flattened to one `paragraph` per row, joining cells in `| a | b |`
+///   form while preserving each cell's inline content and ADF marks
+///   (`flatten_table_to_paragraphs`). The grid structure is not preserved.
 /// - `rule` → dropped (empty leaf, meaningless inside a list item).
 ///
 /// Permitted blocks and loose inline nodes (`text`, `hardBreak`) pass through
@@ -365,20 +366,57 @@ fn normalize_list_item_content(children: Vec<Value>) -> Vec<Value> {
                 let content = child.get("content").cloned().unwrap_or_else(|| json!([]));
                 out.push(json!({ "type": "paragraph", "content": content }));
             }
-            Some("table") => {
-                let doc = json!({ "type": "doc", "version": 1, "content": [child] });
-                for line in adf_to_text(&doc).lines().filter(|l| !l.trim().is_empty()) {
-                    out.push(json!({
-                        "type": "paragraph",
-                        "content": [{ "type": "text", "text": line }],
-                    }));
-                }
-            }
+            Some("table") => out.extend(flatten_table_to_paragraphs(&child)),
             Some("rule") => { /* dropped — no content, invalid inside listItem */ }
             _ => out.push(child),
         }
     }
     out
+}
+
+/// Flatten an ADF `table` node into one `paragraph` per row, for embedding inside
+/// a `listItem` (which the ADF content model forbids from containing a table).
+///
+/// Cells are joined in `| a | b |` form. Each cell's inline content is spliced in
+/// as real ADF nodes, so marks (`strong`, `em`, `link`, …) are **preserved** — we
+/// do NOT route through `adf_to_text`, which would render marks as literal
+/// markdown syntax (`**bold**`, `[label](url)`) that Jira would then display
+/// verbatim. The table's grid structure is necessarily lost (there is no ADF node
+/// nesting a table inside a listItem); only the per-row pipe layout and cell
+/// content survive.
+fn flatten_table_to_paragraphs(table: &Value) -> Vec<Value> {
+    let mut paragraphs: Vec<Value> = Vec::new();
+    let Some(rows) = table.get("content").and_then(|c| c.as_array()) else {
+        return paragraphs;
+    };
+    for row in rows {
+        if row.get("type").and_then(Value::as_str) != Some("tableRow") {
+            continue;
+        }
+        let Some(cells) = row.get("content").and_then(|c| c.as_array()) else {
+            continue;
+        };
+        let mut content: Vec<Value> = Vec::new();
+        for cell in cells {
+            let sep = if content.is_empty() { "| " } else { " | " };
+            content.push(json!({ "type": "text", "text": sep }));
+            // A cell's content is block-level (paragraphs); splice each block's
+            // inline children in, preserving their marks.
+            if let Some(blocks) = cell.get("content").and_then(|c| c.as_array()) {
+                for block in blocks {
+                    if let Some(inlines) = block.get("content").and_then(|c| c.as_array()) {
+                        content.extend(inlines.iter().cloned());
+                    }
+                }
+            }
+        }
+        if content.is_empty() {
+            continue; // a row with no cells contributes nothing
+        }
+        content.push(json!({ "type": "text", "text": " |" }));
+        paragraphs.push(json!({ "type": "paragraph", "content": content }));
+    }
+    paragraphs
 }
 
 fn heading_level_to_u8(level: HeadingLevel) -> u8 {
@@ -1072,9 +1110,10 @@ mod tests {
     #[test]
     fn test_markdown_table_inside_list_item_flattens_to_paragraphs() {
         // ADF `listItem` does not permit `table`. The table is flattened to one
-        // paragraph per rendered row line; no `table` node survives, and cell
-        // text is preserved.
-        let adf = markdown_to_adf("- intro\n\n  | a | b |\n  | - | - |\n  | 1 | 2 |");
+        // paragraph per row (`| a | b |` form); no `table`/`tableRow` node
+        // survives. The header cell is bold to verify inline marks are preserved
+        // as real ADF marks (NOT serialized to literal `**` markdown).
+        let adf = markdown_to_adf("- intro\n\n  | **a** | b |\n  | - | - |\n  | 1 | 2 |");
         let item = &adf["content"][0]["content"][0];
         assert_eq!(item["type"], "listItem");
         let children = item["content"].as_array().unwrap();
@@ -1097,33 +1136,45 @@ mod tests {
             !contains_node_type(&adf, "table") && !contains_node_type(&adf, "tableRow"),
             "no table node may appear inside listItem: {adf}"
         );
-        // Each flattened paragraph is a single newline-free text node holding one
-        // rendered row line; the header and data rows are preserved verbatim. (The
-        // `| --- | --- |` separator row is also emitted — documented as acceptable
-        // for this extreme edge case.)
-        let row_texts: Vec<&str> = children
+
+        // Every text node across the flattened paragraphs is newline-free, and no
+        // literal markdown mark syntax leaked (the bold cell must NOT render as
+        // `**a**` — that would mean we routed through adf_to_text).
+        let all_texts: Vec<String> = children
             .iter()
-            .filter_map(|p| {
-                let content = p["content"].as_array()?;
-                assert_eq!(
-                    content.len(),
-                    1,
-                    "row paragraph must hold exactly one text node: {p}"
-                );
-                content[0]["text"].as_str()
-            })
+            .filter_map(|p| p["content"].as_array())
+            .flatten()
+            .filter_map(|n| n["text"].as_str().map(str::to_string))
             .collect();
         assert!(
-            row_texts.iter().all(|t| !t.contains('\n')),
-            "row text nodes must be newline-free: {row_texts:?}"
+            all_texts.iter().all(|t| !t.contains('\n')),
+            "text nodes must be newline-free: {all_texts:?}"
+        );
+        let joined = all_texts.concat();
+        assert!(
+            !joined.contains("**"),
+            "bold cell must be a real strong mark, not literal `**`: {joined:?}"
+        );
+        // The pipe layout and both rows' cell text survive.
+        assert!(
+            joined.contains("| a "),
+            "header cell 'a' missing: {joined:?}"
         );
         assert!(
-            row_texts.contains(&"| a | b |"),
-            "header row paragraph missing: {row_texts:?}"
+            joined.contains("| 1 ") && joined.contains("| 2 "),
+            "data cells missing: {joined:?}"
         );
-        assert!(
-            row_texts.contains(&"| 1 | 2 |"),
-            "data row paragraph missing: {row_texts:?}"
+
+        // The bold header cell keeps its ADF `strong` mark.
+        let bold_a = children
+            .iter()
+            .filter_map(|p| p["content"].as_array())
+            .flatten()
+            .find(|n| n["text"] == "a")
+            .expect("expected an 'a' text node from the header cell");
+        assert_eq!(
+            bold_a["marks"][0]["type"], "strong",
+            "bold cell text must retain its strong mark: {bold_a}"
         );
     }
 

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -416,7 +416,7 @@ fn flatten_table_to_paragraphs(table: &Value) -> Vec<Value> {
                         }
                     } else {
                         let doc = json!({ "type": "doc", "version": 1, "content": [block] });
-                        let text = adf_to_text(&doc).trim_end().replace('\n', " ");
+                        let text = adf_to_text(&doc).trim_end().replace(['\n', '\r'], " ");
                         if !text.is_empty() {
                             content.push(json!({ "type": "text", "text": text }));
                         }
@@ -1191,6 +1191,45 @@ mod tests {
         assert_eq!(
             bold_a["marks"][0]["type"], "strong",
             "bold cell text must retain its strong mark: {bold_a}"
+        );
+    }
+
+    #[test]
+    fn test_flatten_table_non_paragraph_cell_block_renders_as_plain_text() {
+        // Defensive branch: the ADF tableCell schema permits non-paragraph blocks
+        // (here a codeBlock with an embedded newline) even though markdown_to_adf
+        // never produces them. flatten_table_to_paragraphs must NOT splice such a
+        // block as inline (that would be invalid `paragraph > codeBlock`); it
+        // renders to a single newline-free text node. Tests the private fn directly
+        // since the branch is unreachable through the parser.
+        let table = json!({
+            "type": "table",
+            "content": [{
+                "type": "tableRow",
+                "content": [{
+                    "type": "tableCell",
+                    "content": [{
+                        "type": "codeBlock",
+                        "content": [{ "type": "text", "text": "line1\nline2" }]
+                    }]
+                }]
+            }]
+        });
+        let paras = flatten_table_to_paragraphs(&table);
+        assert_eq!(paras.len(), 1, "one row → one paragraph: {paras:?}");
+        let content = paras[0]["content"].as_array().unwrap();
+        // No block node smuggled into the paragraph; every child is a text node.
+        for node in content {
+            assert_eq!(node["type"], "text", "paragraph child must be text: {node}");
+            assert!(
+                !node["text"].as_str().unwrap().contains(['\n', '\r']),
+                "flattened text must be newline-free: {node}"
+            );
+        }
+        let joined: String = content.iter().filter_map(|n| n["text"].as_str()).collect();
+        assert!(
+            joined.contains("line1 line2"),
+            "code text must survive: {joined:?}"
         );
     }
 

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -162,25 +162,24 @@ impl AdfBuilder {
                 Some(node)
             }
             NodeKind::ListItem => {
-                // The documented ADF listItem schema lists paragraph, bulletList,
-                // orderedList, codeBlock, and mediaSingle as accepted content.
-                // pulldown-cmark, however, legitimately emits blockquote, heading,
-                // table, and rule inside Item for markdown like `- > quoted` or
-                // `- # heading`. We recognize those as blocks (don't wrap them in a
-                // paragraph — that would produce `paragraph > blockquote`, invalid
-                // at a lower level than `listItem > blockquote`). Jira's renderer
-                // handles the latter shape leniently; the former it does not.
+                // ADF `listItem.content` permits ONLY paragraph, bulletList,
+                // orderedList, codeBlock, and mediaSingle. pulldown-cmark
+                // legitimately emits blockquote, heading, table, and rule inside
+                // Item for markdown like `- > quoted` or `- # heading`; those are
+                // NOT valid listItem children (issue #470,
+                // docs/specs/adf-listitem-content-model.md). `normalize_list_item_content`
+                // transforms each disallowed block into the permitted set BEFORE
+                // wrapping loose inline runs — shrinking the allowlist alone would
+                // instead wrap them into a paragraph, producing the equally-invalid
+                // `paragraph > blockquote` shape.
+                let normalized = normalize_list_item_content(children);
                 let wrapped = wrap_inlines_as_blocks(
-                    children,
+                    normalized,
                     &[
                         "paragraph",
                         "bulletList",
                         "orderedList",
-                        "blockquote",
                         "codeBlock",
-                        "heading",
-                        "table",
-                        "rule",
                         "mediaSingle",
                     ],
                 );
@@ -329,6 +328,57 @@ fn wrap_inlines_as_blocks(children: Vec<Value>, block_types: &[&str]) -> Vec<Val
         result.push(json!({ "type": "paragraph", "content": inline_run }));
     }
     result
+}
+
+/// Normalize the children of a `listItem` to the ADF-permitted content model.
+///
+/// ADF `listItem.content` permits only `paragraph`, `bulletList`, `orderedList`,
+/// `codeBlock`, and `mediaSingle`. pulldown-cmark legitimately emits
+/// `blockquote`, `heading`, `table`, and `rule` inside list items; this pass
+/// transforms each into the permitted set (issue #470,
+/// `docs/specs/adf-listitem-content-model.md`):
+///
+/// - `blockquote` → unwrapped: its child blocks are spliced in and recursively
+///   normalized (handles e.g. `- > # heading`).
+/// - `heading` → converted to `paragraph`, preserving inline content and dropping
+///   the `level` attr.
+/// - `table` → flattened to one `paragraph` per rendered row line via
+///   `adf_to_text` (keeps each text node newline-free).
+/// - `rule` → dropped (empty leaf, meaningless inside a list item).
+///
+/// Permitted blocks and loose inline nodes (`text`, `hardBreak`) pass through
+/// untouched; the caller's `wrap_inlines_as_blocks` then groups the inline runs
+/// into paragraphs.
+fn normalize_list_item_content(children: Vec<Value>) -> Vec<Value> {
+    let mut out: Vec<Value> = Vec::new();
+    for child in children {
+        match child["type"].as_str() {
+            Some("blockquote") => {
+                let inner = child
+                    .get("content")
+                    .and_then(|c| c.as_array())
+                    .cloned()
+                    .unwrap_or_default();
+                out.extend(normalize_list_item_content(inner));
+            }
+            Some("heading") => {
+                let content = child.get("content").cloned().unwrap_or_else(|| json!([]));
+                out.push(json!({ "type": "paragraph", "content": content }));
+            }
+            Some("table") => {
+                let doc = json!({ "type": "doc", "version": 1, "content": [child] });
+                for line in adf_to_text(&doc).lines().filter(|l| !l.trim().is_empty()) {
+                    out.push(json!({
+                        "type": "paragraph",
+                        "content": [{ "type": "text", "text": line }],
+                    }));
+                }
+            }
+            Some("rule") => { /* dropped — no content, invalid inside listItem */ }
+            _ => out.push(child),
+        }
+    }
+    out
 }
 
 fn heading_level_to_u8(level: HeadingLevel) -> u8 {
@@ -919,19 +969,149 @@ mod tests {
     }
 
     #[test]
-    fn test_markdown_blockquote_inside_list_item_is_nested_not_paragraph_wrapped() {
-        // `- > quoted` → pulldown-cmark emits blockquote inside Item. The block
-        // must be a direct child of the listItem; wrapping in a paragraph would
-        // produce `paragraph > blockquote`, which violates paragraph's inline-only
-        // content rule at a lower level than `listItem > blockquote` does.
+    fn test_markdown_blockquote_inside_list_item_is_unwrapped_to_paragraph() {
+        // `- > quoted` → pulldown-cmark emits blockquote inside Item. The ADF
+        // `listItem` content model does NOT permit `blockquote` (only paragraph,
+        // bulletList, orderedList, codeBlock, mediaSingle — see
+        // docs/specs/adf-listitem-content-model.md, issue #470). We unwrap the
+        // blockquote and splice its child paragraph(s) directly into the listItem.
         let adf = markdown_to_adf("- > quoted text");
         let item = &adf["content"][0]["content"][0];
         assert_eq!(item["type"], "listItem");
         let first_child = &item["content"][0];
-        assert_eq!(first_child["type"], "blockquote");
-        let inner_para = &first_child["content"][0];
-        assert_eq!(inner_para["type"], "paragraph");
-        assert_eq!(inner_para["content"][0]["text"], "quoted text");
+        assert_eq!(first_child["type"], "paragraph");
+        assert_eq!(first_child["content"][0]["text"], "quoted text");
+        // No blockquote node anywhere in the document.
+        assert!(
+            !adf.to_string().contains("\"blockquote\""),
+            "blockquote must not appear inside listItem: {adf}"
+        );
+    }
+
+    #[test]
+    fn test_markdown_heading_inside_list_item_becomes_paragraph() {
+        // ADF `listItem` does not permit `heading`. Convert to a paragraph,
+        // preserving inline content (issue #470).
+        let adf = markdown_to_adf("- # Heading text");
+        let item = &adf["content"][0]["content"][0];
+        assert_eq!(item["type"], "listItem");
+        let first_child = &item["content"][0];
+        assert_eq!(first_child["type"], "paragraph");
+        assert_eq!(first_child["content"][0]["text"], "Heading text");
+        assert!(
+            first_child.get("attrs").is_none(),
+            "downconverted paragraph must not carry the heading's level attr: {first_child}"
+        );
+        assert!(
+            !adf.to_string().contains("\"heading\""),
+            "heading must not appear inside listItem: {adf}"
+        );
+    }
+
+    #[test]
+    fn test_markdown_heading_inside_list_item_preserves_inline_marks() {
+        // `- ### deep **bold** head` → paragraph preserving the strong mark on
+        // "bold" (inline content kept verbatim, only the heading wrapper dropped).
+        let adf = markdown_to_adf("- ### deep **bold** head");
+        let para = &adf["content"][0]["content"][0]["content"][0];
+        assert_eq!(para["type"], "paragraph");
+        let content = para["content"].as_array().unwrap();
+        let bold = content
+            .iter()
+            .find(|n| n["text"] == "bold")
+            .expect("expected a 'bold' text node");
+        assert_eq!(bold["marks"][0]["type"], "strong");
+    }
+
+    #[test]
+    fn test_markdown_blockquote_with_heading_inside_list_item_normalizes_recursively() {
+        // `- > # quoted heading` → unwrap blockquote, then the inner heading is
+        // itself downconverted to a paragraph (recursive normalization).
+        let adf = markdown_to_adf("- > # quoted heading");
+        let item = &adf["content"][0]["content"][0];
+        assert_eq!(item["type"], "listItem");
+        let first_child = &item["content"][0];
+        assert_eq!(first_child["type"], "paragraph");
+        assert_eq!(first_child["content"][0]["text"], "quoted heading");
+        let s = adf.to_string();
+        assert!(
+            !s.contains("\"blockquote\"") && !s.contains("\"heading\""),
+            "neither blockquote nor heading may appear inside listItem: {adf}"
+        );
+    }
+
+    #[test]
+    fn test_markdown_rule_inside_list_item_is_dropped() {
+        // ADF `listItem` does not permit `rule`. A horizontal rule inside a list
+        // item carries no content and is dropped; the paragraph is kept.
+        let adf = markdown_to_adf("- item\n\n  ---");
+        let item = &adf["content"][0]["content"][0];
+        assert_eq!(item["type"], "listItem");
+        assert_eq!(item["content"][0]["type"], "paragraph");
+        assert_eq!(item["content"][0]["content"][0]["text"], "item");
+        assert!(
+            !adf.to_string().contains("\"rule\""),
+            "rule must not appear inside listItem: {adf}"
+        );
+    }
+
+    #[test]
+    fn test_markdown_table_inside_list_item_flattens_to_paragraphs() {
+        // ADF `listItem` does not permit `table`. The table is flattened to one
+        // paragraph per rendered row line; no `table` node survives, and cell
+        // text is preserved.
+        let adf = markdown_to_adf("- intro\n\n  | a | b |\n  | - | - |\n  | 1 | 2 |");
+        let item = &adf["content"][0]["content"][0];
+        assert_eq!(item["type"], "listItem");
+        let children = item["content"].as_array().unwrap();
+        // Every child must be a permitted listItem block type.
+        for child in children {
+            let t = child["type"].as_str().unwrap();
+            assert!(
+                [
+                    "paragraph",
+                    "bulletList",
+                    "orderedList",
+                    "codeBlock",
+                    "mediaSingle"
+                ]
+                .contains(&t),
+                "unexpected listItem child type {t:?}: {item}"
+            );
+        }
+        let s = adf.to_string();
+        assert!(
+            !s.contains("\"table\"") && !s.contains("\"tableRow\""),
+            "no table node may appear inside listItem: {adf}"
+        );
+        // Each flattened paragraph is a single newline-free text node holding one
+        // rendered row line; the header and data rows are preserved verbatim. (The
+        // `| --- | --- |` separator row is also emitted — documented as acceptable
+        // for this extreme edge case.)
+        let row_texts: Vec<&str> = children
+            .iter()
+            .filter_map(|p| {
+                let content = p["content"].as_array()?;
+                assert_eq!(
+                    content.len(),
+                    1,
+                    "row paragraph must hold exactly one text node: {p}"
+                );
+                content[0]["text"].as_str()
+            })
+            .collect();
+        assert!(
+            row_texts.iter().all(|t| !t.contains('\n')),
+            "row text nodes must be newline-free: {row_texts:?}"
+        );
+        assert!(
+            row_texts.contains(&"| a | b |"),
+            "header row paragraph missing: {row_texts:?}"
+        );
+        assert!(
+            row_texts.contains(&"| 1 | 2 |"),
+            "data row paragraph missing: {row_texts:?}"
+        );
     }
 
     #[test]

--- a/src/adf.rs
+++ b/src/adf.rs
@@ -744,6 +744,21 @@ fn apply_marks(text: &str, marks: Option<&Vec<Value>>) -> String {
 mod tests {
     use super::*;
 
+    /// Recursively check whether any node in an ADF value (or its `content`
+    /// subtrees) has the given `type`. Structural — unlike a serialized-string
+    /// substring search, it cannot false-positive on a text node whose literal
+    /// text happens to contain the type name.
+    fn contains_node_type(value: &Value, node_type: &str) -> bool {
+        if value.get("type").and_then(Value::as_str) == Some(node_type) {
+            return true;
+        }
+        match value {
+            Value::Array(items) => items.iter().any(|v| contains_node_type(v, node_type)),
+            Value::Object(map) => map.values().any(|v| contains_node_type(v, node_type)),
+            _ => false,
+        }
+    }
+
     #[test]
     fn test_text_to_adf() {
         let adf = text_to_adf("Hello world");
@@ -983,7 +998,7 @@ mod tests {
         assert_eq!(first_child["content"][0]["text"], "quoted text");
         // No blockquote node anywhere in the document.
         assert!(
-            !adf.to_string().contains("\"blockquote\""),
+            !contains_node_type(&adf, "blockquote"),
             "blockquote must not appear inside listItem: {adf}"
         );
     }
@@ -1003,7 +1018,7 @@ mod tests {
             "downconverted paragraph must not carry the heading's level attr: {first_child}"
         );
         assert!(
-            !adf.to_string().contains("\"heading\""),
+            !contains_node_type(&adf, "heading"),
             "heading must not appear inside listItem: {adf}"
         );
     }
@@ -1033,9 +1048,8 @@ mod tests {
         let first_child = &item["content"][0];
         assert_eq!(first_child["type"], "paragraph");
         assert_eq!(first_child["content"][0]["text"], "quoted heading");
-        let s = adf.to_string();
         assert!(
-            !s.contains("\"blockquote\"") && !s.contains("\"heading\""),
+            !contains_node_type(&adf, "blockquote") && !contains_node_type(&adf, "heading"),
             "neither blockquote nor heading may appear inside listItem: {adf}"
         );
     }
@@ -1050,7 +1064,7 @@ mod tests {
         assert_eq!(item["content"][0]["type"], "paragraph");
         assert_eq!(item["content"][0]["content"][0]["text"], "item");
         assert!(
-            !adf.to_string().contains("\"rule\""),
+            !contains_node_type(&adf, "rule"),
             "rule must not appear inside listItem: {adf}"
         );
     }
@@ -1079,9 +1093,8 @@ mod tests {
                 "unexpected listItem child type {t:?}: {item}"
             );
         }
-        let s = adf.to_string();
         assert!(
-            !s.contains("\"table\"") && !s.contains("\"tableRow\""),
+            !contains_node_type(&adf, "table") && !contains_node_type(&adf, "tableRow"),
             "no table node may appear inside listItem: {adf}"
         );
         // Each flattened paragraph is a single newline-free text node holding one


### PR DESCRIPTION
## Summary

Fixes #470. `markdown_to_adf` (`src/adf.rs`) emitted `blockquote`, `heading`, `table`, and `rule` nodes as **direct children of `listItem`**, which the ADF `listItem` content model does not permit — it allows only `paragraph`, `bulletList`, `orderedList`, `codeBlock`, `mediaSingle`. Jira rendered these out-of-spec shapes leniently, but leniency isn't contractual: a renderer tightening, an editor round-trip, or reuse in another Atlassian surface (e.g. Confluence) could drop, reflow, or reject the content.

Validated against the Atlassian `listItem` node reference (`developer.atlassian.com/.../nodes/listItem/`) via Perplexity. Root cause: the code generalized the `tableCell`/`tableHeader` content model (which *does* allow rich blocks) to `listItem` (which does not).

## Change

New `normalize_list_item_content`, run **before** `wrap_inlines_as_blocks` (shrinking the allowlist alone would instead wrap these into a paragraph → the equally-invalid `paragraph > blockquote`):

| Disallowed child | Normalization |
|---|---|
| `blockquote` | Unwrap — splice child blocks in, **recursively** normalized (handles `- > # heading`) |
| `heading` | → `paragraph`, preserving inline content/marks, dropping `level` |
| `table` | Flatten to one `paragraph` per rendered row line (via `adf_to_text`; text nodes stay newline-free) |
| `rule` | Dropped (empty leaf, meaningless in a list item) |

Permitted children and loose inline runs pass through untouched. No change to top-level `blockquote`/`heading`/`table`/`rule` or to `tableCell`/`tableHeader` content.

## Behavior changes

- `- > quote` → `listItem > paragraph` (was `listItem > blockquote > paragraph`)
- `- # heading` → `listItem > paragraph` (was `listItem > heading`)
- `- item\n\n  ---` → rule dropped
- indented table in a list item → flattened paragraphs

The existing `test_markdown_blockquote_inside_list_item_*` test asserted the old out-of-spec shape and is updated to assert the in-spec shape (requirements changed to spec compliance, per CLAUDE.md test-modification policy).

## Spec

`docs/specs/adf-listitem-content-model.md`

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --all-features --tests -- -D warnings` (clean, no `#[allow]`)
- [x] `cargo test --all-features` (full suite green; 75 adf unit tests, +5 new)
- [x] `cargo check --all-features` (MSRV 1.85.0)
- [x] `cargo mutants --in-diff` (no-op — `src/adf.rs` out of mutation scope per `.cargo/mutants.toml`)
- [x] Multi-agent code review: clean, no critical/important findings

## Out of scope (tracked separately)

Task lists (#471), footnotes (#472), bare-URL autolinks (#473), minor constructs (#474), ADF→text E2E coverage (#475).