### PR TITLE
test(e2e): settle search-index visibility before bulk move

### DIFF
--- a/tests/e2e_live.rs
+++ b/tests/e2e_live.rs
@@ -4321,6 +4321,39 @@ fn test_e2e_issue_move_multikey_bulk() {
     let key1 = seed_issue(&h, &label, &format!("[e2e {label}] bulk-move A"));
     let key2 = seed_issue(&h, &label, &format!("[e2e {label}] bulk-move B"));
 
+    // Block until BOTH seeds are SEARCH-INDEX-visible before firing the bulk move.
+    //
+    // seed_issue only guarantees GET-consistency (poll_view). The async
+    // bulk-transition task, however, resolves issues through the search index,
+    // which lags independently: a GET-visible-but-not-yet-indexed issue is
+    // excluded from the task's processed *and* failed sets and reported
+    // `inaccessible`. That is the flake this guards against (live run
+    // 27159962721 reported ES-1049 as inaccessible). poll_jql with
+    // FailOnShort(2) absorbs the lag with the same idiom as
+    // test_e2e_pagination_dedup: 0 results = pure index lag (clean-skip),
+    // 1 result after full budget = fail loud, 2 = proceed. An exact `key in`
+    // probe queries the same index subsystem the bulk task uses, so a positive
+    // result is the strongest available "the move will not report inaccessible"
+    // gate.
+    let settle_jql = format!("key in ({key1}, {key2})");
+    let settled = poll_jql(
+        &settle_jql,
+        |v| v.as_array().is_some_and(|a| a.len() == 2),
+        PollJqlMode::FailOnShort(2),
+        &h,
+    );
+    if settled.is_none() {
+        // 0 results after full budget — pure index lag; clean-skip rather than
+        // fire a move that is guaranteed to report `inaccessible`.
+        eprintln!(
+            "test_e2e_issue_move_multikey_bulk: seeds never reached search-index \
+             visibility (0 results after full poll budget) — clean-skip"
+        );
+        best_effort_close(&h, &key1);
+        best_effort_close(&h, &key2);
+        return;
+    }
+
     let output = h
         .cmd()
         .args([


### PR DESCRIPTION
## Problem

The post-merge nightly E2E run [27159962721](https://github.com/Zious11/jira-cli/actions/runs/27159962721) failed `test_e2e_issue_move_multikey_bulk` (82 passed, 1 failed):

```
multi-key move must report success for ES-1049;
got: {"key":"ES-1049","status":"inaccessible"}
```

`inaccessible` means Jira's async bulk-transition task excluded ES-1049 from **both** its `processedAccessibleIssues` and `failedAccessibleIssues` sets. `jr` reported it correctly — the test's settle condition was too weak.

## Root cause

`seed_issue` only polls for **GET-consistency** (`poll_view` → `issue view`). The async bulk-transition task, however, resolves issues through the **search index**, which lags independently. A freshly-seeded issue can be GET-visible yet not-yet-indexed at the moment the bulk task fires → reported `inaccessible`. This is a flaky test, not a regression from #479.

## Fix

Gate the bulk move on a `poll_jql("key in (...)", FailOnShort(2))` settle that probes the **same index subsystem** the bulk task uses, before firing the move. Mirrors the established `test_e2e_pagination_dedup` idiom:

- **0 results** after full poll budget → pure index lag → **clean-skip** (no false-red)
- **1 result** after full budget → **fail loud** (genuine anomaly)
- **2 results** → proceed with the move

Test-only change — no `src/` modification. `e2e.yml` is non-blocking/nightly, so develop was never broken.

## Verification

- `cargo test --test e2e_live --no-run` — compiles
- `cargo clippy --test e2e_live -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test --test e2e_cli_surface_guard` — 10 passed (no new CLI surface)
- `cargo test --test e2e_live poll_outcome` — 6 passed (poll decision logic unaffected)

The live E2E path itself runs only in `e2e.yml` (gated by `JR_RUN_E2E`); it will exercise on the next nightly.

Traces to: E2E-HV-1, BC-3.2.009, NFR-T-E2E-1.