### PR TITLE
test(e2e): live-Jira bare-URL autolink link-mark round-trip (#473)

### DIFF
--- a/docs/specs/e2e-live-jira-testing.md
+++ b/docs/specs/e2e-live-jira-testing.md
@@ -116,6 +116,22 @@ GET succeeding immediately.
   - `test_e2e_jsm_non_jsm_guard` — `queue list --project <ES>` exits 64; stderr contains `"Jira Service Management project"` (does NOT require `JR_E2E_JSM_PROJECT`)
 - **Sprint mutation** (`sprint add/remove`): only if `JR_E2E_BOARD_ID` is set.
 
+### ADF markdown round-trip (`--markdown` → live ADF)
+These tests prove the `--markdown` path drives `markdown_to_adf` end-to-end and
+that Jira's REST API accepts/preserves the produced ADF on read-back (no extra
+env vars; run in the default `JR_E2E_PROJECT`):
+- `test_e2e_issue_markdown_description_roundtrip` — a heading in the markdown
+  description yields a `heading` ADF node in `fields.description` (E2E-HV-2).
+- `test_e2e_markdown_bare_url_produces_link_mark` (#473) — a **bare** `http(s)://`
+  URL in a `--markdown` description round-trips as an ADF `link` mark: the test
+  creates the issue, then `poll_view`s the STORED description and asserts a `text`
+  node carries a `link` mark whose `href` is the URL. This is the live proof of
+  the autolink feature's premise — Jira does **not** auto-linkify plain-text URLs
+  in a REST-submitted ADF body, so the explicit mark is required for clickability.
+  If a live run shows Jira normalizing the `link` mark into a different node
+  (e.g. an `inlineCard` smart-link), that is itself actionable signal and the
+  assertion should be widened to accept it. Broader ADF E2E expansion: #475.
+
 ## 5. CI workflow — `.github/workflows/e2e.yml`
 
 ```yaml

--- a/tests/e2e_live.rs
+++ b/tests/e2e_live.rs
@@ -4651,6 +4651,124 @@ fn test_e2e_issue_markdown_description_roundtrip() {
     best_effort_close(&h, &key);
 }
 
+/// Recursively search an ADF value for a `text` node whose **visible text is
+/// `url`** AND which carries a `link` mark whose `href` **contains `url`**.
+/// Returns true on the first match. Used to assert a bare URL survived as a real
+/// link rather than plain text (#473).
+///
+/// Two deliberate choices (F5 review): (1) requiring the matched `text` to equal
+/// the URL proves the URL *run itself* is linked, not some neighbouring text a
+/// wrong-slice regression might have marked; (2) both `text` and `href` are
+/// compared **tolerant of trailing slash(es)** Jira may add on storage
+/// (`trim_end_matches('/')` strips any number), but otherwise EXACTLY — a
+/// `contains`-style match would wrongly accept a redirect
+/// href that merely embeds the URL in a query string (e.g.
+/// `https://evil.example?u=https://example.com/...`).
+///
+/// Recursion is unbounded by depth, which is safe here: the only input is the
+/// small, self-created issue description read back via `poll_view`, never an
+/// adversarial or pathologically deep document.
+fn adf_has_linked_url(node: &Value, url: &str) -> bool {
+    let norm = |s: &str| s.trim_end_matches('/').to_string();
+    let target = norm(url);
+    if node.get("type").and_then(Value::as_str) == Some("text")
+        && node.get("text").and_then(Value::as_str).map(&norm) == Some(target.clone())
+    {
+        if let Some(marks) = node.get("marks").and_then(Value::as_array) {
+            let hit = marks.iter().any(|m| {
+                m.get("type").and_then(Value::as_str) == Some("link")
+                    && m.get("attrs")
+                        .and_then(|a| a.get("href"))
+                        .and_then(Value::as_str)
+                        .map(&norm)
+                        == Some(target.clone())
+            });
+            if hit {
+                return true;
+            }
+        }
+    }
+    match node {
+        Value::Array(items) => items.iter().any(|v| adf_has_linked_url(v, url)),
+        Value::Object(map) => map.values().any(|v| adf_has_linked_url(v, url)),
+        _ => false,
+    }
+}
+
+/// E2E (#473): a bare `http(s)://` URL in a `--markdown` description produces an
+/// ADF `link` mark that Jira's REST API ACCEPTS and PRESERVES on read-back.
+///
+/// This is the live proof of the feature's load-bearing premise: Jira does not
+/// auto-linkify a plain-text URL in a REST-submitted ADF body (smart-link unfurl
+/// is a browser-editor, compose-time feature), so the explicit `link` mark our
+/// autolink pass adds is *required* for the URL to be clickable. We create via
+/// `--markdown`, then GET-by-key (`poll_view`) and assert the STORED description
+/// carries a `link` mark whose `href` is the URL — proving the mark survived both
+/// the create POST and Jira's server-side storage/normalization (not merely that
+/// our client built it locally before sending).
+///
+/// Traces to: #473 (bare-URL autolink), broader ADF E2E coverage (#475).
+#[test]
+#[ignore = "set JR_RUN_E2E=1 and use --include-ignored to run against a live Jira site"]
+fn test_e2e_markdown_bare_url_produces_link_mark() {
+    if !e2e_enabled() {
+        return;
+    }
+    let label = run_label();
+    let itype = issue_type();
+    let proj = project();
+    let h = e2e_harness();
+
+    let url = "https://example.com/e2e-autolink";
+    let md = format!("see {url} now");
+    let create = h
+        .cmd()
+        .args([
+            "issue",
+            "create",
+            "--project",
+            &proj,
+            "--type",
+            &itype,
+            "--summary",
+            &format!("[e2e {label}] bare-url autolink"),
+            "--markdown",
+            "--description",
+            &md,
+            "--label",
+            &label,
+            "--output",
+            "json",
+        ])
+        .output()
+        .expect("failed to spawn jr for create --markdown bare-url");
+    assert!(
+        create.status.success(),
+        "create --markdown (bare url) failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&create.stdout),
+        String::from_utf8_lossy(&create.stderr)
+    );
+    let json: Value =
+        serde_json::from_slice(&create.stdout).expect("create output must be valid JSON");
+    let key = json
+        .get("key")
+        .and_then(Value::as_str)
+        .expect("create JSON must contain a 'key'")
+        .to_string();
+
+    // Read back what Jira STORED — proves the REST API accepted and preserved the
+    // link mark, not just that our client built it locally before the POST.
+    let view = poll_view(&key, &h);
+    let description = &view["fields"]["description"];
+    assert!(
+        adf_has_linked_url(description, url),
+        "bare URL must round-trip as an ADF link mark on the URL text (href \
+         containing {url}); stored description: {description}"
+    );
+
+    best_effort_close(&h, &key);
+}
+
 /// E2E: `issue comment` across all three input channels — `--file`, `--stdin`,
 /// `--markdown` (positional message).
 ///


### PR DESCRIPTION
## Summary

Adds the live-Jira E2E coverage for the bare-URL autolink feature (#473, merged in #491). Follows up the question *"did we add E2E tests for this?"* — we hadn't.

The feature's entire premise is that **Jira's REST API does not auto-linkify a plain-text URL** in a submitted ADF body, so the explicit `link` mark our autolink pass adds is required for clickability. That was Atlassian-doc-confirmed via research but never proven against live Jira. This test proves it end-to-end.

## What it does

`test_e2e_markdown_bare_url_produces_link_mark` (gated on `JR_RUN_E2E`, `#[ignore]` — inert in normal CI, runs nightly in `e2e.yml`):
1. `issue create --markdown --description "see https://example.com/e2e-autolink now"`
2. `poll_view` reads the issue back (proves we assert what Jira **stored**, not what our client built pre-POST)
3. asserts the stored `fields.description` ADF carries a `link` mark **on the URL text**

Helper `adf_has_linked_url` requires the matched text node's visible text to equal the URL (proves the URL run itself is linked, not neighbouring text) and compares text/href tolerant of trailing slashes but otherwise exactly.

## Delivered via the full VSDD delta cycle

| Phase | Outcome |
|-------|---------|
| F1 delta analysis | scope: 1 gated test + helper + spec; no new CLI surface |
| F2/F3 spec | documented in `docs/specs/e2e-live-jira-testing.md §4` |
| F4 TDD | test + helper; compiles, gated, offline guards pass |
| F5 adversarial | **Claude pass CLEAN** → **Gemini cross-model slice caught `href.contains` over-permissiveness** (a redirect href embedding the URL would pass) → fixed to exact±slash → **Claude confirm pass CLEAN** |
| F7 convergence | fmt + clippy clean; gate-guard + surface-subset guards green |

## Verification (offline — the test itself needs a live sandbox)

- `cargo test --test e2e_live --test e2e_cli_surface_guard` — **40 passed / 0 failed** (test compiles, 54 live tests correctly ignored)
- `test_every_ignored_test_has_gate_guard` ✅ (confirms the `e2e_enabled()` gate)
- `test_parser_paths_are_subset_of_surface_table` ✅ (no new surface — reuses `create --markdown` / `issue view`)
- `cargo clippy --tests -D warnings` clean, `cargo fmt --check` clean

No new env vars. Runs in the default `JR_E2E_PROJECT`. Broader ADF E2E expansion remains tracked in #475.