### PR TITLE
chore(release): v0.5.0-dev.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to jr will be documented here.
 
 ### Breaking Changes
 
+### Added
+
+### Fixed
+
+### Changed
+
+## [0.5.0-dev.14] - 2026-06-11
+
+### Breaking Changes
+
 - **`jr issue move <key> <done-status>` now requires an explicit resolution on
   done-category transitions** (BC-3.2.013, ADR-0015, S-JSM-RESOLUTION-REQUIRED).
   When the target transition is done-category AND offers a resolution field (or has
@@ -32,7 +42,28 @@ All notable changes to jr will be documented here.
   transition offers a resolution field — no additional round-trip (replaces the plain
   `GET .../transitions` call in `handle_move`). `jr issue transitions` read command
   unchanged. (BC-3.2.013, ADR-0015, S-JSM-RESOLUTION-REQUIRED)
-
+- **GFM task lists → ADF `taskList`/`taskItem` (#471, BC-7.2.010):** `markdown_to_adf`
+  now maps `- [ ] task` / `- [x] done` (tight and loose lists, nested sublists) to
+  native ADF `taskList` and `taskItem` nodes with `state: "TODO"/"DONE"`. Jira renders
+  these as interactive checkboxes. Each item receives a document-unique `localId` via a
+  DFS post-processing pass. Loose multi-paragraph items are merged using `hardBreak`
+  separators. Nested `taskList` children and hoisted sibling lists are handled correctly.
+  (`docs/specs/adf-task-list.md`)
+- **GFM alerts → ADF `panel` (#483, BC-7.2.009):** `> [!NOTE]`, `> [!TIP]`,
+  `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]` blockquotes are mapped to ADF
+  `panel` nodes (panelType: `info`/`success`/`note`/`warning`/`error`). Nested panels
+  and blockquotes are unwrapped recursively; nested tables are flattened to paragraphs.
+  ADF `listItem` gains a `panel` unwrap arm. Round-trips back to GFM markers via
+  `adf_to_text`. (`docs/specs/adf-panel-content-model.md`)
+- **Markdown superscript/subscript → ADF `subsup` (#474):** `^x^` maps to ADF
+  `subsup sup`; `~x~` maps to `subsup sub`. Double-tilde `~~x~~` continues to map
+  to `strike`. Heading attributes (`## Title {#id}`) are parsed and silently dropped
+  (ADF headings have no id attribute) rather than leaking `{#id}` into the title text.
+- **Bare `http(s)://` URLs → ADF `link` mark (#473):** a post-build pass applies a
+  `link` mark to bare URL runs in text nodes, so URLs are clickable in Jira without
+  the author needing explicit Markdown link syntax. Scope is explicit-scheme only
+  (`http(s)://`); `www.`-prefixed and bare emails are out of scope. Existing inline
+  links and code spans are never double-linked. (`src/adf.rs`)
 - **JSM live-E2E coverage expansion (S-JSM-E2E-1):** replaces 2 shallow JSM smoke tests
   with 7 shape-asserting / round-trip live tests — queue list/view (by-name + `--id`),
   requesttype list/fields (numeric-bypass pin), internal vs external comment visibility
@@ -42,49 +73,84 @@ All notable changes to jr will be documented here.
   a pre-existing gap (`--priority` missing from the `issue edit` SURFACE row). Zero `src/`
   change. Gated on `JR_E2E_JSM_PROJECT`; set to `EJ` in the `jira-e2e` GitHub Environment
   to activate. (S-JSM-E2E-1)
-- **Fork-safe E2E CI gate:** `e2e.yml` and `e2e-sweeper.yml` are now gated by a repository
-  variable `JR_E2E_ENABLED`. Both workflow jobs skip cleanly on forks and any repo where the
-  variable is not set (empty string `!= 'true'`). A preflight step in `e2e.yml` asserts all
-  required secrets/variables are present before consuming runner minutes building Rust.
-  **Maintainers:** after merging, create a repository variable `JR_E2E_ENABLED=true` at
-  Settings → Secrets and variables → Actions → Variables (repository scope, NOT
-  environment scope) to re-enable nightly E2E on the canonical repo. Without this step both
-  workflows skip on every trigger. See `docs/specs/e2e-fork-safe-ci-enablement.md §5.1`.
-- **README E2E status badge:** `[![E2E](...e2e.yml/badge.svg?branch=develop)]` added as the
-  second badge in the badge row. Shows green for passing or skipped runs (skipped = no
-  `JR_E2E_ENABLED`); shows red when tests fail. Badge is pinned to the canonical repo.
+- **Fork-safe E2E CI gate (#459):** `e2e.yml` and `e2e-sweeper.yml` are now gated by a
+  repository variable `JR_E2E_ENABLED`. Both workflow jobs skip cleanly on forks and any
+  repo where the variable is not set (empty string `!= 'true'`). A preflight step in
+  `e2e.yml` asserts all required secrets/variables are present before consuming runner
+  minutes building Rust. **Maintainers:** after merging, create a repository variable
+  `JR_E2E_ENABLED=true` at Settings → Secrets and variables → Actions → Variables
+  (repository scope, NOT environment scope) to re-enable nightly E2E on the canonical
+  repo. Without this step both workflows skip on every trigger. See
+  `docs/specs/e2e-fork-safe-ci-enablement.md §5.1`.
+- **README E2E status badge:** `[![E2E](...e2e.yml/badge.svg?branch=develop)]` added as
+  the second badge in the badge row. Shows green for passing or skipped runs; shows red
+  when tests fail. Badge is pinned to the canonical repo.
+- **High-value live E2E coverage (#467, #468, E2E-HV-1/2):** expanded live test suite
+  covers project list, user list, sprint add/remove, bulk move, write-flag paths
+  (description/stdin/markdown, comment channels, story points, parent, `--field`).
+- **Assign-by-query live E2E coverage (#458, E2E-PG-4).**
 
 ### Fixed
 
-- **Leading-dash values now accepted for all free-text write-command args (#471):** `issue create`/`edit`
-  `--summary` and `--description`, `worklog add --message`, the `issue comment` positional
-  message, and `issue remote-link --title` all carry `allow_hyphen_values = true`. This fixes the
-  `"unexpected argument"` clap error that occurred when passing GFM markdown task lists
-  (e.g. `--description "- [ ] todo"`), bullet-list content, or titled links
-  (e.g. `--title "- important ref"`) as free-text write inputs. Surfaced by the nightly E2E test
-  `test_e2e_markdown_task_list_produces_task_items`. The `--description` / `--description-stdin`
-  mutual-exclusion guard is unaffected. Use `--description="…"` or `--description-stdin` for
-  programmatic usage where the value may start with a dash. (`src/cli/mod.rs`)
-
-- **`markdown_to_adf` listItem content-model conformance (#470):** markdown like
+- **Leading-dash values now accepted for all free-text write-command args (#496, #471):**
+  `issue create`/`edit` `--summary` and `--description`, `worklog add --message`, the
+  `issue comment` positional message, and `issue remote-link --title` all carry
+  `allow_hyphen_values = true`. This fixes the `"unexpected argument"` clap error that
+  occurred when passing GFM markdown task lists (e.g. `--description "- [ ] todo"`),
+  bullet-list content, or titled links as free-text write inputs. Surfaced by the nightly
+  E2E test `test_e2e_markdown_task_list_produces_task_items`. Use `--description="…"` or
+  `--description-stdin` for programmatic usage where the value may start with a dash.
+  (`src/cli/mod.rs`)
+- **`markdown_to_adf` listItem content-model conformance (#470, #477):** markdown like
   `- > quote`, `- # heading`, `- ---`, and indented tables inside list items no longer
-  emit `blockquote`/`heading`/`table`/`rule` nodes as direct `listItem` children, which
-  violates the ADF `listItem` content model (only `paragraph`, `bulletList`,
-  `orderedList`, `codeBlock`, `mediaSingle` are permitted). Blockquotes are unwrapped
-  (recursively), headings are downconverted to paragraphs (inline marks preserved),
-  tables are flattened to one paragraph per row, and rules are dropped. Jira rendered the
-  old out-of-spec shapes leniently, but they were fragile to renderer changes and
-  cross-product round-trips. (BC-7.2.006, docs/specs/adf-listitem-content-model.md)
-
-- **JSM E2E self-close teardown (S-JSM-E2E-2):** the comment-visibility and
+  emit `blockquote`/`heading`/`table`/`rule` nodes as direct `listItem` children (ADF
+  schema violation). Blockquotes are unwrapped recursively, headings are downconverted
+  to paragraphs with inline marks preserved, tables are flattened to one paragraph per
+  row, and rules are dropped. (BC-7.2.006, `docs/specs/adf-listitem-content-model.md`)
+- **Markdown footnotes no longer emit malformed ADF (#481, #472):** `[^1]` reference
+  markers and footnote definitions are now preserved as plain text markers and an
+  appended definition section (one `rule` divider + one paragraph per definition) instead
+  of being dropped or emitting ADF structures that Jira rejects with HTTP 400. Duplicate
+  definition labels are deduped; empty container shells left by pulldown-cmark after
+  hoisting are pruned. (`src/adf.rs`)
+- **Block-level HTML preserved as literal text instead of being dropped (#489, #490):**
+  `markdown_to_adf` now routes `Tag::HtmlBlock` through a `NodeKind::HtmlBlock` path
+  rather than the silent `Sink` catch-all, so `<div>…</div>` and similar block HTML
+  appears as a literal paragraph in ADF rather than vanishing. Interior newlines are kept
+  verbatim; a single trailing newline is trimmed. Symmetric with the pre-existing inline
+  HTML preservation. (`src/adf.rs`)
+- **Bulk transition body now nested in `bulkTransitionInputs` wrapper (#479):**
+  `POST /rest/api/3/bulk/issues/transition` was sending a flat top-level schema
+  (`selectedIssueIdsOrKeys` + `transitionId` at root) that live Jira rejects with
+  HTTP 400 "bulkTransitionInputs must not be empty". Fixed to the nested form required
+  by the live API: `{"bulkTransitionInputs":[{"selectedIssueIdsOrKeys":[…],"transitionId":"…"}],"sendBulkNotification":false}`.
+  (FIX-BULK-TRANSITION-001)
+- **JSM E2E self-close teardown (#464, S-JSM-E2E-2):** the comment-visibility and
   create-request live tests now self-close their EJ tickets by dynamically discovering a
-  closing transition (`statusCategory.key == "done"`, preferring Resolved/Closed/Done)
-  instead of the hardcoded `"Done"` status name, which the EJ JSM workflow rejects —
-  created EJ tickets were being left open on every nightly run. Best-effort teardown
-  preserved (warn-and-return on failure, never fails the test). Zero `src/` change.
-  (S-JSM-E2E-2)
+  closing transition (`statusCategory.key == "done"`) instead of the hardcoded `"Done"`
+  status name, which the EJ JSM workflow rejects — created EJ tickets were being left open
+  on every nightly run. Best-effort teardown preserved (warn-and-return on failure).
+  Zero `src/` change. (S-JSM-E2E-2)
+- **ADF read-path and gate-guard hardening (#499, #475):** `adf_to_text` human-mode
+  coverage for `taskList`/`taskItem`/`panel`/`subsup`/block-HTML round-trips; E2E
+  gate-guard `test_every_ignored_test_has_gate_guard` and
+  `test_e2e_gate_disabled_when_env_unset` tightened to catch newly-added tests missing
+  their `if !e2e_enabled() { return; }` guard.
 
 ### Changed
+
+- Dependency bumps:
+  - **`gitleaks/gitleaks-action` 2.3.9 → 3.0.0 (#469) — MAJOR version bump.** The
+    v3 release drops the legacy `GITHUB_TOKEN`-based secret scanning in favour of a
+    purpose-built token; existing workflows may need to update the action inputs if
+    they customise the gitleaks configuration. Review the upstream v3 migration guide
+    before merging if you maintain a fork.
+  - `reqwest` 0.13.3 → 0.13.4 (#461)
+  - `chrono` 0.4.44 → 0.4.45 (#497)
+  - `EmbarkStudios/cargo-deny-action` 2.0.18 → 2.0.20 (#466)
+  - `step-security/harden-runner` 2.19.3 → 2.19.4 (#463)
+  - `github/codeql-action` 4.35.5 → 4.36.2 (#462, #498)
+  - `actions/checkout` 6.0.2 → 6.0.3 (#484)
 
 ## [0.5.0-dev.13] - 2026-06-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.5.0-dev.13"
+version = "0.5.0-dev.14"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.5.0-dev.13"
+version = "0.5.0-dev.14"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary

- Bumps `Cargo.toml` version `0.5.0-dev.13` → `0.5.0-dev.14`; `Cargo.lock` updated accordingly
- Finalizes `CHANGELOG.md`: renames `[Unreleased]` → `[0.5.0-dev.14] - 2026-06-11`, inserts fresh empty `[Unreleased]` skeleton above, adds all 31 missing commit entries

## What's in this release

### Highlights

**ADF markdown-conversion feature set (six features shipped since dev.13):**
- GFM task lists `- [ ] / - [x]` → ADF `taskList`/`taskItem` with interactive Jira checkboxes (#471, BC-7.2.010)
- GFM alerts `> [!NOTE/TIP/IMPORTANT/WARNING/CAUTION]` → ADF `panel` with content-model normalization (#483, BC-7.2.009)
- Markdown superscript `^x^` / subscript `~x~` → ADF `subsup`; heading attrs `{#id}` stripped (#474)
- Bare `http(s)://` URLs → ADF `link` mark (Jira does not auto-link plain-text URLs) (#473)
- Markdown footnotes → preserved as plain markers + appended definition section, no more malformed ADF (#481)
- Block-level HTML preserved as literal text instead of silently dropped (#489)

**Breaking fix — bulk transition wire schema (#479):** `jr issue move` multi-key was sending a flat payload that live Jira rejects with HTTP 400; corrected to the `bulkTransitionInputs` nested wrapper (FIX-BULK-TRANSITION-001).

**Breaking change — resolution enforcement on `jr issue move` (#465, BC-3.2.013):** done-category single-key transitions now require `--resolution <name>` or `--no-resolution` in non-interactive mode. Scripts using the silent bypass need updating.

**Leading-dash free-text args (#496):** `--description "- [ ] todo"` and similar markdown inputs no longer trigger clap's "unexpected argument" error.

**E2E test suite expansion:** ~15 new live-Jira test functions across task lists, subsup, panel, block-HTML, bare-URL, write-flag paths, JSM request types, and bulk-move robustness.

### Dependency bump — gitleaks MAJOR

`gitleaks/gitleaks-action` **2.3.9 → 3.0.0** (#469) is a **major version bump**. The v3 action changes how it acquires its token. Forks and repos that customise the gitleaks configuration should review the upstream v3 migration guide. The canonical repo's workflow has been updated and passes CI.

### Other dependency bumps
`reqwest` 0.13.3→0.13.4, `chrono` 0.4.44→0.4.45, `cargo-deny-action` 2.0.18→2.0.20, `harden-runner` 2.19.3→2.19.4, `codeql-action` 4.35.5→4.36.2, `actions/checkout` 6.0.2→6.0.3

## Test plan

- [ ] CI passes on this PR (`lint`, `test`, `build` status checks green)
- [ ] Confirm `Cargo.toml` shows `version = "0.5.0-dev.14"` and `Cargo.lock` `jr` entry matches
- [ ] Confirm `CHANGELOG.md` `[0.5.0-dev.14]` section looks correct
- [ ] After merge to develop: tag `v0.5.0-dev.14` on the merge commit → triggers `release.yml`