### PR TITLE
docs(adr): ADR-0003 cert-root verification accurate for reqwest 0.13

### DIFF
--- a/docs/adr/0003-reqwest-rustls.md
+++ b/docs/adr/0003-reqwest-rustls.md
@@ -17,5 +17,5 @@ Use `reqwest` with `default-features = false` and explicitly enable rustls. Feat
 
 ## Consequences
 - Binary size slightly larger than native-tls (~500KB)
-- No platform keystore certificate integration (rustls uses its own CA bundle via `webpki-roots`)
-- Corporate environments with custom CA certificates need `RUSTLS_NATIVE_CERTS=1` or equivalent configuration
+- **Certificate-root verification uses the platform trust store** (updated for reqwest 0.13): the `rustls` default in reqwest 0.13 delegates root-CA verification to `rustls-platform-verifier`, which reads the OS trust store (macOS Security framework, Windows CryptoAPI/certificate store, Linux system roots). The TLS handshake and crypto remain pure Rust — no OpenSSL, no Schannel for the protocol itself. This replaces the prior reqwest 0.12 behavior of bundling Mozilla roots via `webpki-roots`. As a result, enterprise CAs trusted in the OS store work automatically; `RUSTLS_NATIVE_CERTS=1` is no longer needed for that case. The `rustls-tls-webpki-roots` feature remains available as an opt-in to restore bundled-Mozilla-roots behavior (zero OS-store reliance) at the cost of enterprise-CA and CRL support.
+- Corporate environments with custom CA certificates should install the CA into the OS trust store (the platform verifier picks it up automatically under reqwest 0.13)


### PR DESCRIPTION
## Summary

- Corrects a stale claim in ADR-0003's Consequences section: the prior text said \"rustls uses its own CA bundle via `webpki-roots`\" and required `RUSTLS_NATIVE_CERTS=1` for corporate CAs.
- **What actually changed in reqwest 0.13:** the default `rustls` backend now uses `rustls-platform-verifier`, which delegates root-CA verification to the OS trust store (macOS Security framework, Windows CryptoAPI/certificate store, Linux system roots). The TLS *handshake and crypto* remain pure Rust — no OpenSSL, no Schannel for the protocol layer.
- Enterprise CAs trusted in the OS store now work automatically under reqwest 0.13; `RUSTLS_NATIVE_CERTS=1` is no longer needed for that case.
- `rustls-tls-webpki-roots` remains available as an explicit opt-in feature flag to restore bundled-Mozilla-roots behavior (zero OS-store reliance) at the cost of enterprise-CA and CRL support.
- Surfaced during research validation for the Windows-build feature (2026-06-12).

## Change type

Docs-only — no code, no tests, no Cargo.toml changes.

## Test plan

- [ ] No build or test changes required for a docs-only ADR correction.
- [ ] Reviewer: confirm the updated Consequences section accurately reflects reqwest 0.13 / rustls-platform-verifier behavior.