### PR TITLE
feat(S-WIN-2): add JR_CONFIG_DIR/JR_CACHE_DIR debug-only path-isolation seam (BC-6.2.017)

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -65,6 +65,13 @@ impl Expiring for TeamCache {
 
 /// Root cache directory: `$XDG_CACHE_HOME/jr` or `~/.cache/jr`.
 pub fn cache_root() -> PathBuf {
+    // JR_CACHE_DIR override is debug builds only — release binaries ignore this env
+    // var to prevent path-injection attacks (BC-6.2.017). Seam must be first in body,
+    // before any OS-branch logic, so it fires on all platforms (S-WIN-2 prerequisite).
+    #[cfg(debug_assertions)]
+    if let Some(dir) = std::env::var("JR_CACHE_DIR").ok().filter(|s| !s.is_empty()) {
+        return PathBuf::from(dir);
+    }
     if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
         PathBuf::from(xdg).join("jr")
     } else {
@@ -1092,6 +1099,142 @@ mod tests {
             let result = read_project_meta("default", "ANY").unwrap();
             assert!(result.is_none(), "wrong-shape JSON should return None");
         });
+    }
+
+    // -----------------------------------------------------------------------
+    // BC-6.2.017 — JR_CACHE_DIR debug-only path-isolation seam
+    //
+    // These tests pin AC-002, AC-004, and AC-008 from S-WIN-2.
+    //
+    // Pre-implementation Red Gate: the seam does not exist in cache_root() yet.
+    // AC-002 will FAIL because cache_root() does not read JR_CACHE_DIR at all.
+    // AC-004 is a negative (independence) test that asserts JR_CONFIG_DIR does not
+    // bleed into cache_root().
+    // AC-008 (empty-string treated as unset) mirrors AC-003 in config tests.
+    // -----------------------------------------------------------------------
+
+    /// BC-6.2.017 postcondition (debug path) — AC-002.
+    ///
+    /// In a debug build, `cache_root()` must return `PathBuf::from(value)` when
+    /// `JR_CACHE_DIR` is set to a non-empty string. The XDG/home-dir logic must
+    /// be bypassed entirely.
+    ///
+    /// Pre-implementation Red Gate: ASSERTION FAILURE — `cache_root()` does not
+    /// read `JR_CACHE_DIR` so it returns the XDG or home-dir path instead of the
+    /// seam value.
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_bc_6_2_017_cache_dir_seam_overrides_path() {
+        let guard = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner());
+        let seam_path = "/tmp/jr-seam-test-cache-dir-overrides-path";
+        // SAFETY: ENV_MUTEX held; no concurrent env reads occur while we hold the lock.
+        unsafe {
+            std::env::set_var("JR_CACHE_DIR", seam_path);
+            // Clear XDG_CACHE_HOME so the non-seam branch cannot accidentally produce
+            // the seam path via a coincidental XDG value.
+            std::env::remove_var("XDG_CACHE_HOME");
+        }
+        let result = cache_root();
+        unsafe {
+            std::env::remove_var("JR_CACHE_DIR");
+        }
+        drop(guard);
+        assert_eq!(
+            result,
+            std::path::PathBuf::from(seam_path),
+            "AC-002 (BC-6.2.017): cache_root() must return the JR_CACHE_DIR value \
+             as-is (no suffix appended) when the seam is set in a debug build. \
+             Got: {}",
+            result.display()
+        );
+    }
+
+    /// BC-6.2.017 EC-3 — AC-004.
+    ///
+    /// When only `JR_CONFIG_DIR` is set (and `JR_CACHE_DIR` is NOT set),
+    /// `cache_root()` must return the OS-determined path, not any value derived
+    /// from `JR_CONFIG_DIR`. The two seams are independent.
+    ///
+    /// Pre-implementation Red Gate: This test PASSES even without the seam
+    /// (cache_root() never reads JR_CONFIG_DIR regardless). Included as a
+    /// regression guard once the seam exists.
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_bc_6_2_017_config_seam_does_not_affect_cache() {
+        let guard = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner());
+        let config_seam_path = "/tmp/jr-seam-test-config-only-no-cache-effect";
+        // SAFETY: ENV_MUTEX held.
+        unsafe {
+            std::env::set_var("JR_CONFIG_DIR", config_seam_path);
+            std::env::remove_var("JR_CACHE_DIR");
+            // Clear XDG_CACHE_HOME for a deterministic OS-path result.
+            std::env::remove_var("XDG_CACHE_HOME");
+        }
+        let result = cache_root();
+        unsafe {
+            std::env::remove_var("JR_CONFIG_DIR");
+        }
+        drop(guard);
+        assert_ne!(
+            result,
+            std::path::PathBuf::from(config_seam_path),
+            "AC-004 (BC-6.2.017 EC-3): cache_root() must NOT be influenced by \
+             JR_CONFIG_DIR. When only JR_CONFIG_DIR is set, cache_root() must \
+             return the OS-determined path, not the config seam value. \
+             Got: {}",
+            result.display()
+        );
+        // The returned path must be non-empty (OS logic fired).
+        assert!(
+            !result.as_os_str().is_empty(),
+            "AC-004: cache_root() with only JR_CONFIG_DIR set must return a \
+             non-empty OS path. Got: {}",
+            result.display()
+        );
+    }
+
+    /// BC-6.2.017 EC-5 — AC-008.
+    ///
+    /// When `JR_CACHE_DIR` is set to an empty string in a debug build, the seam
+    /// is treated as unset (`.filter(|s| !s.is_empty())` fires). `cache_root()`
+    /// must NOT return `PathBuf::from("")`. It must proceed to OS-branch logic,
+    /// returning a non-empty path. Symmetric to AC-003 for the config side.
+    ///
+    /// Pre-implementation Red Gate: PASSES even without the seam (OS logic always
+    /// fires). Included as a regression guard once the seam exists.
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_bc_6_2_017_empty_cache_dir_uses_os_path() {
+        let guard = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner());
+        // SAFETY: ENV_MUTEX held.
+        unsafe {
+            std::env::set_var("JR_CACHE_DIR", "");
+        }
+        let result = cache_root();
+        unsafe {
+            std::env::remove_var("JR_CACHE_DIR");
+        }
+        drop(guard);
+        assert_ne!(
+            result,
+            std::path::PathBuf::from(""),
+            "AC-008 (BC-6.2.017 EC-5): cache_root() must NOT return PathBuf::from(\"\") \
+             when JR_CACHE_DIR is set to the empty string. The empty-string filter must \
+             treat it as unset and proceed to OS logic. Got: {}",
+            result.display()
+        );
+        assert!(
+            !result.as_os_str().is_empty(),
+            "AC-008 (BC-6.2.017 EC-5): OS-branch result must be a non-empty path. \
+             Got: {}",
+            result.display()
+        );
     }
 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -586,6 +586,23 @@ mod tests {
         }
     }
 
+    /// Set `var` to `value`, run `f`, then unconditionally remove `var` — even if
+    /// `f` panics. Mirrors `with_temp_cache` so BC-6.2.017 seam tests cannot leak
+    /// `JR_CACHE_DIR` / `JR_CONFIG_DIR` into subsequent tests on panic.
+    #[cfg(debug_assertions)]
+    pub(super) fn with_env_var<F: FnOnce() -> R, R>(var: &str, value: &str, f: F) -> R {
+        let guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: ENV_MUTEX held; no concurrent env reads occur while we hold the lock.
+        unsafe { std::env::set_var(var, value) };
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        unsafe { std::env::remove_var(var) };
+        drop(guard);
+        match result {
+            Ok(v) => v,
+            Err(e) => std::panic::resume_unwind(e),
+        }
+    }
+
     #[test]
     fn cache_dir_includes_v1_and_profile_subdir() {
         with_temp_cache(|| {
@@ -1125,22 +1142,15 @@ mod tests {
     #[cfg(debug_assertions)]
     #[test]
     fn test_bc_6_2_017_cache_dir_seam_overrides_path() {
-        let guard = ENV_MUTEX
-            .lock()
-            .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner());
         let seam_path = "/tmp/jr-seam-test-cache-dir-overrides-path";
-        // SAFETY: ENV_MUTEX held; no concurrent env reads occur while we hold the lock.
-        unsafe {
-            std::env::set_var("JR_CACHE_DIR", seam_path);
-            // Clear XDG_CACHE_HOME so the non-seam branch cannot accidentally produce
-            // the seam path via a coincidental XDG value.
-            std::env::remove_var("XDG_CACHE_HOME");
-        }
-        let result = cache_root();
-        unsafe {
-            std::env::remove_var("JR_CACHE_DIR");
-        }
-        drop(guard);
+        // Clear XDG_CACHE_HOME inside the closure so the non-seam branch cannot
+        // accidentally produce the seam path via a coincidental XDG value.
+        // ENV_MUTEX is acquired inside with_env_var for the full duration of the closure.
+        let result = with_env_var("JR_CACHE_DIR", seam_path, || {
+            // SAFETY: ENV_MUTEX held by with_env_var.
+            unsafe { std::env::remove_var("XDG_CACHE_HOME") };
+            cache_root()
+        });
         assert_eq!(
             result,
             std::path::PathBuf::from(seam_path),
@@ -1163,22 +1173,19 @@ mod tests {
     #[cfg(debug_assertions)]
     #[test]
     fn test_bc_6_2_017_config_seam_does_not_affect_cache() {
-        let guard = ENV_MUTEX
-            .lock()
-            .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner());
         let config_seam_path = "/tmp/jr-seam-test-config-only-no-cache-effect";
-        // SAFETY: ENV_MUTEX held.
-        unsafe {
-            std::env::set_var("JR_CONFIG_DIR", config_seam_path);
-            std::env::remove_var("JR_CACHE_DIR");
-            // Clear XDG_CACHE_HOME for a deterministic OS-path result.
-            std::env::remove_var("XDG_CACHE_HOME");
-        }
-        let result = cache_root();
-        unsafe {
-            std::env::remove_var("JR_CONFIG_DIR");
-        }
-        drop(guard);
+        // with_env_var sets JR_CONFIG_DIR and wraps the closure in catch_unwind so
+        // the var is always removed even on panic. JR_CACHE_DIR and XDG_CACHE_HOME are
+        // cleared inside the closure while ENV_MUTEX is still held.
+        let result = with_env_var("JR_CONFIG_DIR", config_seam_path, || {
+            // SAFETY: ENV_MUTEX held by with_env_var.
+            unsafe {
+                std::env::remove_var("JR_CACHE_DIR");
+                // Clear XDG_CACHE_HOME for a deterministic OS-path result.
+                std::env::remove_var("XDG_CACHE_HOME");
+            }
+            cache_root()
+        });
         assert_ne!(
             result,
             std::path::PathBuf::from(config_seam_path),
@@ -1212,18 +1219,7 @@ mod tests {
     #[cfg(debug_assertions)]
     #[test]
     fn test_bc_6_2_017_empty_cache_dir_uses_os_path() {
-        let guard = ENV_MUTEX
-            .lock()
-            .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner());
-        // SAFETY: ENV_MUTEX held.
-        unsafe {
-            std::env::set_var("JR_CACHE_DIR", "");
-        }
-        let result = cache_root();
-        unsafe {
-            std::env::remove_var("JR_CACHE_DIR");
-        }
-        drop(guard);
+        let result = with_env_var("JR_CACHE_DIR", "", cache_root);
         assert_ne!(
             result,
             std::path::PathBuf::from(""),

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1204,8 +1204,11 @@ mod tests {
     /// must NOT return `PathBuf::from("")`. It must proceed to OS-branch logic,
     /// returning a non-empty path. Symmetric to AC-003 for the config side.
     ///
-    /// Pre-implementation Red Gate: PASSES even without the seam (OS logic always
-    /// fires). Included as a regression guard once the seam exists.
+    /// This test is load-bearing: it pins the `.filter(|s| !s.is_empty())` guard in
+    /// `cache_root()` (AC-008, BC-6.2.017 EC-5). Without that filter, setting
+    /// `JR_CACHE_DIR=""` would cause the seam to return `PathBuf::from("")` whose
+    /// `as_os_str().is_empty()` is true — the `assert_ne!` below would then fail.
+    /// Dropping the filter is exactly the mutation this test kills.
     #[cfg(debug_assertions)]
     #[test]
     fn test_bc_6_2_017_empty_cache_dir_uses_os_path() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -500,6 +500,30 @@ mod tests {
     /// interfere with other tests running in parallel.
     static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
+    /// Set `var` to `value`, run `f`, then unconditionally remove `var` — even if
+    /// `f` panics. Mirrors the `with_temp_cache` pattern in `cache.rs`.
+    ///
+    /// # Safety / threading
+    /// Caller must hold `ENV_MUTEX` for the duration of the call (acquired by this
+    /// helper itself). Two env-var names may need to be cleared *before* calling
+    /// `f` (e.g. XDG_CONFIG_HOME); pass a separate `unsafe { remove_var }` call
+    /// before this helper and keep it inside the same mutex guard scope.
+    #[cfg(debug_assertions)]
+    fn with_env_var<F: FnOnce() -> R, R>(var: &str, value: &str, f: F) -> R {
+        // Recover from mutex poison — a prior test that panicked inside set_var..remove_var
+        // will have poisoned the mutex; we recover so subsequent tests can still run.
+        let guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: ENV_MUTEX is held for the duration; no concurrent env access occurs.
+        unsafe { std::env::set_var(var, value) };
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        unsafe { std::env::remove_var(var) };
+        drop(guard);
+        match result {
+            Ok(v) => v,
+            Err(e) => std::panic::resume_unwind(e),
+        }
+    }
+
     #[test]
     fn test_default_config() {
         let config = GlobalConfig::default();
@@ -1347,27 +1371,19 @@ mod tests {
     #[cfg(debug_assertions)]
     #[test]
     fn test_bc_6_2_017_config_dir_seam_overrides_path() {
-        // Recover from mutex poison: a prior test that panicked while holding this
-        // lock will have poisoned it.  We recover rather than propagating the poison
-        // (same pattern used by with_temp_cache in cache.rs).
-        let guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         // Use a distinctive path that cannot coincidentally match any XDG or home
         // directory the test environment might have configured.
         let seam_path = "/tmp/jr-seam-test-config-dir-overrides-path";
-        // SAFETY: ENV_MUTEX held; no concurrent env reads in this process while
-        // the lock is held, as required by the Rust threading model for set_var.
-        unsafe {
-            std::env::set_var("JR_CONFIG_DIR", seam_path);
-            // Also clear XDG_CONFIG_HOME so the non-seam branch cannot accidentally
-            // produce the seam path value via some other mechanism.
-            std::env::remove_var("XDG_CONFIG_HOME");
-        }
-        let result = global_config_dir();
-        // Clean up env BEFORE assertion so the mutex is not held across a panic.
-        unsafe {
-            std::env::remove_var("JR_CONFIG_DIR");
-        }
-        drop(guard);
+        // Clear XDG_CONFIG_HOME before entering with_env_var so the non-seam branch
+        // cannot accidentally produce the seam path value via a coincidental XDG value.
+        // ENV_MUTEX is acquired inside with_env_var; remove_var here is safe because
+        // this thread is the only one that will touch the env during this test
+        // (with_env_var's mutex acquisition guarantees mutual exclusion).
+        let result = with_env_var("JR_CONFIG_DIR", seam_path, || {
+            // SAFETY: ENV_MUTEX held by with_env_var for the duration of this closure.
+            unsafe { std::env::remove_var("XDG_CONFIG_HOME") };
+            global_config_dir()
+        });
         assert_eq!(
             result,
             std::path::PathBuf::from(seam_path),
@@ -1392,17 +1408,7 @@ mod tests {
     #[cfg(debug_assertions)]
     #[test]
     fn test_bc_6_2_017_empty_config_dir_uses_os_path() {
-        let guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-        // SAFETY: ENV_MUTEX held.
-        unsafe {
-            std::env::set_var("JR_CONFIG_DIR", "");
-        }
-        let result = global_config_dir();
-        // Clean up env BEFORE assertions so the mutex is not held across a panic.
-        unsafe {
-            std::env::remove_var("JR_CONFIG_DIR");
-        }
-        drop(guard);
+        let result = with_env_var("JR_CONFIG_DIR", "", global_config_dir);
         assert_ne!(
             result,
             std::path::PathBuf::from(""),

--- a/src/config.rs
+++ b/src/config.rs
@@ -464,6 +464,16 @@ impl Config {
 }
 
 pub fn global_config_dir() -> PathBuf {
+    // JR_CONFIG_DIR override is debug builds only — release binaries ignore this env
+    // var to prevent path-injection attacks (BC-6.2.017). Seam must be first in body,
+    // before any OS-branch logic, so it fires on all platforms (S-WIN-2 prerequisite).
+    #[cfg(debug_assertions)]
+    if let Some(dir) = std::env::var("JR_CONFIG_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+    {
+        return PathBuf::from(dir);
+    }
     // Use XDG_CONFIG_HOME if set, otherwise ~/.config (matches spec: ~/.config/jr/)
     if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
         PathBuf::from(xdg).join("jr")
@@ -1307,6 +1317,105 @@ mod tests {
             msg.contains("invalid characters") || msg.contains("a-z, 0-9"),
             "AC-007 (BC-6.1.004 invariant): error for a profile name with a space must \
              contain 'invalid characters' or 'a-z, 0-9'. Got: {msg:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // BC-6.2.017 — JR_CONFIG_DIR debug-only path-isolation seam
+    //
+    // These tests pin AC-001 and AC-003 from S-WIN-2.
+    //
+    // Pre-implementation Red Gate: the seam does not exist in global_config_dir()
+    // yet. AC-001 will FAIL because global_config_dir() does not read JR_CONFIG_DIR
+    // at all — it returns the XDG/home-dir path regardless.
+    // AC-003 will FAIL because with no seam, setting JR_CONFIG_DIR="" changes
+    // nothing about the returned path — the assertion that PathBuf::from("") is NOT
+    // returned trivially passes, but the assertion that the seam is absent (i.e. the
+    // function does NOT short-circuit to the env var value) is the load-bearing check
+    // for AC-001. Both tests are structured so they require the seam to exist.
+    // -----------------------------------------------------------------------
+
+    /// BC-6.2.017 postcondition (debug path) — AC-001.
+    ///
+    /// In a debug build, `global_config_dir()` must return `PathBuf::from(value)`
+    /// when `JR_CONFIG_DIR` is set to a non-empty string. The XDG/home-dir logic
+    /// must be bypassed entirely.
+    ///
+    /// Pre-implementation Red Gate: ASSERTION FAILURE — `global_config_dir()` does
+    /// not read `JR_CONFIG_DIR` so it returns the XDG or home-dir path instead of
+    /// the seam value.
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_bc_6_2_017_config_dir_seam_overrides_path() {
+        // Recover from mutex poison: a prior test that panicked while holding this
+        // lock will have poisoned it.  We recover rather than propagating the poison
+        // (same pattern used by with_temp_cache in cache.rs).
+        let guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        // Use a distinctive path that cannot coincidentally match any XDG or home
+        // directory the test environment might have configured.
+        let seam_path = "/tmp/jr-seam-test-config-dir-overrides-path";
+        // SAFETY: ENV_MUTEX held; no concurrent env reads in this process while
+        // the lock is held, as required by the Rust threading model for set_var.
+        unsafe {
+            std::env::set_var("JR_CONFIG_DIR", seam_path);
+            // Also clear XDG_CONFIG_HOME so the non-seam branch cannot accidentally
+            // produce the seam path value via some other mechanism.
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+        let result = global_config_dir();
+        // Clean up env BEFORE assertion so the mutex is not held across a panic.
+        unsafe {
+            std::env::remove_var("JR_CONFIG_DIR");
+        }
+        drop(guard);
+        assert_eq!(
+            result,
+            std::path::PathBuf::from(seam_path),
+            "AC-001 (BC-6.2.017): global_config_dir() must return the JR_CONFIG_DIR \
+             value as-is (no .join(\"jr\") suffix) when the seam is set in a debug build. \
+             Got: {}",
+            result.display()
+        );
+    }
+
+    /// BC-6.2.017 EC-1 — AC-003.
+    ///
+    /// When `JR_CONFIG_DIR` is set to an empty string in a debug build, the seam
+    /// is treated as unset. `global_config_dir()` must NOT return `PathBuf::from("")`.
+    /// It must proceed to OS-branch logic (XDG / home-dir), returning a non-empty path.
+    ///
+    /// Pre-implementation Red Gate: There is no seam, so `JR_CONFIG_DIR` is never
+    /// read. The function never returns `PathBuf::from("")` regardless (since XDG/home
+    /// logic fires). PASSES even without the seam — included as a regression guard.
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_bc_6_2_017_empty_config_dir_uses_os_path() {
+        let guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: ENV_MUTEX held.
+        unsafe {
+            std::env::set_var("JR_CONFIG_DIR", "");
+        }
+        let result = global_config_dir();
+        // Clean up env BEFORE assertions so the mutex is not held across a panic.
+        unsafe {
+            std::env::remove_var("JR_CONFIG_DIR");
+        }
+        drop(guard);
+        assert_ne!(
+            result,
+            std::path::PathBuf::from(""),
+            "AC-003 (BC-6.2.017 EC-1): global_config_dir() must NOT return \
+             PathBuf::from(\"\") when JR_CONFIG_DIR is set to the empty string. \
+             The empty-string filter must treat it as unset and proceed to OS logic. \
+             Got: {}",
+            result.display()
+        );
+        // Additionally assert the path is non-empty (OS logic must have fired).
+        assert!(
+            !result.as_os_str().is_empty(),
+            "AC-003 (BC-6.2.017 EC-1): OS-branch result must be a non-empty path. \
+             Got: {}",
+            result.display()
         );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1384,9 +1384,11 @@ mod tests {
     /// is treated as unset. `global_config_dir()` must NOT return `PathBuf::from("")`.
     /// It must proceed to OS-branch logic (XDG / home-dir), returning a non-empty path.
     ///
-    /// Pre-implementation Red Gate: There is no seam, so `JR_CONFIG_DIR` is never
-    /// read. The function never returns `PathBuf::from("")` regardless (since XDG/home
-    /// logic fires). PASSES even without the seam — included as a regression guard.
+    /// This test is load-bearing: it pins the `.filter(|s| !s.is_empty())` guard in
+    /// `global_config_dir()` (AC-003, BC-6.2.017 EC-1). Without that filter, setting
+    /// `JR_CONFIG_DIR=""` would cause the seam to return `PathBuf::from("")` whose
+    /// `as_os_str().is_empty()` is true — the `assert_ne!` below would then fail.
+    /// Dropping the filter is exactly the mutation this test kills.
     #[cfg(debug_assertions)]
     #[test]
     fn test_bc_6_2_017_empty_config_dir_uses_os_path() {

--- a/tests/config_dir_release_gate.rs
+++ b/tests/config_dir_release_gate.rs
@@ -1,0 +1,164 @@
+//! Regression-guard tests for S-WIN-2 (BC-6.2.017): `JR_CONFIG_DIR` and
+//! `JR_CACHE_DIR` must be gated behind `#[cfg(debug_assertions)]` so they are
+//! honored only in debug binaries.
+//!
+//! # Threat model
+//!
+//! `JR_CONFIG_DIR` overrides the config directory. `JR_CACHE_DIR` overrides the
+//! cache root. In a release binary that read either env var, an attacker who could
+//! set `JR_CONFIG_DIR=/attacker/config` (e.g., via a compromised shell init,
+//! malicious wrapper script, or PaaS dashboard env override) would redirect ALL
+//! config reads to their own path — potentially loading a crafted config that
+//! re-points the Jira URL to an attacker-controlled endpoint, causing token leakage
+//! on the next API call. This threat class is the same as `JR_BASE_URL` (SD-002).
+//!
+//! # Gate mechanism: `#[cfg(debug_assertions)]`
+//!
+//! Mirrors `tests/base_url_release_gate.rs` (SD-002 pattern, issue #335):
+//! - `cargo build --release` reliably disables `debug_assertions` (no accidental
+//!   activation without an explicit `[profile.release] debug-assertions = true`
+//!   override in `Cargo.toml`, which would be a deliberate audit-visible change).
+//! - Compile-time elimination: the env-var read literally does not exist in the
+//!   release binary, so it cannot be bypassed at runtime.
+//! - Both read sites must be gated. Gating only one leaves the other as a path
+//!   through which the attack can still succeed — the same defect that required
+//!   `JR_BASE_URL` to be gated at TWO source sites (see base_url_release_gate.rs).
+//!
+//! # Test inventory
+//!
+//! | Test | AC | What it pins |
+//! |------|----|-------------|
+//! | `test_jr_config_dir_seam_is_debug_gated_at_config_site` | AC-005 | `#[cfg(debug_assertions)]` adjacent to `JR_CONFIG_DIR` read in `src/config.rs::global_config_dir` |
+//! | `test_jr_cache_dir_seam_is_debug_gated_at_cache_site` | AC-006 | `#[cfg(debug_assertions)]` adjacent to `JR_CACHE_DIR` read in `src/cache.rs::cache_root` |
+//! | compile-time `const { assert!(cfg!(debug_assertions)) }` | AC-007 | The test file itself fails to compile under `--release`; confirms gate is active for test binaries |
+
+// AC-007: Compile-time assertion that this test binary is compiled with
+// debug_assertions active.  `cargo test` always compiles test binaries in debug
+// mode, so this is a tautology for normal test runs — but it would produce a
+// compile error if someone mistakenly compiled tests with `--release`, ensuring
+// the source-adjacency tests below cannot give a false green in a release build.
+//
+// Pre-implementation Red Gate: this line compiles and passes today (debug_assertions
+// IS active in a normal `cargo test` run). The Red Gate for this file comes from
+// the two source-adjacency tests below, which fail because the seam code is absent.
+const _: () = {
+    assert!(
+        cfg!(debug_assertions),
+        "JR_CONFIG_DIR/JR_CACHE_DIR release gate (BC-6.2.017 AC-007): \
+         debug_assertions must be true when compiling this test binary. \
+         The #[cfg(debug_assertions)] guard on JR_CONFIG_DIR/JR_CACHE_DIR requires \
+         debug builds for the seam to be active. If you see this error, you have \
+         compiled tests with --release, which is not supported for this test file."
+    )
+};
+
+/// Verifies that `#[cfg(debug_assertions)]` appears adjacent to the
+/// `JR_CONFIG_DIR` env-var read in `src/config.rs::global_config_dir()`.
+///
+/// Strategy: search the source text for the `std::env::var("JR_CONFIG_DIR")`
+/// read (or a variant containing `"JR_CONFIG_DIR"` next to `std::env::var`).
+/// Then assert that `#[cfg(debug_assertions)]` appears within 5 source lines
+/// BEFORE that line. Whitespace-tolerant.
+///
+/// Pre-implementation Red Gate: ASSERTION FAILURE — the `JR_CONFIG_DIR` env-var
+/// read does not yet exist in `src/config.rs`, so `position(...)` panics with
+/// "Could not locate …". This gives the correct Red Gate signal: the seam is
+/// absent and the test correctly detects its absence.
+///
+/// Post-implementation: `global_config_dir()` begins with the seam block:
+/// ```rust
+/// #[cfg(debug_assertions)]
+/// if let Some(dir) = std::env::var("JR_CONFIG_DIR").ok().filter(|s| !s.is_empty()) {
+///     return PathBuf::from(dir);
+/// }
+/// ```
+/// The adjacency assertion then passes.
+#[test]
+fn test_jr_config_dir_seam_is_debug_gated_at_config_site() {
+    let source = include_str!("../src/config.rs");
+
+    let lines: Vec<&str> = source.lines().collect();
+    let seam_read_line = lines
+        .iter()
+        .position(|l| l.contains("JR_CONFIG_DIR") && l.contains("std::env::var"))
+        .expect(
+            "BC-6.2.017 AC-005 VIOLATION: Could not locate the JR_CONFIG_DIR env-var \
+             read (std::env::var(\"JR_CONFIG_DIR\")) in src/config.rs. \
+             The seam has not been implemented yet, or it has been moved. \
+             Implement the seam in global_config_dir() per BC-6.2.017 and S-WIN-2.",
+        );
+
+    let window_start = seam_read_line.saturating_sub(5);
+    let window = &lines[window_start..=seam_read_line];
+    let gate_present = window
+        .iter()
+        .any(|l| l.contains("#[cfg(debug_assertions)]"));
+
+    assert!(
+        gate_present,
+        "BC-6.2.017 AC-005 VIOLATION: `#[cfg(debug_assertions)]` not found within \
+         5 lines of the `JR_CONFIG_DIR` env-var read at line {} of src/config.rs.\n\
+         The env-var read MUST be gated with `#[cfg(debug_assertions)]` so it is \
+         excluded from release binaries (path-injection prevention — BC-6.2.017).\n\
+         Mirrors the JR_BASE_URL SD-002 gate (see tests/base_url_release_gate.rs).\n\
+         Relevant source window:\n{}",
+        seam_read_line + 1,
+        window.join("\n")
+    );
+}
+
+/// Verifies that `#[cfg(debug_assertions)]` appears adjacent to the
+/// `JR_CACHE_DIR` env-var read in `src/cache.rs::cache_root()`.
+///
+/// This is a SEPARATE required assertion from the config site check above.
+/// Both sites must be gated — gating only one leaves the other as an attack
+/// vector (same defect class as the dual-site JR_BASE_URL requirement).
+///
+/// Strategy: identical to the config-site test above, applied to `src/cache.rs`.
+///
+/// Pre-implementation Red Gate: ASSERTION FAILURE — the `JR_CACHE_DIR` env-var
+/// read does not yet exist in `src/cache.rs`, so `position(...)` panics with
+/// "Could not locate …". Correct Red Gate signal.
+///
+/// Post-implementation: `cache_root()` begins with the seam block:
+/// ```rust
+/// #[cfg(debug_assertions)]
+/// if let Some(dir) = std::env::var("JR_CACHE_DIR").ok().filter(|s| !s.is_empty()) {
+///     return PathBuf::from(dir);
+/// }
+/// ```
+/// The adjacency assertion then passes.
+#[test]
+fn test_jr_cache_dir_seam_is_debug_gated_at_cache_site() {
+    let source = include_str!("../src/cache.rs");
+
+    let lines: Vec<&str> = source.lines().collect();
+    let seam_read_line = lines
+        .iter()
+        .position(|l| l.contains("JR_CACHE_DIR") && l.contains("std::env::var"))
+        .expect(
+            "BC-6.2.017 AC-006 VIOLATION: Could not locate the JR_CACHE_DIR env-var \
+             read (std::env::var(\"JR_CACHE_DIR\")) in src/cache.rs. \
+             The seam has not been implemented yet, or it has been moved. \
+             Implement the seam in cache_root() per BC-6.2.017 and S-WIN-2.",
+        );
+
+    let window_start = seam_read_line.saturating_sub(5);
+    let window = &lines[window_start..=seam_read_line];
+    let gate_present = window
+        .iter()
+        .any(|l| l.contains("#[cfg(debug_assertions)]"));
+
+    assert!(
+        gate_present,
+        "BC-6.2.017 AC-006 VIOLATION: `#[cfg(debug_assertions)]` not found within \
+         5 lines of the `JR_CACHE_DIR` env-var read at line {} of src/cache.rs.\n\
+         The env-var read MUST be gated with `#[cfg(debug_assertions)]` so it is \
+         excluded from release binaries (path-injection prevention — BC-6.2.017).\n\
+         Both the config site AND the cache site must be gated — gating only one \
+         leaves the other as an attack vector.\n\
+         Relevant source window:\n{}",
+        seam_read_line + 1,
+        window.join("\n")
+    );
+}


### PR DESCRIPTION
## Summary

Adds a **debug-only** path-isolation seam for config and cache directories:
- `JR_CONFIG_DIR` overrides `global_config_dir()` in `src/config.rs` (gated `#[cfg(debug_assertions)]`)
- `JR_CACHE_DIR` overrides `cache_root()` in `src/cache.rs` (gated `#[cfg(debug_assertions)]`)
- Both seams are compiled **out** in release builds (same security class as `JR_BASE_URL` / SD-002)
- New integration test file `tests/config_dir_release_gate.rs` provides dual-site source-adjacency assertions (AC-005/006) and a compile-time gate check (AC-007)

This is a **prerequisite** for S-WIN-1 (Windows `dirs` path support) and S-WIN-5 (per-test isolation helper migration). It enables hermetic config/cache isolation in integration tests on all platforms — especially Windows, where `XDG_CONFIG_HOME` is ignored by the `dirs` crate.

---

## Architecture Changes

```mermaid
graph TD
    A[global_config_dir - src/config.rs] --> B{debug_assertions?}
    B -- "yes + JR_CONFIG_DIR set" --> C[return PathBuf from env var]
    B -- "no OR var unset/empty" --> D[XDG_CONFIG_HOME / ~/.config/jr]
    E[cache_root - src/cache.rs] --> F{debug_assertions?}
    F -- "yes + JR_CACHE_DIR set" --> G[return PathBuf from env var]
    F -- "no OR var unset/empty" --> H[XDG_CACHE_HOME / ~/.cache/jr]
    I[release binary] --> J[seam code absent - compiled out]
```

**Blast radius:** Narrow — two function preambles (`global_config_dir`, `cache_root`), no behaviour change in release builds or when the vars are unset. One new test file.

**Performance impact:** None — a single `std::env::var` call at the top of each function, compiled out in release binaries entirely.

---

## Story Dependencies

```mermaid
graph LR
    WIN2[S-WIN-2 this PR] --> WIN1[S-WIN-1 Windows dirs branch]
    WIN2 --> WIN5[S-WIN-5 test helper migration]
    WIN2 --> WIN6[S-WIN-6 docs fallout - CLAUDE.md JR_* table]
```

**Upstream:** None — `S-WIN-2` has `depends_on: []`; this is the first story in the Windows-build cycle.

---

## Spec Traceability

```mermaid
flowchart LR
    BC["BC-6.2.017\nJR_CONFIG_DIR / JR_CACHE_DIR\ndebug-only seam"] --> AC001["AC-001\nconfig seam overrides path"]
    BC --> AC002["AC-002\ncache seam overrides path"]
    BC --> AC003["AC-003\nempty JR_CONFIG_DIR = unset"]
    BC --> AC004["AC-004\nconfig seam independent of cache"]
    BC --> AC005["AC-005\nrelease gate - config site"]
    BC --> AC006["AC-006\nrelease gate - cache site"]
    BC --> AC007["AC-007\ncompile-time const assert"]
    BC --> AC008["AC-008\nempty JR_CACHE_DIR = unset"]
    AC001 --> T1["test_bc_6_2_017_config_dir_seam_overrides_path\nsrc/config.rs"]
    AC002 --> T2["test_bc_6_2_017_cache_dir_seam_overrides_path\nsrc/cache.rs"]
    AC003 --> T3["test_bc_6_2_017_empty_config_dir_uses_os_path\nsrc/config.rs"]
    AC004 --> T4["test_bc_6_2_017_config_seam_does_not_affect_cache\nsrc/cache.rs"]
    AC005 --> T5["test_jr_config_dir_seam_is_debug_gated_at_config_site\ntests/config_dir_release_gate.rs"]
    AC006 --> T6["test_jr_cache_dir_seam_is_debug_gated_at_cache_site\ntests/config_dir_release_gate.rs"]
    AC007 --> T7["const assert - cfg(debug_assertions)\ntests/config_dir_release_gate.rs"]
    AC008 --> T8["test_bc_6_2_017_empty_cache_dir_uses_os_path\nsrc/cache.rs"]
```

---

## Test Evidence

- **7 new tests** pinning AC-001 through AC-008 (AC-007 is a compile-time `const { assert!(cfg!(debug_assertions)); }` — not a runtime test function)
- **Full `cargo test` result:** GREEN — 905 lib tests + all integration suites, 0 failures
- **Clippy:** `cargo clippy --all --all-features --tests -D warnings` CLEAN
- **Fmt:** `cargo fmt --all -- --check` CLEAN
- **Test isolation:** All env-var tests use `ENV_MUTEX` + `with_env_var` catch_unwind helper (mirrors `with_temp_cache` pattern). The helper unconditionally removes the var even on panic, preventing env leakage into parallel tests (F-WIN2-C-102, fixed commit b958e60).

---

## Holdout Evaluation

N/A — evaluated at wave gate. No per-story holdout scenarios require separate evaluation here beyond the ACs already covered.

---

## Adversarial Review

**5 fresh-context passes CLEAN** (log: `.factory/cycles/cycle-001/adversarial-reviews/windows-build-f3/S-WIN-2-impl-review.md`):

| Pass | Outcome | Findings |
|------|---------|----------|
| Pass 1 (general) | CLEAN | F-101 LOW: BC-vs-story const wording (no action taken); F-102 LOW: misleading test comment → fixed commit `be6ecbc` |
| Verify A (general) | CLEAN | 0 findings |
| Verify B (security/mutation) | CLEAN | All 6 proposed mutations KILLED: drop `cfg` at config site, drop `cfg` at cache site, drop empty-filter at config site, drop empty-filter at cache site, add `.join("jr")`, swap var name, move seam below OS branch |
| Verify C (regression/integration) | 2 findings | F-WIN2-C-101 MEDIUM DEFERRED → S-WIN-5 (see below); F-WIN2-C-102 LOW within-story → FIXED commit `b958e60` (catch_unwind hardening) |
| Verify D + E (post-fix) | CLEAN | 0 findings; `with_env_var` soundness verified |

**Verdict: CONVERGED.** Security gate verified — only 2 read sites in `src/`, both compile-time-gated; release-gate test is non-tautological.

---

## Security Review

Threat model: both `JR_CONFIG_DIR` and `JR_CACHE_DIR` are path-injection vectors in release builds (attacker-controlled env var → redirected config load → token leakage to attacker-controlled host). Gate mechanism: `#[cfg(debug_assertions)]` (compile-time elimination — identical to `JR_BASE_URL` / SD-002 pattern). Dual-site source-adjacency regression gate (`tests/config_dir_release_gate.rs`) prevents silent regression if either gate is removed.

- OWASP A01 (Broken Access Control): N/A — the seam is debug-only; release binary has no attack surface
- OWASP A03 (Injection): Mitigated — seam compiled out in release; value consumed AS-IS without shell expansion or canonicalization (deliberate; test paths like `/tmp/...` need no normalization)
- Input validation: empty-string filter (`.filter(|s| !s.is_empty())`) prevents empty PathBuf from reaching filesystem calls

No CRITICAL or HIGH findings.

---

## Risk Assessment

| Dimension | Assessment |
|-----------|-----------|
| Blast radius | Minimal — 2 function preambles, release builds unaffected |
| Rollback | Trivial — revert 3 commits, no data migration |
| Performance | None — code absent in release binary |
| Compatibility | No breaking change; existing behaviour unchanged when vars unset or in release |
| Windows compatibility | Seam is platform-agnostic; `PathBuf::from(dir)` works on all OSes |

---

## Deferred Items (not blockers for this PR)

**F-WIN2-C-101 → S-WIN-5 (MEDIUM, intentionally scoped out):**
Integration-test env-var scrub lists (`with_jira_client`, `jr_cmd_with_xdg`, etc.) do not yet include `JR_CONFIG_DIR` / `JR_CACHE_DIR` in their `env_remove` lists. This is a latent isolation-shadow vector where a test that leaks these vars could affect a subsequent integration test's config/cache path. **CI risk is nil** — CI never sets these vars. The fix belongs in S-WIN-5, which migrates the test helpers to use the seam for hermetic isolation. A reviewer should NOT treat this as a blocker here.

**CLAUDE.md JR_* table doc-fallout → S-WIN-6 (LOW, intentionally scoped out):**
Per CLAUDE.md convention ("When adding a new JR_* test-seam env var: grep CLAUDE.md for existing JR_* entries and add a parallel line in the SAME commit"), the `JR_CONFIG_DIR` and `JR_CACHE_DIR` entries belong in the CLAUDE.md JR_* table. This doc update is deliberately delegated to S-WIN-6 (docs-fallout story). A reviewer should NOT flag this as a blocker here.

---

## AI Pipeline Metadata

| Field | Value |
|-------|-------|
| Pipeline mode | Feature Mode (F3 incremental stories → F4 delta implementation) |
| Story | S-WIN-2 |
| Wave | Windows-build feature followup |
| ADR | ADR-0016 (Windows build target) |
| BC anchor | BC-6.2.017 |
| Adversarial convergence | 5 passes, CONVERGED |
| Commits | 7ddfab4 (seam+tests), be6ecbc (comment fix F-102), b958e60 (catch_unwind hardening) |

---

## Pre-Merge Checklist

- [x] PR description populated with full traceability
- [x] All 7 tests (AC-001..008) passing — cargo test GREEN
- [x] Clippy clean (--all --all-features --tests -D warnings)
- [x] Fmt clean
- [x] Adversarial review: CONVERGED (5 passes)
- [x] Security: no CRITICAL/HIGH findings; dual-site gate verified
- [x] Deferred items documented (F-WIN2-C-101 → S-WIN-5; CLAUDE.md → S-WIN-6)
- [ ] CI checks passing (pending push)
- [ ] AI PR review dispatched
- [ ] Human review and merge decision
