### PR TITLE
feat(S-WIN-3): add keyring windows-native feature; add deny.toml transitive skip set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,10 +1193,12 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
  "linux-keyutils",
  "log",
  "security-framework 2.11.1",
  "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ comfy-table = "7"
 dialoguer = "0.12"
 dirs = "6"
 figment = { version = "0.10", features = ["toml", "env"] }
-keyring = { version = "3", features = ["apple-native", "linux-native"] }
+keyring = { version = "3", features = ["apple-native", "linux-native", "windows-native"] }
 open = "5"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 serde = { version = "1", features = ["derive"] }

--- a/deny.toml
+++ b/deny.toml
@@ -140,9 +140,24 @@ reason = "clap, tokio, reqwest and most of the dependency graph use windows-sys 
 
 # windows-targets and windows_* arch crates: transitive sub-deps of windows-sys.
 # windows-sys 0.45 (via jni) pulls windows-targets 0.42.2 and windows_* 0.42.2;
+# windows-sys 0.52 (via ring) pulls windows-targets 0.52.6 and windows_* 0.52.6;
 # windows-sys 0.60 (via keyring v3.6.3 windows-native) pulls windows-targets 0.53.5
 # and windows_* 0.53.1. These are unavoidable until jni and keyring converge on the
 # same windows-sys version. (S-WIN-3, C-V2(b) research finding)
+#
+# Why no `[[bans.skip]]` for windows-targets/windows_* version "0.52"?
+#
+# cargo-deny's multiple-versions = "deny" fires when 2+ UN-SKIPPED versions of the
+# same crate remain in the dependency graph. With three versions in Cargo.lock
+# (0.42 from jni, 0.52 from ring, 0.53 from keyring windows-native), we only need
+# to skip N-1 = 2 of them. The two skips below (0.42 and 0.53) leave exactly ONE
+# un-skipped canonical version — 0.52.6 (pulled by ring via windows-sys 0.52) —
+# which satisfies cargo-deny's "single remaining version" requirement.
+#
+# Adding a 0.52 skip would leave ZERO un-skipped versions, which is unnecessary.
+# A future reviewer should NOT add a 0.52 skip; doing so would produce an
+# `unnecessary-skip` warning and is semantically wrong — 0.52.6 is the canonical
+# un-skipped version by design.
 
 [[bans.skip]]
 name = "windows-targets"

--- a/deny.toml
+++ b/deny.toml
@@ -123,20 +123,39 @@ name = "toml_datetime"
 version = "1"
 reason = "toml 1.x (direct dep) requires toml_datetime 1.x; toml 0.8 (via figment) requires 0.6. Unavoidable until figment upgrades to toml 1.x."
 
+# windows-sys: FOUR versions in Cargo.lock as of S-WIN-3.
+#   0.45.0 — jni v0.21.1 (via rustls-platform-verifier/reqwest)
+#   0.52.0 — ring (cryptography dep of rustls)
+#   0.60.2 — keyring v3.6.3 windows-native feature (Win32_Security_Credentials)
+#   0.61.2 — clap, tokio, reqwest and the broad dependency graph
+#
+# THREE are skipped (0.45, 0.60, 0.61); the single canonical UN-skipped version
+# is windows-sys 0.52.0 (via ring). N-1: 4 versions − 3 skips = 1 remaining,
+# which satisfies cargo-deny's "single remaining version" requirement.
+#
+# Adding a 0.52 skip would leave ZERO un-skipped versions (unnecessary-skip
+# error). Do NOT add a 0.52 skip — 0.52.0 is the canonical un-skipped version
+# by design, parallel to windows-targets 0.52.6 documented below.
+#
+# Maintenance caveat (F-WIN3-RC-103): if ring later bumps its windows-sys minor
+# off 0.52 (or if jni drops 0.45, or a new lineage is added), the canonical
+# un-skipped version changes. The guard is `cargo deny check` in CI; a future
+# dep bump may require adding or removing skip entries here.
+
 [[bans.skip]]
 name = "windows-sys"
 version = "0.45"
-reason = "jni v0.21.1 (via rustls-platform-verifier/reqwest) requires windows-sys 0.45; the majority of the crate graph uses windows-sys 0.61. Blocked by jni not yet releasing with windows-sys 0.6x support."
+reason = "jni v0.21.1 (via rustls-platform-verifier/reqwest) requires windows-sys 0.45; ring requires 0.52, keyring windows-native requires 0.60, and the broad graph (clap/tokio/reqwest) requires 0.61. Four semver-incompatible 0.x versions; 0.45/0.60/0.61 are skipped, leaving 0.52.0 (ring) as the canonical un-skipped version."
 
 [[bans.skip]]
 name = "windows-sys"
 version = "0.60"
-reason = "keyring v3.6.3 windows-native feature requires windows-sys 0.60 (Win32_Security_Credentials); jni (via rustls-platform-verifier) requires 0.45 and the broad graph (clap/tokio/reqwest) requires 0.61. Three semver-incompatible 0.x majors; unification blocked upstream until keyring bumps windows-sys."
+reason = "keyring v3.6.3 windows-native feature requires windows-sys 0.60 (Win32_Security_Credentials); jni requires 0.45, ring requires 0.52, and the broad graph (clap/tokio/reqwest) requires 0.61. Four semver-incompatible 0.x versions; 0.45/0.60/0.61 are skipped, leaving 0.52.0 (ring) as the canonical un-skipped version. Unification blocked upstream until keyring bumps windows-sys."
 
 [[bans.skip]]
 name = "windows-sys"
 version = "0.61"
-reason = "clap, tokio, reqwest and most of the dependency graph use windows-sys 0.61; jni 0.21.1 requires 0.45. Dual version is unavoidable until jni upgrades."
+reason = "clap, tokio, reqwest and most of the dependency graph use windows-sys 0.61; jni 0.21.1 requires 0.45, ring requires 0.52, and keyring windows-native requires 0.60. Four semver-incompatible 0.x versions; 0.45/0.60/0.61 are skipped, leaving 0.52.0 (ring) as the canonical un-skipped version. Unification blocked until jni and keyring upgrade."
 
 # windows-targets and windows_* arch crates: transitive sub-deps of windows-sys.
 # S-WIN-3 adds 17 entries total (1 windows-sys 0.60 + 2 windows-targets + 14 = 7 arch crates × 2 tiers):

--- a/deny.toml
+++ b/deny.toml
@@ -139,11 +139,19 @@ version = "0.61"
 reason = "clap, tokio, reqwest and most of the dependency graph use windows-sys 0.61; jni 0.21.1 requires 0.45. Dual version is unavoidable until jni upgrades."
 
 # windows-targets and windows_* arch crates: transitive sub-deps of windows-sys.
-# windows-sys 0.45 (via jni) pulls windows-targets 0.42.2 and windows_* 0.42.2;
-# windows-sys 0.52 (via ring) pulls windows-targets 0.52.6 and windows_* 0.52.6;
-# windows-sys 0.60 (via keyring v3.6.3 windows-native) pulls windows-targets 0.53.5
-# and windows_* 0.53.1. These are unavoidable until jni and keyring converge on the
-# same windows-sys version. (S-WIN-3, C-V2(b) research finding)
+# S-WIN-3 adds 17 entries total (1 windows-sys 0.60 + 2 windows-targets + 14 = 7 arch crates × 2 tiers):
+#   windows-sys 0.45 (via jni) pulls windows-targets 0.42.2 and windows_* 0.42.2;
+#   windows-sys 0.52 (via ring) pulls windows-targets 0.52.6 and windows_* 0.52.6;
+#   windows-sys 0.60 (via keyring v3.6.3 windows-native) pulls windows-targets 0.53.5
+#   and windows_* 0.53.1. These are unavoidable until jni and keyring converge on the
+#   same windows-sys version. (S-WIN-3, C-V2(b) research finding)
+#
+# The 7 skipped arch crates are: windows_aarch64_gnullvm, windows_aarch64_msvc,
+# windows_i686_gnu, windows_i686_msvc, windows_x86_64_gnu, windows_x86_64_gnullvm,
+# windows_x86_64_msvc. windows_i686_gnullvm is deliberately NOT skipped: it exists
+# in Cargo.lock only at 0.52.6 and 0.53.1 (the i686-gnullvm stub did not exist in
+# the windows 0.42 generation), so only two versions are present and cargo-deny
+# requires no skip — skipping either would produce an `unmatched-skip` error.
 #
 # Why no `[[bans.skip]]` for windows-targets/windows_* version "0.52"?
 #
@@ -158,6 +166,14 @@ reason = "clap, tokio, reqwest and most of the dependency graph use windows-sys 
 # A future reviewer should NOT add a 0.52 skip; doing so would produce an
 # `unnecessary-skip` warning and is semantically wrong — 0.52.6 is the canonical
 # un-skipped version by design.
+#
+# Maintenance caveat (F-WIN3-RC-103): this skip set is correct for the CURRENT
+# dependency topology. A future dep bump that changes the windows-sys/windows-targets
+# version set (e.g. ring updating its windows-sys minor, or jni dropping 0.45, or a
+# new lineage being added) could leave zero canonical un-skipped versions
+# (→ unnecessary-skip warnings) or introduce a new un-skipped duplicate
+# (→ multiple-versions error). The guard is `cargo deny check` in CI; there is no
+# separate canonical-version invariant test (process-gap tracked by orchestrator).
 
 [[bans.skip]]
 name = "windows-targets"

--- a/deny.toml
+++ b/deny.toml
@@ -130,8 +130,99 @@ reason = "jni v0.21.1 (via rustls-platform-verifier/reqwest) requires windows-sy
 
 [[bans.skip]]
 name = "windows-sys"
+version = "0.60"
+reason = "keyring v3.6.3 windows-native feature requires windows-sys 0.60 (Win32_Security_Credentials); jni (via rustls-platform-verifier) requires 0.45 and the broad graph (clap/tokio/reqwest) requires 0.61. Three semver-incompatible 0.x majors; unification blocked upstream until keyring bumps windows-sys."
+
+[[bans.skip]]
+name = "windows-sys"
 version = "0.61"
 reason = "clap, tokio, reqwest and most of the dependency graph use windows-sys 0.61; jni 0.21.1 requires 0.45. Dual version is unavoidable until jni upgrades."
+
+# windows-targets and windows_* arch crates: transitive sub-deps of windows-sys.
+# windows-sys 0.45 (via jni) pulls windows-targets 0.42.2 and windows_* 0.42.2;
+# windows-sys 0.60 (via keyring v3.6.3 windows-native) pulls windows-targets 0.53.5
+# and windows_* 0.53.1. These are unavoidable until jni and keyring converge on the
+# same windows-sys version. (S-WIN-3, C-V2(b) research finding)
+
+[[bans.skip]]
+name = "windows-targets"
+version = "0.42"
+reason = "transitive sub-dep of windows-sys 0.45 (via jni/rustls-platform-verifier); windows-sys 0.60 (via keyring windows-native) pulls windows-targets 0.53.5. Unavoidable until jni and keyring converge on the same windows-sys version."
+
+[[bans.skip]]
+name = "windows-targets"
+version = "0.53"
+reason = "transitive sub-dep of windows-sys 0.60 (via keyring v3.6.3 windows-native); windows-sys 0.45 (via jni) pulls windows-targets 0.42.2. Unavoidable until jni and keyring converge on the same windows-sys version."
+
+[[bans.skip]]
+name = "windows_aarch64_gnullvm"
+version = "0.42"
+reason = "transitive arch crate for windows-targets 0.42.2 (via windows-sys 0.45/jni); windows-sys 0.60 (via keyring windows-native) pulls 0.53.1. Unavoidable until jni and keyring converge on the same windows-sys version."
+
+[[bans.skip]]
+name = "windows_aarch64_gnullvm"
+version = "0.53"
+reason = "transitive arch crate for windows-targets 0.53.5 (via windows-sys 0.60/keyring windows-native); windows-sys 0.45 (via jni) pulls 0.42.2. Unavoidable until jni and keyring converge on the same windows-sys version."
+
+[[bans.skip]]
+name = "windows_aarch64_msvc"
+version = "0.42"
+reason = "transitive arch crate for windows-targets 0.42.2 (via windows-sys 0.45/jni); windows-sys 0.60 (via keyring windows-native) pulls 0.53.1. Unavoidable until jni and keyring converge on the same windows-sys version."
+
+[[bans.skip]]
+name = "windows_aarch64_msvc"
+version = "0.53"
+reason = "transitive arch crate for windows-targets 0.53.5 (via windows-sys 0.60/keyring windows-native); windows-sys 0.45 (via jni) pulls 0.42.2. Unavoidable until jni and keyring converge on the same windows-sys version."
+
+[[bans.skip]]
+name = "windows_i686_gnu"
+version = "0.42"
+reason = "transitive arch crate for windows-targets 0.42.2 (via windows-sys 0.45/jni); windows-sys 0.60 (via keyring windows-native) pulls 0.53.1. Unavoidable until jni and keyring converge on the same windows-sys version."
+
+[[bans.skip]]
+name = "windows_i686_gnu"
+version = "0.53"
+reason = "transitive arch crate for windows-targets 0.53.5 (via windows-sys 0.60/keyring windows-native); windows-sys 0.45 (via jni) pulls 0.42.2. Unavoidable until jni and keyring converge on the same windows-sys version."
+
+[[bans.skip]]
+name = "windows_i686_msvc"
+version = "0.42"
+reason = "transitive arch crate for windows-targets 0.42.2 (via windows-sys 0.45/jni); windows-sys 0.60 (via keyring windows-native) pulls 0.53.1. Unavoidable until jni and keyring converge on the same windows-sys version."
+
+[[bans.skip]]
+name = "windows_i686_msvc"
+version = "0.53"
+reason = "transitive arch crate for windows-targets 0.53.5 (via windows-sys 0.60/keyring windows-native); windows-sys 0.45 (via jni) pulls 0.42.2. Unavoidable until jni and keyring converge on the same windows-sys version."
+
+[[bans.skip]]
+name = "windows_x86_64_gnu"
+version = "0.42"
+reason = "transitive arch crate for windows-targets 0.42.2 (via windows-sys 0.45/jni); windows-sys 0.60 (via keyring windows-native) pulls 0.53.1. Unavoidable until jni and keyring converge on the same windows-sys version."
+
+[[bans.skip]]
+name = "windows_x86_64_gnu"
+version = "0.53"
+reason = "transitive arch crate for windows-targets 0.53.5 (via windows-sys 0.60/keyring windows-native); windows-sys 0.45 (via jni) pulls 0.42.2. Unavoidable until jni and keyring converge on the same windows-sys version."
+
+[[bans.skip]]
+name = "windows_x86_64_gnullvm"
+version = "0.42"
+reason = "transitive arch crate for windows-targets 0.42.2 (via windows-sys 0.45/jni); windows-sys 0.60 (via keyring windows-native) pulls 0.53.1. Unavoidable until jni and keyring converge on the same windows-sys version."
+
+[[bans.skip]]
+name = "windows_x86_64_gnullvm"
+version = "0.53"
+reason = "transitive arch crate for windows-targets 0.53.5 (via windows-sys 0.60/keyring windows-native); windows-sys 0.45 (via jni) pulls 0.42.2. Unavoidable until jni and keyring converge on the same windows-sys version."
+
+[[bans.skip]]
+name = "windows_x86_64_msvc"
+version = "0.42"
+reason = "transitive arch crate for windows-targets 0.42.2 (via windows-sys 0.45/jni); windows-sys 0.60 (via keyring windows-native) pulls 0.53.1. Unavoidable until jni and keyring converge on the same windows-sys version."
+
+[[bans.skip]]
+name = "windows_x86_64_msvc"
+version = "0.53"
+reason = "transitive arch crate for windows-targets 0.53.5 (via windows-sys 0.60/keyring windows-native); windows-sys 0.45 (via jni) pulls 0.42.2. Unavoidable until jni and keyring converge on the same windows-sys version."
 
 [[bans.skip]]
 name = "winnow"

--- a/tests/keyring_windows_native_feature_present.rs
+++ b/tests/keyring_windows_native_feature_present.rs
@@ -1,0 +1,113 @@
+//! Red-Gate tests for S-WIN-3: keyring `windows-native` feature and deny.toml compatibility.
+//!
+//! These are source-text assertion tests (manifest grepping) that pin two acceptance criteria:
+//!
+//! - AC-001: `Cargo.toml` lists `windows-native` in the keyring features array.
+//! - AC-002: `deny.toml` contains a `[[bans.skip]]` entry for `windows-sys` version `"0.60"`.
+//!
+//! Pattern mirrors `tests/base_url_release_gate.rs` (source-text assertions).
+//! Neither test executes Credential Manager code — they assert manifest content only.
+//!
+//! # Why these tests exist
+//!
+//! keyring v3.6.3 with `windows-native` pulls `windows-sys = "0.60"` as a transitive
+//! dependency (C-V2(b), `.factory/research/windows-build-f4-preflight-verification.md`).
+//! The project's `deny.toml` sets `bans.multiple-versions = "deny"`. The existing skips
+//! cover only `windows-sys` 0.45 and 0.61; adding `windows-native` WITHOUT a 0.60 skip
+//! causes `cargo deny check` to fail. Both manifest changes MUST land in the same commit.
+//!
+//! # Test inventory
+//!
+//! | Test | AC | What it pins |
+//! |------|----|--------------|
+//! | `test_keyring_has_windows_native_feature` | AC-001 | `"windows-native"` present in keyring features in `Cargo.toml` |
+//! | `test_deny_toml_has_windows_sys_0_60_skip` | AC-002 | `[[bans.skip]]` for `windows-sys` version `"0.60"` present in `deny.toml` |
+
+/// AC-001 — `Cargo.toml` lists `windows-native` in the keyring features array.
+///
+/// Confirms the keyring dependency declaration includes `"windows-native"` alongside
+/// the existing `"apple-native"` and `"linux-native"` features (ADR-0016 §Decision 5b).
+///
+/// Strategy: load `Cargo.toml` at compile time via `include_str!`, locate the keyring
+/// dependency line, and verify `"windows-native"` appears in it.
+#[test]
+fn test_keyring_has_windows_native_feature() {
+    let cargo_toml = include_str!("../Cargo.toml");
+
+    // Find the keyring dependency line(s). It may be a multi-line table entry but the
+    // feature list is on a single line (inline array). We look for the line that declares
+    // the keyring dep and contains the features key.
+    let keyring_line = cargo_toml
+        .lines()
+        .find(|l| l.contains("keyring") && l.contains("features"))
+        .expect(
+            "Could not locate a `keyring` dependency line with `features` in Cargo.toml. \
+             Has the keyring dep been restructured? Update this test if the format changed.",
+        );
+
+    assert!(
+        keyring_line.contains("\"windows-native\""),
+        "S-WIN-3 AC-001 VIOLATION: `\"windows-native\"` not found in the keyring features \
+         declaration in Cargo.toml.\n\
+         Expected: `keyring = {{ version = \"3\", features = [..., \"windows-native\"] }}`\n\
+         Found line: {keyring_line}\n\
+         The `windows-native` feature enables Windows Credential Manager backend via keyring v3.6.3 \
+         (ADR-0016 §Decision 5b). All three platform features — apple-native, linux-native, \
+         windows-native — must be listed so the Windows release build links correctly.",
+    );
+}
+
+/// AC-002 — `deny.toml` contains a `[[bans.skip]]` entry for `windows-sys` version `"0.60"`.
+///
+/// Confirms the required skip entry is present alongside the existing 0.45 and 0.61 skips.
+/// Without this skip, adding `windows-native` to keyring features causes `cargo deny check`
+/// to fail: keyring v3.6.3 pulls `windows-sys 0.60`, which is semver-incompatible with
+/// the existing 0.45 (jni) and 0.61 (clap/tokio/reqwest) under 0.x semantics
+/// (C-V2(b) BLOCKER finding, `.factory/research/windows-build-f4-preflight-verification.md`).
+///
+/// Strategy: load `deny.toml` at compile time via `include_str!` and verify that both
+/// `name = "windows-sys"` and `version = "0.60"` appear in adjacent lines within the file,
+/// indicating a `[[bans.skip]]` block for exactly this version exists.
+#[test]
+fn test_deny_toml_has_windows_sys_0_60_skip() {
+    let deny_toml = include_str!("../deny.toml");
+
+    // Locate a `[[bans.skip]]` block that covers windows-sys 0.60.
+    // We scan the file in a sliding window: within any 5-line window,
+    // both `name = "windows-sys"` and `version = "0.60"` must co-appear.
+    // This is structurally equivalent to the existing 0.45 and 0.61 entries.
+    let lines: Vec<&str> = deny_toml.lines().collect();
+
+    let found = lines.windows(5).any(|window| {
+        let has_windows_sys_name = window.iter().any(|l| l.contains(r#"name = "windows-sys""#));
+        let has_version_0_60 = window.iter().any(|l| l.contains(r#"version = "0.60""#));
+        has_windows_sys_name && has_version_0_60
+    });
+
+    assert!(
+        found,
+        "S-WIN-3 AC-002 VIOLATION: No `[[bans.skip]]` entry for `windows-sys` version `\"0.60\"` \
+         found in deny.toml.\n\
+         \n\
+         This skip is REQUIRED (not conditional) because keyring v3.6.3 with the `windows-native` \
+         feature pulls `windows-sys = \"0.60\"` as a transitive dep (C-V2(b) BLOCKER, research \
+         verification file: .factory/research/windows-build-f4-preflight-verification.md).\n\
+         \n\
+         With `bans.multiple-versions = \"deny\"` active and three semver-incompatible 0.x versions \
+         in the graph (0.45 from jni, 0.60 from keyring windows-native, 0.61 from clap/tokio/reqwest), \
+         `cargo deny check` will fail until this skip entry is added.\n\
+         \n\
+         The required entry (add alongside existing 0.45 and 0.61 skips):\n\
+         \n\
+         [[bans.skip]]\n\
+         name = \"windows-sys\"\n\
+         version = \"0.60\"\n\
+         reason = \"keyring v3.6.3 windows-native feature requires windows-sys 0.60 \
+(Win32_Security_Credentials); jni (via rustls-platform-verifier) requires 0.45 and the broad \
+graph (clap/tokio/reqwest) requires 0.61. Three semver-incompatible 0.x majors; unification \
+blocked upstream until keyring bumps windows-sys.\"\n\
+         \n\
+         This change MUST be committed in the same commit as the `windows-native` feature \
+         addition to Cargo.toml (S-WIN-3 File Structure Requirements).",
+    );
+}

--- a/tests/keyring_windows_native_feature_present.rs
+++ b/tests/keyring_windows_native_feature_present.rs
@@ -1,27 +1,79 @@
 //! Red-Gate tests for S-WIN-3: keyring `windows-native` feature and deny.toml compatibility.
 //!
-//! These are source-text assertion tests (manifest grepping) that pin two acceptance criteria:
+//! These are source-text assertion tests (manifest grepping) that pin three acceptance criteria:
 //!
 //! - AC-001: `Cargo.toml` lists `windows-native` in the keyring features array.
-//! - AC-002: `deny.toml` contains a `[[bans.skip]]` entry for `windows-sys` version `"0.60"`.
+//! - AC-002: `deny.toml` contains `[[bans.skip]]` blocks for `windows-sys` 0.60,
+//!   `windows-targets` 0.53, and at least one `windows_*` arch crate at 0.53.
 //!
 //! Pattern mirrors `tests/base_url_release_gate.rs` (source-text assertions).
 //! Neither test executes Credential Manager code — they assert manifest content only.
 //!
 //! # Why these tests exist
 //!
-//! keyring v3.6.3 with `windows-native` pulls `windows-sys = "0.60"` as a transitive
-//! dependency (C-V2(b), `.factory/research/windows-build-f4-preflight-verification.md`).
-//! The project's `deny.toml` sets `bans.multiple-versions = "deny"`. The existing skips
-//! cover only `windows-sys` 0.45 and 0.61; adding `windows-native` WITHOUT a 0.60 skip
-//! causes `cargo deny check` to fail. Both manifest changes MUST land in the same commit.
+//! keyring v3.6.3 with `windows-native` pulls `windows-sys = "0.60"` and its transitive
+//! arch crates (`windows-targets 0.53.5`, `windows_x86_64_msvc 0.53.1`, etc.) as
+//! transitive dependencies (C-V2(b), `.factory/research/windows-build-f4-preflight-verification.md`).
+//! The project's `deny.toml` sets `bans.multiple-versions = "deny"`. Without the 0.60 skip
+//! AND the transitive 0.53 skips, `cargo deny check` fails. All manifest changes MUST land
+//! in the same commit.
+//!
+//! # How AC-002 assertions work (F-104)
+//!
+//! Each skip assertion parses `deny.toml` into discrete `[[bans.skip]]` blocks and requires
+//! that the target name and version co-appear **within the same block**. This avoids a
+//! false-positive that a 5-line sliding-window approach could produce when two adjacent,
+//! unrelated `[[bans.skip]]` blocks happen to straddle a window boundary.
 //!
 //! # Test inventory
 //!
 //! | Test | AC | What it pins |
 //! |------|----|--------------|
 //! | `test_keyring_has_windows_native_feature` | AC-001 | `"windows-native"` present in keyring features in `Cargo.toml` |
-//! | `test_deny_toml_has_windows_sys_0_60_skip` | AC-002 | `[[bans.skip]]` for `windows-sys` version `"0.60"` present in `deny.toml` |
+//! | `test_deny_toml_has_windows_sys_0_60_skip` | AC-002 | `[[bans.skip]]` block for `windows-sys` version `"0.60"` in `deny.toml` |
+//! | `test_deny_toml_has_windows_targets_0_53_skip` | AC-002 | `[[bans.skip]]` block for `windows-targets` version `"0.53"` in `deny.toml` |
+//! | `test_deny_toml_has_windows_arch_0_53_skip` | AC-002 | at least one `[[bans.skip]]` block for a `windows_*` arch crate at version `"0.53"` in `deny.toml` |
+
+/// Parse `deny.toml` text into a `Vec` of individual `[[bans.skip]]` block texts.
+///
+/// Each element in the returned `Vec` is the raw text of one `[[bans.skip]]` block,
+/// spanning from (and including) the `[[bans.skip]]` header line up to (but not
+/// including) the next `[[bans.skip]]` header or end-of-file. Comment lines inside
+/// a block are included as-is so that callers can search the full block text.
+fn parse_bans_skip_blocks(deny_toml: &str) -> Vec<String> {
+    let mut blocks: Vec<String> = Vec::new();
+    let mut current: Option<String> = None;
+
+    for line in deny_toml.lines() {
+        if line.trim() == "[[bans.skip]]" {
+            // Flush any previous block.
+            if let Some(block) = current.take() {
+                blocks.push(block);
+            }
+            current = Some(String::from("[[bans.skip]]\n"));
+        } else if let Some(ref mut block) = current {
+            block.push_str(line);
+            block.push('\n');
+        }
+    }
+    // Flush the last block.
+    if let Some(block) = current {
+        blocks.push(block);
+    }
+    blocks
+}
+
+/// Return `true` if any `[[bans.skip]]` block in `blocks` contains BOTH `name_needle`
+/// and `version_needle` (both matched as substrings within the same block).
+fn block_contains_name_and_version(
+    blocks: &[String],
+    name_needle: &str,
+    version_needle: &str,
+) -> bool {
+    blocks
+        .iter()
+        .any(|block| block.contains(name_needle) && block.contains(version_needle))
+}
 
 /// AC-001 — `Cargo.toml` lists `windows-native` in the keyring features array.
 ///
@@ -57,7 +109,7 @@ fn test_keyring_has_windows_native_feature() {
     );
 }
 
-/// AC-002 — `deny.toml` contains a `[[bans.skip]]` entry for `windows-sys` version `"0.60"`.
+/// AC-002 (windows-sys 0.60) — `deny.toml` has a `[[bans.skip]]` block for `windows-sys` 0.60.
 ///
 /// Confirms the required skip entry is present alongside the existing 0.45 and 0.61 skips.
 /// Without this skip, adding `windows-native` to keyring features causes `cargo deny check`
@@ -65,49 +117,125 @@ fn test_keyring_has_windows_native_feature() {
 /// the existing 0.45 (jni) and 0.61 (clap/tokio/reqwest) under 0.x semantics
 /// (C-V2(b) BLOCKER finding, `.factory/research/windows-build-f4-preflight-verification.md`).
 ///
-/// Strategy: load `deny.toml` at compile time via `include_str!` and verify that both
-/// `name = "windows-sys"` and `version = "0.60"` appear in adjacent lines within the file,
-/// indicating a `[[bans.skip]]` block for exactly this version exists.
+/// Strategy: parse `deny.toml` into discrete `[[bans.skip]]` blocks and require that
+/// `name = "windows-sys"` and `version = "0.60"` co-appear **within the same block**.
+/// This prevents a false-positive across adjacent unrelated blocks (F-104).
 #[test]
 fn test_deny_toml_has_windows_sys_0_60_skip() {
     let deny_toml = include_str!("../deny.toml");
+    let blocks = parse_bans_skip_blocks(deny_toml);
 
-    // Locate a `[[bans.skip]]` block that covers windows-sys 0.60.
-    // We scan the file in a sliding window: within any 5-line window,
-    // both `name = "windows-sys"` and `version = "0.60"` must co-appear.
-    // This is structurally equivalent to the existing 0.45 and 0.61 entries.
-    let lines: Vec<&str> = deny_toml.lines().collect();
-
-    let found = lines.windows(5).any(|window| {
-        let has_windows_sys_name = window.iter().any(|l| l.contains(r#"name = "windows-sys""#));
-        let has_version_0_60 = window.iter().any(|l| l.contains(r#"version = "0.60""#));
-        has_windows_sys_name && has_version_0_60
-    });
+    let found =
+        block_contains_name_and_version(&blocks, r#"name = "windows-sys""#, r#"version = "0.60""#);
 
     assert!(
         found,
-        "S-WIN-3 AC-002 VIOLATION: No `[[bans.skip]]` entry for `windows-sys` version `\"0.60\"` \
+        "S-WIN-3 AC-002 VIOLATION: No `[[bans.skip]]` block for `windows-sys` version `\"0.60\"` \
          found in deny.toml.\n\
          \n\
-         This skip is REQUIRED (not conditional) because keyring v3.6.3 with the `windows-native` \
-         feature pulls `windows-sys = \"0.60\"` as a transitive dep (C-V2(b) BLOCKER, research \
-         verification file: .factory/research/windows-build-f4-preflight-verification.md).\n\
+         This skip is REQUIRED because keyring v3.6.3 with the `windows-native` feature pulls \
+         `windows-sys = \"0.60\"` as a transitive dep (C-V2(b) BLOCKER, research verification \
+         file: .factory/research/windows-build-f4-preflight-verification.md).\n\
          \n\
-         With `bans.multiple-versions = \"deny\"` active and three semver-incompatible 0.x versions \
-         in the graph (0.45 from jni, 0.60 from keyring windows-native, 0.61 from clap/tokio/reqwest), \
-         `cargo deny check` will fail until this skip entry is added.\n\
+         With `bans.multiple-versions = \"deny\"` active and three semver-incompatible 0.x \
+         versions in the graph (0.45 from jni, 0.60 from keyring windows-native, 0.61 from \
+         clap/tokio/reqwest), `cargo deny check` will fail until this skip entry is added.\n\
          \n\
          The required entry (add alongside existing 0.45 and 0.61 skips):\n\
          \n\
          [[bans.skip]]\n\
          name = \"windows-sys\"\n\
          version = \"0.60\"\n\
-         reason = \"keyring v3.6.3 windows-native feature requires windows-sys 0.60 \
-(Win32_Security_Credentials); jni (via rustls-platform-verifier) requires 0.45 and the broad \
-graph (clap/tokio/reqwest) requires 0.61. Three semver-incompatible 0.x majors; unification \
-blocked upstream until keyring bumps windows-sys.\"\n\
+         reason = \"...\"\n\
          \n\
          This change MUST be committed in the same commit as the `windows-native` feature \
          addition to Cargo.toml (S-WIN-3 File Structure Requirements).",
+    );
+}
+
+/// AC-002 (windows-targets 0.53) — `deny.toml` has a `[[bans.skip]]` block for
+/// `windows-targets` version `"0.53"`.
+///
+/// `windows-sys 0.60` (via keyring windows-native) transitively pulls `windows-targets 0.53.5`.
+/// Without this skip, `cargo deny check` fails because `windows-targets` appears at three
+/// semver-incompatible versions (0.42 from jni, 0.52 from ring, 0.53 from keyring windows-native).
+/// cargo-deny requires N-1 versions skipped; 0.42 and 0.53 are skipped, leaving 0.52.6 as
+/// the single canonical un-skipped version.
+///
+/// If this skip is dropped, `cargo deny check` fails but AC-002's windows-sys assertion
+/// remains green — this test closes that gap (F-103).
+///
+/// Strategy: same block-boundary parsing as `test_deny_toml_has_windows_sys_0_60_skip` (F-104).
+#[test]
+fn test_deny_toml_has_windows_targets_0_53_skip() {
+    let deny_toml = include_str!("../deny.toml");
+    let blocks = parse_bans_skip_blocks(deny_toml);
+
+    let found = block_contains_name_and_version(
+        &blocks,
+        r#"name = "windows-targets""#,
+        r#"version = "0.53""#,
+    );
+
+    assert!(
+        found,
+        "S-WIN-3 AC-002 VIOLATION: No `[[bans.skip]]` block for `windows-targets` \
+         version `\"0.53\"` found in deny.toml.\n\
+         \n\
+         `windows-sys 0.60` (via keyring v3.6.3 windows-native) transitively pulls \
+         `windows-targets 0.53.5`. With three versions in Cargo.lock (0.42 from jni, \
+         0.52 from ring, 0.53 from keyring), the 0.42 and 0.53 skips are load-bearing: \
+         they leave 0.52.6 as the single canonical un-skipped version. Removing the 0.53 \
+         skip causes `cargo deny check` to fail (two un-skipped versions remain: 0.52 + 0.53).\n\
+         \n\
+         Required entry:\n\
+         \n\
+         [[bans.skip]]\n\
+         name = \"windows-targets\"\n\
+         version = \"0.53\"\n\
+         reason = \"...\"",
+    );
+}
+
+/// AC-002 (windows_* arch crates 0.53) — `deny.toml` has at least one `[[bans.skip]]`
+/// block for a `windows_*` arch crate at version `"0.53"` (e.g. `windows_x86_64_msvc`).
+///
+/// `windows-targets 0.53.5` (via keyring windows-native) pulls per-arch stub crates such as
+/// `windows_x86_64_msvc 0.53.1`, `windows_aarch64_msvc 0.53.1`, etc. Without these skips,
+/// `cargo deny check` fails for each arch crate individually. This test asserts the
+/// most commonly-built arch crate (`windows_x86_64_msvc`) is covered, which is sufficient
+/// to confirm the 0.53 arch-crate skip pattern is in place.
+///
+/// Strategy: same block-boundary parsing as the other AC-002 tests (F-104).
+#[test]
+fn test_deny_toml_has_windows_arch_0_53_skip() {
+    let deny_toml = include_str!("../deny.toml");
+    let blocks = parse_bans_skip_blocks(deny_toml);
+
+    // Check that windows_x86_64_msvc 0.53 (the canonical x64 MSVC arch crate) is skipped.
+    // If the 0.53 arch-crate skip pattern is present, this representative crate will be covered.
+    let found = block_contains_name_and_version(
+        &blocks,
+        r#"name = "windows_x86_64_msvc""#,
+        r#"version = "0.53""#,
+    );
+
+    assert!(
+        found,
+        "S-WIN-3 AC-002 VIOLATION: No `[[bans.skip]]` block for `windows_x86_64_msvc` \
+         version `\"0.53\"` found in deny.toml.\n\
+         \n\
+         `windows-targets 0.53.5` (via keyring v3.6.3 windows-native) pulls per-arch stub \
+         crates including `windows_x86_64_msvc 0.53.1`. Each arch crate appears at three \
+         versions (0.42 from jni, 0.52 from ring, 0.53 from keyring); the 0.42 and 0.53 \
+         skips are load-bearing. Removing them causes `cargo deny check` to fail for each \
+         arch crate individually.\n\
+         \n\
+         Required entry (representative — all arch crates need equivalent skips):\n\
+         \n\
+         [[bans.skip]]\n\
+         name = \"windows_x86_64_msvc\"\n\
+         version = \"0.53\"\n\
+         reason = \"...\"",
     );
 }


### PR DESCRIPTION
## Summary

- Adds `"windows-native"` to the `keyring` features list in `Cargo.toml`, enabling the Windows Credential Manager backend (required for `jr auth login` to persist credentials on Windows targets).
- Adds 17 `[[bans.skip]]` entries to `deny.toml` — the full transitive skip set required when `keyring v3.6.3 windows-native` pulls `windows-sys 0.60`, which in turn pulls `windows-targets 0.53.5` and 7 per-arch stub crates at version 0.53.1.
- The deny scope was an implementation discovery (spec estimated 1 entry; actual count is 17). The formula is `1 + 2×(1+7) = 17`: one `windows-sys 0.60` skip plus two tiers (0.42 + 0.53) each for `windows-targets` and the 7 arch crates. The 0.52.6 tier is left as the single canonical un-skipped version (N-1 rule). No `src/` changes.

## Architecture Changes

```mermaid
graph TD
    A[Cargo.toml] -->|adds windows-native| B[keyring v3.6.3]
    B -->|pulls| C[windows-sys 0.60]
    C -->|pulls| D[windows-targets 0.53.5]
    D -->|pulls| E[windows_aarch64_gnullvm 0.53.1]
    D -->|pulls| F[windows_aarch64_msvc 0.53.1]
    D -->|pulls| G[windows_i686_gnu 0.53.1]
    D -->|pulls| H[windows_i686_msvc 0.53.1]
    D -->|pulls| I[windows_x86_64_gnu 0.53.1]
    D -->|pulls| J[windows_x86_64_gnullvm 0.53.1]
    D -->|pulls| K[windows_x86_64_msvc 0.53.1]
    L[deny.toml] -->|17 skip entries| C
    L -->|skip 0.42+0.53| D
    L -->|skip 0.42+0.53 each| E
    L -->|skip 0.42+0.53 each| F
    L -->|skip 0.42+0.53 each| G
    L -->|skip 0.42+0.53 each| H
    L -->|skip 0.42+0.53 each| I
    L -->|skip 0.42+0.53 each| J
    L -->|skip 0.42+0.53 each| K
```

**No source code changes.** `keyring` selects its backend via Cargo features; the platform switch is cfg-gated inside keyring's own source.

## Story Dependencies

```mermaid
graph LR
    SWIN3[S-WIN-3 this PR] -->|blocks| SWIN4[S-WIN-4 release matrix]
    SWIN3 -->|used by| SWIN5[S-WIN-5 windows CI job]
    SWIN1[S-WIN-1 config isolation] -.->|independent| SWIN3
    SWIN2[S-WIN-2 JR_CONFIG_DIR seam] -.->|independent| SWIN3
```

`depends_on: []` — no upstream dependencies. Blocks S-WIN-4 (release matrix needs `windows-native` to link the Windows binary).

## Spec Traceability

```mermaid
flowchart LR
    NFR[NFR-P-W1\nWindows cred persistence] --> AC1[AC-001\nCargo.toml has windows-native]
    NFR --> AC2[AC-002\ndeny.toml skip set + cargo deny EXIT 0]
    ADR[ADR-0016 Decision 5b\nAll 3 platform features listed] --> AC1
    RW1[R-W1 risk mitigation\nC-V2b BLOCKER finding] --> AC2
    AC1 --> T1[test_keyring_has_windows_native_feature\nCargo.toml source-text grep]
    AC2 --> T2[test_deny_toml_has_windows_sys_0_60_skip]
    AC2 --> T3[test_deny_toml_has_windows_targets_0_53_skip]
    AC2 --> T4[test_deny_toml_has_windows_arch_0_53_skip]
    AC2 --> CI[CI deny job\ncargo deny check EXIT 0]
```

## Acceptance Criteria

| AC | Description | Verification |
|----|-------------|-------------|
| AC-001 | `Cargo.toml` has `windows-native` in keyring features | `test_keyring_has_windows_native_feature` (source-text grep) |
| AC-002 | `deny.toml` has full 17-entry skip set; `cargo deny check` exits 0 | 3 new tests + CI `deny` job |
| AC-003 | Windows release build succeeds | Validated by S-WIN-4 release matrix |
| AC-004 | macOS and Linux builds unaffected | Existing CI ubuntu-latest + macos-latest jobs |

## Test Evidence

| Test | File | AC | Result |
|------|------|----|--------|
| `test_keyring_has_windows_native_feature` | `tests/keyring_windows_native_feature_present.rs` | AC-001 | PASS |
| `test_deny_toml_has_windows_sys_0_60_skip` | `tests/keyring_windows_native_feature_present.rs` | AC-002 | PASS |
| `test_deny_toml_has_windows_targets_0_53_skip` | `tests/keyring_windows_native_feature_present.rs` | AC-002 | PASS |
| `test_deny_toml_has_windows_arch_0_53_skip` | `tests/keyring_windows_native_feature_present.rs` | AC-002 | PASS |

- `cargo test --test keyring_windows_native_feature_present`: 4/4 PASS
- `cargo test --lib`: PASS (no regressions)
- `cargo clippy -- -D warnings`: CLEAN
- `cargo fmt --all -- --check`: CLEAN
- `cargo deny check`: EXIT 0

## Deny Scope Discovery Note (Implementation Finding)

The original spec estimated 1 skip entry for `windows-sys 0.60`. Implementation confirmed the actual transitive fan-out requires **17 entries** (F-WIN3-IMPL-102 / architecture-delta §5.3 / ADR-0016 Decision 5b scope correction / PG-WIN3-001 / F-WIN3-RA-101):

- `windows-sys 0.60` — 1 entry
- `windows-targets {0.42, 0.53}` — 2 entries
- 7 arch crates × {0.42, 0.53} — 14 entries

Formula: `1 + 2×(1+7) = 17`. `windows_i686_gnullvm` is correctly omitted — it has no 0.42 tier in Cargo.lock (only 0.52.6 + 0.53.1), so no skip is required. The canonical un-skipped version for `windows-targets` and each arch crate is 0.52.6 (via ring → windows-sys 0.52.0).

The spec was reconciled; deny.toml carries explanatory comments documenting the N-1 logic for both `windows-sys` (4 versions, 0.52.0 ring canonical) and `windows-targets`/arch crates (3 versions, 0.52.6 canonical).

**Tracked LOW item WIN-DENY-FRAGILITY:** The canonical-version invariant (N-1 skips, 0.52.x un-skipped) has no dedicated CI guard beyond `cargo deny check` itself. A future dep bump that shifts the canonical version could leave zero un-skipped versions (unnecessary-skip warnings) or introduce a new duplicate (multiple-versions error). Mitigated by `cargo deny check` running in CI on every PR.

## Adversarial Review Convergence

Per-story adversarial review: **3-clean final** after a spec-reconciliation round + 2 count-correction rounds.

Log: `.factory/cycles/cycle-001/adversarial-reviews/windows-build-f3/S-WIN-3-impl-review.md`

Spec-steward governance: spec-changelog v1.3.12; counts unchanged (BC 597 / Stories 74).

## Demo Evidence

Demo status: **adapted-skip** — this story modifies Cargo manifest and deny configuration only; there is no user-visible behavior change. The backend selection (`windows-native`) is cfg-gated at compile time in keyring's own source; no `src/` files change. CI `cargo deny check` passing is the observable evidence.

## Security Review

No new network calls, authentication flows, cryptographic operations, or privilege escalations. The change enables a compile-time cfg-gated dependency backend. The `windows-native` feature activates Windows Credential Manager (OS-provided secure storage) — this is a security improvement over any insecure fallback, not a new attack surface.

## Risk Assessment

| Dimension | Assessment |
|-----------|-----------|
| Blast radius | Low — manifest-only change; no src/ files modified |
| Platform impact | macOS and Linux: no change (cfg-gated). Windows: enables secure credential storage |
| Dependency surface | 17 new transitive entries in Cargo.lock; all are `windows-sys` subtree crates with well-known provenance |
| Regression risk | `cargo deny check` CI job exercises all-target skip resolution even on ubuntu-latest |
| WIN-DENY-FRAGILITY | LOW — no dedicated canonical-version guard; mitigated by `cargo deny check` in CI |

## AI Pipeline Metadata

| Field | Value |
|-------|-------|
| Pipeline mode | Feature Mode (F-WIN3, Windows build cycle) |
| Story | S-WIN-3 |
| Wave | feature-followup |
| Scope | small (xsmall effort) |
| Story points | 2 |
| Branch | feat/win-3-keyring-windows-native |
| Base | develop |

## Pre-Merge Checklist

- [x] `cargo test` passes (all tests green)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo deny check` exits 0
- [x] AC-001 pinned by source-text test
- [x] AC-002 pinned by 3 source-text tests + CI deny job
- [x] No src/ changes (compile-time feature only)
- [x] Adversarial review: 3-clean final
- [x] Spec-steward governance: spec-changelog v1.3.12 / counts unchanged
- [x] PR description matches diff
- [ ] CI checks passing on GitHub (verify after PR creation — esp. `deny` job on ubuntu-latest)
- [ ] Code owner review
