### PR TITLE
ci(windows): add release-path jr.exe smoke step; harden release.yml guard tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,15 @@ jobs:
         shell: bash
         run: sha256sum jr-${{ github.ref_name }}-${{ matrix.target }}.zip > jr-${{ github.ref_name }}-${{ matrix.target }}.zip.sha256
 
+      - name: Smoke test (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Set-Location "target/${{ matrix.target }}/release"
+          jr.exe --version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Verify embedded OAuth app present
         if: runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,9 +90,13 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $ErrorActionPreference = 'Stop'
+          $ErrorActionPreference = 'Stop'   # Catches Set-Location failure (directory missing)
           Set-Location "target/${{ matrix.target }}/release"
-          jr.exe --version
+          # Use `.\jr.exe` (explicit current-directory prefix) — PowerShell does NOT
+          # search CWD for executables without it, unlike cmd.exe.
+          # NOTE: $ErrorActionPreference does NOT catch non-zero exit from native
+          # executables in PS7; the explicit LASTEXITCODE check below is load-bearing.
+          .\jr.exe --version
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Verify embedded OAuth app present

--- a/src/config.rs
+++ b/src/config.rs
@@ -1697,4 +1697,57 @@ mod tests {
             result.display()
         );
     }
+
+    // -----------------------------------------------------------------------
+    // M-6 — Unix XDG fallback branch coverage (XDG_CONFIG_HOME unset)
+    //
+    // Pins the `else` branch of `global_config_dir()` on Unix: when neither
+    // XDG_CONFIG_HOME nor JR_CONFIG_DIR is set, the function falls back to
+    // `dirs::home_dir().join(".config").join("jr")`.  A refactor that changed
+    // the fallback suffix (e.g. to ".cache/jr") would silently break without
+    // this pin test.
+    // -----------------------------------------------------------------------
+
+    /// M-6 — On Unix, `global_config_dir()` falls back to `~/.config/jr` when
+    /// `XDG_CONFIG_HOME` is unset and `JR_CONFIG_DIR` is absent.
+    ///
+    /// Removes both env vars, calls `global_config_dir()`, and asserts the
+    /// returned path ends with `.config/jr`.  The full prefix is `home_dir()`
+    /// which varies by user, so only the suffix is checked.
+    ///
+    /// Traces: `global_config_dir()` Unix else-branch (`#[cfg(not(windows))]`);
+    /// FIX-F5-001 M-6.
+    #[cfg(not(windows))]
+    #[test]
+    fn test_global_config_dir_falls_back_to_home_config_on_unix_when_xdg_unset() {
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+
+        // SAFETY: ENV_MUTEX is held for the duration; no concurrent env access occurs.
+        // Remove both overrides so the production else-branch fires.
+        // Note: cleanup is not panic-safe (consistent with adjacent R1-003 test);
+        // global_config_dir() on a standard system cannot panic.
+        unsafe {
+            std::env::remove_var("JR_CONFIG_DIR");
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+
+        let result = global_config_dir();
+        drop(_guard);
+
+        // The fallback path must end with ".config/jr" (the Unix default).
+        // We cannot assert the full path (home dir varies), so check the suffix.
+        let result_str = result.to_string_lossy();
+        assert!(
+            result_str.ends_with("/.config/jr"),
+            "M-6: global_config_dir() fallback (XDG_CONFIG_HOME unset) must end \
+             with '/.config/jr'. Got: {}",
+            result.display()
+        );
+        // Structural invariant: path ends with 'jr' component.
+        assert!(
+            result.ends_with("jr"),
+            "M-6: resolved path must end with 'jr' component. Got: {}",
+            result.display()
+        );
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -232,6 +232,13 @@ impl Config {
 
         // Read with env-overlay for in-memory use. The rest of the program
         // sees `JR_*` env overrides applied on top of `config.toml`.
+        //
+        // GUARD: GlobalConfig MUST NEVER gain a `config_dir` or `cache_dir`
+        // field. If it did, figment's `Env::prefixed("JR_")` would honor
+        // `JR_CONFIG_DIR` / `JR_CACHE_DIR` in RELEASE builds, bypassing the
+        // `#[cfg(debug_assertions)]` gate in `global_config_dir()` /
+        // `cache_root()` and re-opening the path-injection vector (SEC-PATH-1).
+        // Those env vars are intentionally debug-only seams (BC-6.2.017).
         let mut global: GlobalConfig = Figment::new()
             .merge(Serialized::defaults(GlobalConfig::default()))
             .merge(Toml::file(&global_path))
@@ -1623,6 +1630,70 @@ mod tests {
             result.ends_with("jr"),
             "AC-003 (BC-6.1.014 invariant): path must still end with 'jr' component \
              when XDG_CONFIG_HOME is set. Got: {}",
+            result.display()
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // R1-003 — Unix XDG_CONFIG_HOME branch integration coverage
+    //
+    // Characterizes the existing Unix production path: when XDG_CONFIG_HOME is
+    // set and JR_CONFIG_DIR is absent, `global_config_dir()` resolves through
+    // the XDG branch (PathBuf::from(xdg).join("jr")).
+    //
+    // This is a GREEN test (passes against current code) that pins pre-migration
+    // Unix path coverage so a future refactor can't silently drop the XDG branch.
+    // NOT `#[cfg(debug_assertions)]` — the XDG branch is NOT gated on debug_assertions
+    // (unlike JR_CONFIG_DIR which is), so this test runs in both debug and release
+    // builds on Unix.
+    // -----------------------------------------------------------------------
+
+    /// R1-003 — On Unix, `global_config_dir()` resolves through `XDG_CONFIG_HOME`
+    /// when that variable is set and `JR_CONFIG_DIR` is absent.
+    ///
+    /// Sets `XDG_CONFIG_HOME` to a tempdir and explicitly removes `JR_CONFIG_DIR`,
+    /// then asserts the returned path equals `<tempdir>/jr`.
+    ///
+    /// This test PASSES against current code — it characterizes existing behavior
+    /// and prevents regression of the Unix XDG path during Windows-build refactors.
+    ///
+    /// Traces: `global_config_dir()` Unix branch (`#[cfg(not(windows))]`); FIX-F5-001 R1-003.
+    #[cfg(not(windows))]
+    #[test]
+    fn test_global_config_dir_resolves_through_xdg_on_unix() {
+        let dir = TempDir::new().unwrap();
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+
+        // SAFETY: ENV_MUTEX is held for the duration; no concurrent env access occurs.
+        // Explicitly remove JR_CONFIG_DIR so the debug seam cannot short-circuit
+        // to a different path (even though JR_CONFIG_DIR is debug-only, removing it
+        // is defense-in-depth for all build configurations).
+        unsafe {
+            std::env::remove_var("JR_CONFIG_DIR");
+            std::env::set_var("XDG_CONFIG_HOME", dir.path());
+        }
+
+        let result = global_config_dir();
+
+        // SAFETY: ENV_MUTEX still held.
+        unsafe {
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+        drop(_guard);
+
+        let expected = dir.path().join("jr");
+        assert_eq!(
+            result,
+            expected,
+            "R1-003: global_config_dir() must resolve through XDG_CONFIG_HOME when \
+             set (and JR_CONFIG_DIR is absent). Expected: {}, got: {}",
+            expected.display(),
+            result.display()
+        );
+        // Structural invariant: path ends with 'jr' component.
+        assert!(
+            result.ends_with("jr"),
+            "R1-003: resolved path must end with 'jr' component. Got: {}",
             result.display()
         );
     }

--- a/tests/release_yml_windows_matrix.rs
+++ b/tests/release_yml_windows_matrix.rs
@@ -25,7 +25,8 @@
 //! | Test | AC |
 //! |------|----|
 //! | `test_release_yml_has_windows_matrix_row` | AC-001 |
-//! | `test_release_yml_windows_package_step_produces_zip` | AC-002 |
+//! | `test_release_yml_windows_package_step_produces_zip` | AC-002 (R1-001 fix) |
+//! | `test_release_yml_windows_has_functional_smoke_step` | R1-002 (Red Gate) |
 //! | `test_release_yml_smoke_step_skipped_on_windows` | AC-003 |
 //! | `test_release_yml_upload_artifact_includes_zip` | AC-004 |
 //! | `test_release_yml_release_job_files_includes_zip` | AC-005 |
@@ -190,20 +191,25 @@ fn test_release_yml_windows_package_step_produces_zip() {
         pkg_block
     );
 
-    // C-V3 negative check: `zip ` (Unix Info-ZIP) must NOT appear in the Package
-    // (Windows) step body — only in the adjacent Compress-Archive invocation which
-    // uses it as a DestinationPath suffix, not as a shell command.
-    // We check for `zip ` with a trailing space to avoid false-matching the `.zip`
-    // extension inside the Compress-Archive -DestinationPath argument.
+    // C-V3 negative check: a bash `zip` invocation (Unix Info-ZIP) must NOT appear
+    // in the Package (Windows) step body. A bare `zip ` substring check is BRITTLE
+    // because `.zip` appears legitimately in the Compress-Archive -DestinationPath
+    // argument. Instead we check for run-line patterns that indicate a real
+    // Info-ZIP invocation: a line starting with `zip ` after trim, or containing
+    // `&& zip ` or `| zip ` (shell pipeline/chain forms).
+    let has_bash_zip_invocation = pkg_block.lines().any(|line| {
+        let t = line.trim();
+        t.starts_with("zip ") || t.contains("&& zip ") || t.contains("| zip ")
+    });
     assert!(
-        !pkg_block.contains("zip "),
-        "AC-002 FAIL: `zip ` (Unix Info-ZIP invocation) found in the \
-         'Package (Windows)' step block (up to the next step) in \
-         .github/workflows/release.yml.\n\
-         The Package (Windows) step MUST use `Compress-Archive`, not the Unix `zip` \
-         command. `zip` is NOT available on `windows-latest` PATH (C-V3 BLOCKER).\n\
+        !has_bash_zip_invocation,
+        "AC-002 FAIL: a bash `zip` invocation (line starting with `zip `, or \
+         containing `&& zip ` / `| zip `) found in the 'Package (Windows)' step \
+         block (up to the next step) in .github/workflows/release.yml.\n\
+         The Package (Windows) step MUST use `Compress-Archive`, not the Unix \
+         `zip` command. `zip` is NOT available on `windows-latest` PATH (C-V3 BLOCKER).\n\
          Step block:\n{}\n\
-         (S-WIN-4 AC-002 / ADR-0016 §Decision 2 C-V3)",
+         (S-WIN-4 AC-002 / ADR-0016 §Decision 2 C-V3 / R1-001)",
         pkg_block
     );
 
@@ -244,6 +250,153 @@ fn test_release_yml_windows_package_step_produces_zip() {
          Step block:\n{}\n\
          (S-WIN-4 AC-002 / ADR-0016 §Decision 2 C-V3)",
         chk_block
+    );
+}
+
+/// R1-002 — Windows build job has a functional smoke step that executes `jr.exe`.
+///
+/// Verifies that the `build` job contains a step that runs the freshly-built
+/// `jr.exe` on Windows (e.g. `jr.exe --version` or `jr.exe --help`), so the
+/// release binary's `/STACK:8388608` reserve and basic launchability are validated
+/// in the RELEASE path.
+///
+/// Currently the only smoke step ("Verify embedded OAuth app present") is gated
+/// `if: runner.os != 'Windows'`, leaving Windows with NO runtime validation.
+/// This test asserts the existence of a Windows-applicable step that:
+/// 1. Invokes `jr.exe` (the Windows binary name)
+/// 2. Is NOT excluded on Windows (does NOT carry `runner.os != 'Windows'`)
+/// 3. Uses `shell: pwsh` OR an explicit `runner.os == 'Windows'` condition
+///
+/// **Red Gate:** This assertion MUST FAIL against the current release.yml, which
+/// has no such step. It will pass once a Windows smoke step is added by the
+/// implementer.
+///
+/// Traces to: WIN-STACK (jr.exe stack reservation); ADR-0016 §Decision 5; FIX-F5-001.
+#[test]
+fn test_release_yml_windows_has_functional_smoke_step() {
+    let yml = release_yml();
+
+    // Strategy: find every step block in the build job that EXECUTES `jr.exe` as a
+    // binary (not merely references it as a file path argument). For each such block,
+    // check that:
+    //   (a) it is NOT excluded on Windows (no `runner.os != 'Windows'` gate)
+    //   (b) it is either explicitly Windows-only (`runner.os == 'Windows'`) or
+    //       uses `shell: pwsh` (pwsh is Windows-native and implies a Windows step)
+    //
+    // "Executes jr.exe" means a run-line that launches the binary, i.e. any trimmed
+    // line that:
+    //   - starts with `jr.exe` (direct invocation without path), OR
+    //   - starts with `$` and contains `jr.exe` on the same word boundary (PowerShell
+    //     variable-based invocation: `$bin = "…/jr.exe"` followed by `& $bin …`), OR
+    //   - contains `& ` followed by something referencing `jr.exe` (PowerShell call
+    //     operator), OR
+    //   - contains a path ending in `/jr.exe` or `\jr.exe` immediately followed by a
+    //     space, flag, or end-of-line (i.e., used as a command, not a `-Path` argument)
+    //
+    // The Compress-Archive packaging step MUST NOT match: it references `jr.exe` only
+    // as a `-Path "target/.../jr.exe"` argument to Compress-Archive, not as an
+    // executable invocation.
+
+    let step_marker = "\n      - name:";
+
+    // Collect starting offsets of all step blocks in the file.
+    let mut step_starts: Vec<usize> = Vec::new();
+    let mut search_from = 0;
+    while let Some(rel) = yml[search_from..].find(step_marker) {
+        let abs = search_from + rel + 1; // +1: skip the leading '\n', point at '-'
+        step_starts.push(abs);
+        search_from = abs + 1;
+    }
+
+    /// Returns true if any run-line in `block` *executes* jr.exe as a binary.
+    ///
+    /// Rejects lines where jr.exe appears only as an argument to another command
+    /// (e.g. `Compress-Archive -Path "…/jr.exe"`), which is not an execution.
+    fn step_executes_jr_exe(block: &str) -> bool {
+        block.lines().any(|line| {
+            let t = line.trim();
+            // Direct invocation: line starts with jr.exe (bare or with leading `.\`)
+            if t.starts_with("jr.exe") || t.starts_with(".\\jr.exe") || t.starts_with("./jr.exe") {
+                return true;
+            }
+            // PowerShell call-operator: `& $bin` or `& "…/jr.exe"` or `& .\jr.exe`
+            if t.contains("& ") {
+                // After `& `, look for jr.exe used as the callee (not after -Path or similar)
+                let after_call = t.find("& ").map(|i| &t[i + 2..]).unwrap_or("");
+                let callee = after_call.split_whitespace().next().unwrap_or("");
+                if callee.ends_with("jr.exe")
+                    || callee
+                        .trim_matches(|c| c == '"' || c == '\'')
+                        .ends_with("jr.exe")
+                {
+                    return true;
+                }
+            }
+            // Path-based invocation: ends with /jr.exe or \jr.exe as executable
+            // followed by space/flag/EOL (not as a -Path or -DestinationPath argument).
+            // Reject: the line contains `-Path` or `-DestinationPath` before `jr.exe`
+            // (Compress-Archive pattern).
+            if (t.contains("/jr.exe") || t.contains("\\jr.exe"))
+                && !t.contains("-Path")
+                && !t.contains("-DestinationPath")
+            {
+                // Verify jr.exe is used as a command: followed by space, flag, or EOL
+                let find_jr = t.find("/jr.exe").or_else(|| t.find("\\jr.exe"));
+                if let Some(pos) = find_jr {
+                    let after = &t[pos + 7..]; // len("jr.exe") == 6; prefix char is 1 extra
+                    if after.is_empty() || after.starts_with(' ') || after.starts_with('-') {
+                        return true;
+                    }
+                }
+            }
+            false
+        })
+    }
+
+    // For each step, extract its block (up to the next step or EOF) and look for
+    // one that both executes jr.exe AND is Windows-applicable.
+    let found_windows_smoke = step_starts.iter().enumerate().any(|(i, &start)| {
+        let end = step_starts.get(i + 1).copied().unwrap_or(yml.len());
+        let block = &yml[start..end];
+
+        // Must EXECUTE jr.exe (not merely reference it as a file path argument).
+        if !step_executes_jr_exe(block) {
+            return false;
+        }
+
+        // Must NOT be excluded on Windows.
+        if block.contains("runner.os != 'Windows'") {
+            return false;
+        }
+
+        // Must be Windows-applicable: either a Windows-only guard or pwsh shell.
+        block.contains("runner.os == 'Windows'") || block.contains("shell: pwsh")
+    });
+
+    assert!(
+        found_windows_smoke,
+        "R1-002 FAIL: no Windows-applicable smoke step invoking `jr.exe` found in \
+         .github/workflows/release.yml.\n\
+         \n\
+         The build job must contain a step that:\n\
+           1. Invokes `jr.exe` (e.g. `jr.exe --version` or `jr.exe --help`)\n\
+           2. Is NOT excluded on Windows (no `if: runner.os != 'Windows'`)\n\
+           3. Uses `shell: pwsh` or `if: runner.os == 'Windows'`\n\
+         \n\
+         Currently the only smoke step ('Verify embedded OAuth app present') is \
+         gated `if: runner.os != 'Windows'`, leaving the Windows release binary \
+         with NO runtime launchability check — the /STACK:8388608 PE reserve and \
+         basic binary integrity are never exercised in CI for release builds.\n\
+         \n\
+         Required: add a Windows smoke step such as:\n\
+           - name: Smoke test (Windows)\n\
+             if: runner.os == 'Windows'\n\
+             shell: pwsh\n\
+             run: |\n\
+               $bin = \"target/${{ matrix.target }}/release/jr.exe\"\n\
+               & $bin --version\n\
+         \n\
+         (FIX-F5-001 R1-002 / WIN-STACK / ADR-0016 §Decision 5)"
     );
 }
 

--- a/tests/release_yml_windows_matrix.rs
+++ b/tests/release_yml_windows_matrix.rs
@@ -256,46 +256,52 @@ fn test_release_yml_windows_package_step_produces_zip() {
 /// R1-002 — Windows build job has a functional smoke step that executes `jr.exe`.
 ///
 /// Verifies that the `build` job contains a step that runs the freshly-built
-/// `jr.exe` on Windows (e.g. `jr.exe --version` or `jr.exe --help`), so the
-/// release binary's `/STACK:8388608` reserve and basic launchability are validated
-/// in the RELEASE path.
+/// `jr.exe` on Windows (e.g. `.\jr.exe --version`), so the release binary's
+/// `/STACK:8388608` reserve and basic launchability are validated in the RELEASE path.
 ///
-/// Currently the only smoke step ("Verify embedded OAuth app present") is gated
-/// `if: runner.os != 'Windows'`, leaving Windows with NO runtime validation.
+/// The existing "Verify embedded OAuth app present" step is gated
+/// `if: runner.os != 'Windows'` (ADR-0016 §Decision 5c), leaving Windows with
+/// no runtime validation without this dedicated step.
+///
+/// This test is a regression guard: it asserts that a Windows-applicable smoke step
+/// exists and was not accidentally removed. The step and this test were co-delivered
+/// in PR #511 (FIX-F5-001); the failing state can be reproduced locally by reverting
+/// only the release.yml hunk from that PR.
+///
 /// This test asserts the existence of a Windows-applicable step that:
-/// 1. Invokes `jr.exe` (the Windows binary name)
+/// 1. Invokes `jr.exe` (the Windows binary name, with explicit `.\` prefix for pwsh)
 /// 2. Is NOT excluded on Windows (does NOT carry `runner.os != 'Windows'`)
 /// 3. Uses `shell: pwsh` OR an explicit `runner.os == 'Windows'` condition
 ///
-/// **Red Gate:** This assertion MUST FAIL against the current release.yml, which
-/// has no such step. It will pass once a Windows smoke step is added by the
-/// implementer.
-///
-/// Traces to: WIN-STACK (jr.exe stack reservation); ADR-0016 §Decision 5; FIX-F5-001.
+/// Traces to: WIN-STACK (jr.exe stack reservation, CLAUDE.md §Gotchas);
+/// ADR-0016 §Decision 5c (OAuth smoke step gated off on Windows — motivation for
+/// this dedicated Windows step); FIX-F5-001 R1-002.
 #[test]
 fn test_release_yml_windows_has_functional_smoke_step() {
     let yml = release_yml();
 
-    // Strategy: find every step block in the build job that EXECUTES `jr.exe` as a
+    // Strategy: find every step block in the file that EXECUTES `jr.exe` as a
     // binary (not merely references it as a file path argument). For each such block,
     // check that:
     //   (a) it is NOT excluded on Windows (no `runner.os != 'Windows'` gate)
     //   (b) it is either explicitly Windows-only (`runner.os == 'Windows'`) or
     //       uses `shell: pwsh` (pwsh is Windows-native and implies a Windows step)
     //
-    // "Executes jr.exe" means a run-line that launches the binary, i.e. any trimmed
-    // line that:
-    //   - starts with `jr.exe` (direct invocation without path), OR
-    //   - starts with `$` and contains `jr.exe` on the same word boundary (PowerShell
-    //     variable-based invocation: `$bin = "…/jr.exe"` followed by `& $bin …`), OR
-    //   - contains `& ` followed by something referencing `jr.exe` (PowerShell call
-    //     operator), OR
-    //   - contains a path ending in `/jr.exe` or `\jr.exe` immediately followed by a
-    //     space, flag, or end-of-line (i.e., used as a command, not a `-Path` argument)
+    // "Executes jr.exe" means a run-line that launches the binary. The detection
+    // covers three invocation forms (note: variable-indirection `& $bin` where $bin
+    // holds a path is NOT detected — only literal callee references are):
+    //   - starts with `jr.exe`, `.\jr.exe`, or `./jr.exe` (direct/CWD-relative), OR
+    //   - contains `& ` followed by a token ending in `jr.exe` (PowerShell call
+    //     operator with a literal callee), OR
+    //   - contains a path ending in `/jr.exe` or `\jr.exe` used as a command (not
+    //     as a `-Path` or `-DestinationPath` argument to another cmdlet)
     //
     // The Compress-Archive packaging step MUST NOT match: it references `jr.exe` only
     // as a `-Path "target/.../jr.exe"` argument to Compress-Archive, not as an
     // executable invocation.
+    //
+    // Note: step_starts scans the entire YAML file (not just the build job). The
+    // release job's steps don't reference jr.exe, so this is correct in practice.
 
     let step_marker = "\n      - name:";
 
@@ -379,24 +385,28 @@ fn test_release_yml_windows_has_functional_smoke_step() {
          .github/workflows/release.yml.\n\
          \n\
          The build job must contain a step that:\n\
-           1. Invokes `jr.exe` (e.g. `jr.exe --version` or `jr.exe --help`)\n\
+           1. Invokes `jr.exe` (e.g. `.\\jr.exe --version` — use the `.\\ ` prefix\n\
+              in pwsh; PowerShell does NOT search CWD without it)\n\
            2. Is NOT excluded on Windows (no `if: runner.os != 'Windows'`)\n\
            3. Uses `shell: pwsh` or `if: runner.os == 'Windows'`\n\
          \n\
-         Currently the only smoke step ('Verify embedded OAuth app present') is \
-         gated `if: runner.os != 'Windows'`, leaving the Windows release binary \
-         with NO runtime launchability check — the /STACK:8388608 PE reserve and \
-         basic binary integrity are never exercised in CI for release builds.\n\
+         The 'Verify embedded OAuth app present' step is gated \
+         `if: runner.os != 'Windows'` (ADR-0016 §Decision 5c), leaving the \
+         Windows release binary with NO runtime launchability check — the \
+         /STACK:8388608 PE reserve and basic binary integrity are never exercised \
+         in CI for release builds without this step.\n\
          \n\
          Required: add a Windows smoke step such as:\n\
            - name: Smoke test (Windows)\n\
              if: runner.os == 'Windows'\n\
              shell: pwsh\n\
              run: |\n\
-               $bin = \"target/${{ matrix.target }}/release/jr.exe\"\n\
-               & $bin --version\n\
+               $ErrorActionPreference = 'Stop'\n\
+               Set-Location \"target/${{ matrix.target }}/release\"\n\
+               .\\jr.exe --version\n\
+               if ($LASTEXITCODE -ne 0) {{ exit $LASTEXITCODE }}\n\
          \n\
-         (FIX-F5-001 R1-002 / WIN-STACK / ADR-0016 §Decision 5)"
+         (FIX-F5-001 R1-002 / WIN-STACK / ADR-0016 §Decision 5c)"
     );
 }
 


### PR DESCRIPTION
## Summary

F5 scoped-adversarial fixes for the merged Windows-build delta. This PR addresses 2 HIGH + 2 quality findings identified during the adversarial review of the Windows CI/release work (FIX-F5-001). **CI-config, tests, and one guard comment only — zero runtime behavior change.**

## Findings addressed

| ID | Severity | File | Description |
|----|----------|------|-------------|
| R1-001 | HIGH | `tests/release_yml_windows_matrix.rs` | Brittle `"zip "` substring check false-matched `.zip` in `-DestinationPath`; replaced with precise bash-invocation pattern detection |
| R1-002 | HIGH | `.github/workflows/release.yml` + test | Windows release binary had NO launchability check in CI; added `Smoke test (Windows)` pwsh step (`jr.exe --version`) + guard test |
| R1-003 | quality | `src/config.rs` | Unix XDG_CONFIG_HOME branch of `global_config_dir()` had no integration coverage; restored with `#[cfg(not(windows))]` test |
| R1-007 | quality | `src/config.rs` | Added GUARD comment at `Env::prefixed("JR_")` site warning that `GlobalConfig` must never gain `config_dir`/`cache_dir` fields (figment would honor `JR_CONFIG_DIR`/`JR_CACHE_DIR` in release builds, bypassing the `#[cfg(debug_assertions)]` gate — SEC-PATH-1 / BC-6.2.017) |

## Changes

- `.github/workflows/release.yml` — new `Smoke test (Windows)` step (`if: runner.os == 'Windows'`, `shell: pwsh`): runs `jr.exe --version` via `Set-Location` + bare invocation; validates `/STACK:8388608` PE reserve and binary launchability in the **release** path (previously only exercised in debug CI)
- `tests/release_yml_windows_matrix.rs` — hardened `test_release_yml_windows_package_step_produces_zip` (R1-001): checks for actual bash invocation patterns (`t.starts_with("zip ")`, `&& zip `, `| zip `) not a brittle `.zip` substring; new `test_release_yml_windows_has_functional_smoke_step` (R1-002) asserts the smoke step exists and is Windows-applicable
- `src/config.rs` — new `test_global_config_dir_resolves_through_xdg_on_unix` unit test (R1-003); GUARD comment at `Env::prefixed("JR_")` (R1-007)

## No runtime behavior change

Pure CI-config + tests + one guard comment. No `src/` logic changes. No new dependencies.

## Local gate — CLEAN

```
cargo fmt --check          ✓
cargo clippy -- -D warnings ✓
cargo test                 ✓ (all pass)
cargo deny check           ✓
```

## Branch protection context

`develop` requires all matrix CI contexts to pass: Format, Clippy (ubuntu/windows-latest), Test (ubuntu/macos/windows-latest), MSRV (1.85.0), Deny. All are expected green on this PR (no src logic change).

## Traceability

- FIX-F5-001 (F5 scoped-adversarial review of Windows-build delta)
- ADR-0016 §Decision 5 (Windows smoke validation)
- WIN-STACK (jr.exe /STACK:8388608 PE reserve)
- BC-6.2.017 / SEC-PATH-1 (debug-only seam gate)