### PR TITLE
docs(fork-ops): add shared-docs guidance for CLAUDE.md/README/ADR sync hygiene

### DIFF
--- a/docs/specs/fork-friendly-release-ops.md
+++ b/docs/specs/fork-friendly-release-ops.md
@@ -72,6 +72,28 @@ repo-neutral. The macOS bundle identifier in `packaging/Info.plist` and
 `scripts/create-pkg.sh` (`com.arcavenae.jr`) reflects the first signing fork;
 a different signing fork should override it to match its own Apple team.
 
+## Shared docs (CLAUDE.md, README, ADRs)
+
+Files that exist in both repos and that both repos edit — `CLAUDE.md`,
+`README.md`, `docs/adr/*` — are deliberately NOT protected by
+`local-workflows.txt`. Listing them there would freeze the fork's copy and
+silently drop every upstream improvement to the same file.
+
+The recurring conflict shape is a small hunk where both repos added an
+equivalent bullet (e.g. a `JR_*` env-var doc line for a feature that landed
+in both) at the same position with slightly different phrasing. The sync
+workflow can't auto-resolve it, so the merge stops for a human. To avoid it:
+
+1. **Send the doc bullet upstream alongside the feature.** When a fork-local
+   feature touches a shared doc, open a small `docs(CLAUDE.md)` PR upstream
+   in the same window as the feature. The bullet lands in upstream-canonical
+   placement once; the fork's next sync fast-forwards through it.
+2. **If the doc must land fork-first**, keep upstream-conventional placement
+   and phrasing so the eventual merge resolves cleanly when upstream adds
+   an equivalent.
+3. **Never add shared docs to `local-workflows.txt`.** That converts shared
+   content into fork divergence and swallows upstream edits to the same file.
+
 ## Known limitations
 
 - `sync-upstream.yml` hardcodes the branch matrix


### PR DESCRIPTION
## Summary

Adds a short subsection to `docs/specs/fork-friendly-release-ops.md` covering the docs-side of the fork-sync story.

The existing doc already addresses fork-local files (workflows, formulas, packaging) and the `local-workflows.txt` "ours" auto-resolution. It doesn't cover the *shared* docs case — files like `CLAUDE.md`, `README.md`, and ADRs that both repos edit and that are deliberately not protected. That class hit our `ArcavenAE/jira-cli` fork today: the scheduled `sync-upstream.yml` failed on a small `CLAUDE.md` hunk where both repos had added equivalent `JR_*` env-var doc bullets at the same position with slightly different placement. The merge was trivial to resolve by hand, but the conflict was predictable — and the discipline that avoids it (send the doc bullet upstream alongside the feature) belongs in the doc that already frames "fork-friendly release ops."

The new subsection:

- Names which files are *not* in scope for `local-workflows.txt` protection and why (protecting them would silently drop upstream edits).
- Describes the recurring "two equivalent bullets at the same position" conflict shape.
- Gives three rules in priority order: upstream-first docs PR, upstream-conventional placement if fork-first is unavoidable, never protect shared docs.

22 lines added, zero deletions, no other files touched.

## Test plan

- [ ] Renders correctly in the docs (markdown only — no code paths)
- [ ] Section ordering reads naturally (Formula templates → Shared docs → Known limitations)
- [ ] No conflict with `docs/specs/fork-friendly-release-ops.md` on a future sync (the addition sits cleanly between two existing sections)