### PR TITLE
ci: port release.yml's defensive `rustup target add` to sign-and-publish + backfill-release

### DIFF
--- a/.github/workflows/backfill-release.yml
+++ b/.github/workflows/backfill-release.yml
@@ -66,6 +66,15 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # rust-toolchain.toml pins channel = "stable", which overrides the
+      # toolchain dtolnay/rust-toolchain installs above. Without this step,
+      # native (non-cross) builds fail with `error[E0463]: can't find
+      # crate for 'core'`. Same defensive fix as release.yml.
+      - name: Ensure target installed (defensive)
+        if: ${{ !matrix.use_cross }}
+        shell: bash
+        run: rustup target add ${{ matrix.target }}
+
       - name: Install cross
         if: matrix.use_cross
         run: cargo install cross --git https://github.com/cross-rs/cross

--- a/.github/workflows/sign-and-publish.yml
+++ b/.github/workflows/sign-and-publish.yml
@@ -54,6 +54,15 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # rust-toolchain.toml pins channel = "stable", which overrides the
+      # toolchain dtolnay/rust-toolchain installs above. The target the
+      # action installed sits on the wrong toolchain; without this step
+      # the build fails with `error[E0463]: can't find crate for 'core'`.
+      # Same defensive fix as release.yml.
+      - name: Ensure target installed (defensive)
+        shell: bash
+        run: rustup target add ${{ matrix.target }}
+
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           key: ${{ matrix.target }}


### PR DESCRIPTION
## Summary

Adds a defensive `rustup target add \${{ matrix.target }}` step to two release-ops workflows that were missing it: `sign-and-publish.yml` (alpha build) and `backfill-release.yml` (native build). `release.yml` already carries the same step under the name "Ensure cross-target installed (defensive)".

## Why

Native (non-cross) macOS builds with the matrix target ≠ runner host can fail with:

```
error[E0463]: can't find crate for `core`
   = note: the `x86_64-apple-darwin` target may not be installed
```

The interaction:

1. `dtolnay/rust-toolchain@stable` installs the toolchain with `targets: \${{ matrix.target }}` attached. The action's "parse toolchain version" logic resolves this to a specific toolchain (e.g. `1.85.0`).
2. `rust-toolchain.toml` pins `channel = "stable"`. When `cargo build` runs, rustup honours the toolchain file and re-routes to the *actual current stable* toolchain.
3. That stable toolchain has no extra target installed — the target was attached to the dtolnay-selected toolchain, not the rust-toolchain.toml-selected one.
4. Build fails.

`release.yml` solved this with one line:

```yaml
- name: Ensure cross-target installed (defensive)
  if: \${{ !matrix.use_cross }}
  shell: bash
  run: rustup target add \${{ matrix.target }}
```

This PR ports the same step to `sign-and-publish.yml` and `backfill-release.yml`.

## Scope

Both files are inert in this repo (gated on `SIGNING_ENABLED`, unset upstream), so this isn't a regression here. It's a real failure for any fork that opts in; observed in `ArcavenAE/jira-cli` since `2026-06-13`. Filing upstream so the file stays drift-free between repos per `docs/specs/fork-friendly-release-ops.md`.

## Test plan

- [ ] YAML parses (verified locally with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Downstream fork (`ArcavenAE/jira-cli`) verified end-to-end: Sign & Publish workflow went green after the same patch landed (alpha-20260618.1 built, signed, notarized, published)
- [ ] No-op in this repo because `SIGNING_ENABLED` is unset