### PR TITLE
ci(sign): verify Gatekeeper acceptance + hardened runtime after notarize (closes #210 literal gap)

### DIFF
--- a/.github/workflows/backfill-release.yml
+++ b/.github/workflows/backfill-release.yml
@@ -252,6 +252,43 @@ jobs:
             xcrun stapler staple "$ARTIFACT"
           done
 
+      - name: Verify signatures (Gatekeeper + codesign)
+        run: |
+          set -e
+          # Bare Mach-O binaries: stapler can't attach to a bare binary
+          # (Apple TN3147), so `spctl --assess --type execute` would
+          # report "Unnotarized Developer ID". Verify the load-bearing
+          # properties directly via codesign: Developer ID Application
+          # identity, stable Team Identifier, and hardened runtime flag.
+          for BIN in jr-darwin-arm64 jr-darwin-amd64; do
+            echo "::group::Verify $BIN"
+            codesign -dvv "$BIN" 2>&1 | tee /tmp/cs.out
+            grep -q "^Authority=Developer ID Application:" /tmp/cs.out \
+              || { echo "::error::$BIN missing Developer ID Application authority"; exit 1; }
+            grep -q "^TeamIdentifier=" /tmp/cs.out \
+              || { echo "::error::$BIN missing TeamIdentifier"; exit 1; }
+            grep -qE "^CodeDirectory.*flags=0x[0-9a-f]+\(.*runtime.*\)" /tmp/cs.out \
+              || { echo "::error::$BIN missing hardened runtime (--options runtime) flag"; exit 1; }
+            echo "::endgroup::"
+          done
+          # Stapled containers: spctl --assess returns "accepted
+          # source=Notarized Developer ID" when signed + notarized +
+          # stapled. .pkg → --type install; .dmg → --type open.
+          for PKG in jr-arm64.pkg jr-amd64.pkg; do
+            echo "::group::Verify $PKG"
+            spctl --assess --type install --verbose=4 "$PKG" 2>&1 | tee /tmp/spctl.out
+            grep -q "source=Notarized Developer ID" /tmp/spctl.out \
+              || { echo "::error::$PKG not notarized (spctl source unexpected)"; exit 1; }
+            echo "::endgroup::"
+          done
+          for DMG in jr-arm64.dmg jr-amd64.dmg; do
+            echo "::group::Verify $DMG"
+            spctl --assess --type open --verbose=4 "$DMG" 2>&1 | tee /tmp/spctl.out
+            grep -q "source=Notarized Developer ID" /tmp/spctl.out \
+              || { echo "::error::$DMG not notarized (spctl source unexpected)"; exit 1; }
+            echo "::endgroup::"
+          done
+
       - name: Generate checksums
         run: |
           for f in jr-darwin-arm64 jr-darwin-amd64 jr-arm64.pkg jr-amd64.pkg jr-arm64.dmg jr-amd64.dmg; do

--- a/.github/workflows/sign-and-publish.yml
+++ b/.github/workflows/sign-and-publish.yml
@@ -228,6 +228,43 @@ jobs:
             xcrun stapler staple "$ARTIFACT"
           done
 
+      - name: Verify signatures (Gatekeeper + codesign)
+        run: |
+          set -e
+          # Bare Mach-O binaries: stapler can't attach to a bare binary
+          # (Apple TN3147), so `spctl --assess --type execute` would
+          # report "Unnotarized Developer ID". Verify the load-bearing
+          # properties directly via codesign: Developer ID Application
+          # identity, stable Team Identifier, and hardened runtime flag.
+          for BIN in jr-a-darwin-arm64 jr-a-darwin-amd64; do
+            echo "::group::Verify $BIN"
+            codesign -dvv "$BIN" 2>&1 | tee /tmp/cs.out
+            grep -q "^Authority=Developer ID Application:" /tmp/cs.out \
+              || { echo "::error::$BIN missing Developer ID Application authority"; exit 1; }
+            grep -q "^TeamIdentifier=" /tmp/cs.out \
+              || { echo "::error::$BIN missing TeamIdentifier"; exit 1; }
+            grep -qE "^CodeDirectory.*flags=0x[0-9a-f]+\(.*runtime.*\)" /tmp/cs.out \
+              || { echo "::error::$BIN missing hardened runtime (--options runtime) flag"; exit 1; }
+            echo "::endgroup::"
+          done
+          # Stapled containers: spctl --assess returns "accepted
+          # source=Notarized Developer ID" when signed + notarized +
+          # stapled. .pkg → --type install; .dmg → --type open.
+          for PKG in jr-a-arm64.pkg jr-a-amd64.pkg; do
+            echo "::group::Verify $PKG"
+            spctl --assess --type install --verbose=4 "$PKG" 2>&1 | tee /tmp/spctl.out
+            grep -q "source=Notarized Developer ID" /tmp/spctl.out \
+              || { echo "::error::$PKG not notarized (spctl source unexpected)"; exit 1; }
+            echo "::endgroup::"
+          done
+          for DMG in jr-a-arm64.dmg jr-a-amd64.dmg; do
+            echo "::group::Verify $DMG"
+            spctl --assess --type open --verbose=4 "$DMG" 2>&1 | tee /tmp/spctl.out
+            grep -q "source=Notarized Developer ID" /tmp/spctl.out \
+              || { echo "::error::$DMG not notarized (spctl source unexpected)"; exit 1; }
+            echo "::endgroup::"
+          done
+
       - name: Generate checksums
         run: |
           for f in jr-a-darwin-arm64 jr-a-darwin-amd64 jr-a-arm64.pkg jr-a-amd64.pkg jr-a-arm64.dmg jr-a-amd64.dmg; do
@@ -455,6 +492,43 @@ jobs:
               --team-id "$APPLE_NOTARIZATION_TEAM_ID" \
               --wait --timeout 14400
             xcrun stapler staple "$ARTIFACT"
+          done
+
+      - name: Verify signatures (Gatekeeper + codesign)
+        run: |
+          set -e
+          # Bare Mach-O binaries: stapler can't attach to a bare binary
+          # (Apple TN3147), so `spctl --assess --type execute` would
+          # report "Unnotarized Developer ID". Verify the load-bearing
+          # properties directly via codesign: Developer ID Application
+          # identity, stable Team Identifier, and hardened runtime flag.
+          for BIN in jr-darwin-arm64 jr-darwin-amd64; do
+            echo "::group::Verify $BIN"
+            codesign -dvv "$BIN" 2>&1 | tee /tmp/cs.out
+            grep -q "^Authority=Developer ID Application:" /tmp/cs.out \
+              || { echo "::error::$BIN missing Developer ID Application authority"; exit 1; }
+            grep -q "^TeamIdentifier=" /tmp/cs.out \
+              || { echo "::error::$BIN missing TeamIdentifier"; exit 1; }
+            grep -qE "^CodeDirectory.*flags=0x[0-9a-f]+\(.*runtime.*\)" /tmp/cs.out \
+              || { echo "::error::$BIN missing hardened runtime (--options runtime) flag"; exit 1; }
+            echo "::endgroup::"
+          done
+          # Stapled containers: spctl --assess returns "accepted
+          # source=Notarized Developer ID" when signed + notarized +
+          # stapled. .pkg → --type install; .dmg → --type open.
+          for PKG in jr-arm64.pkg jr-amd64.pkg; do
+            echo "::group::Verify $PKG"
+            spctl --assess --type install --verbose=4 "$PKG" 2>&1 | tee /tmp/spctl.out
+            grep -q "source=Notarized Developer ID" /tmp/spctl.out \
+              || { echo "::error::$PKG not notarized (spctl source unexpected)"; exit 1; }
+            echo "::endgroup::"
+          done
+          for DMG in jr-arm64.dmg jr-amd64.dmg; do
+            echo "::group::Verify $DMG"
+            spctl --assess --type open --verbose=4 "$DMG" 2>&1 | tee /tmp/spctl.out
+            grep -q "source=Notarized Developer ID" /tmp/spctl.out \
+              || { echo "::error::$DMG not notarized (spctl source unexpected)"; exit 1; }
+            echo "::endgroup::"
           done
 
       - name: Generate checksums


### PR DESCRIPTION
## Summary

Closes the literal `spctl --assess` gap from #210. After every `Notarize` step in `sign-and-publish.yml` and `backfill-release.yml`, assert the load-bearing post-signing properties; fail the job if any artifact is not what the signing pipeline claims.

Three signing sites, identical step:

- `sign-and-publish.yml` :: `alpha-sign` (jr-a-* artifacts, every develop push)
- `sign-and-publish.yml` :: `stable-sign` (jr-* artifacts, covers stable + dev + beta + rc)
- `backfill-release.yml` :: `sign` (jr-* artifacts, manual dispatch for back-tagged releases)

## Status of #210

The signing pipeline itself was already merged via the fork-friendly release-ops PR (#503, commit `2cb219b`). `sign-and-publish.yml` does Developer ID Application codesign, hardened runtime, notarytool submit-and-wait, and stapler — checked against the #210 requirement list:

| #210 ask | Status |
|---|---|
| Import Developer ID cert from encrypted secret | ✅ already shipped |
| `codesign --sign "Developer ID Application: ..." --options runtime` on x86_64 + arm64 | ✅ already shipped (with `--timestamp` added, required by notarization) |
| `xcrun notarytool submit --wait` | ✅ already shipped |
| `xcrun stapler staple` | ✅ already shipped (applied to `.pkg`/`.dmg`/`.app` containers — stapler does not work on bare Mach-O, per Apple TN3147) |
| `spctl --assess --type execute --verbose=4 jr` | ❌ → **this PR** |

This PR is the last bullet.

## Why this isn't a one-liner

`spctl --assess` is artifact-type-specific (see spctl(8)):

```
.pkg  → --type install
.dmg  → --type open
.app  → --type execute
```

And `spctl` can't return "Notarized Developer ID" on a bare Mach-O binary, because stapler doesn't attach to bare binaries (Apple TN3147 §Stapling Eligibility). The bare binary IS the artifact `brew install` actually puts on disk — and is the artifact most worth verifying.

So the step uses two complementary checks:

1. **`spctl --assess`** for `.pkg` + `.dmg` (and `.app` if/when surfaced), each with the correct `--type`, plus a `grep "source=Notarized Developer ID"` to fail-on-not-notarized (since `spctl` accepts ad-hoc and self-signed binaries in dev-mode and we don't want false greens there).
2. **`codesign -dvv`** for bare binaries with three load-bearing greps:
   - `Authority=Developer ID Application:` — confirms it's a real Developer ID identity, not ad-hoc or self-signed.
   - `TeamIdentifier=` present — confirms a stable teamid (the property #210 says is the actual root cause: the legacy-Keychain partition list keys on `teamid:` and only Developer ID gives a stable one across rebuilds).
   - `CodeDirectory ... flags=...runtime...` — confirms `--options runtime` was applied. Hardened runtime is what makes the binary eligible for notarization.

## Test plan

- [ ] YAML parses (verified locally with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Each `Verify signatures (...)` step's inline shell parses with `bash -n`
- [ ] Inert in this repo because `SIGNING_ENABLED` is unset (no behavior change to canonical CI)
- [ ] In a fork with signing enabled, the next alpha build will exercise this end-to-end against `alpha-YYYYMMDD.N` artifacts. The downstream `ArcavenAE/jira-cli` fork (where the prior PR #503 cosigning machinery is active) will be the first place this runs.

## Scope notes

- Step is purely additive: it runs after `Notarize`, before `Generate checksums`/`Upload signed artifacts to release`. No prior step's behavior changes; if signing was healthy before this PR, the verify step is a no-op observer.
- A future failure mode (stapler skipped, ad-hoc instead of Developer ID, hardened runtime regressed, notarization broken) will be caught at CI time rather than after a user's `brew upgrade`.
- No new secrets, no new artifact downloads, no new actions. Pure shell using tooling already installed on `macos-latest`.

Refs: #210