### PR TITLE
chore(release): v0.6.0-dev.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,60 @@ All notable changes to jr will be documented here.
 
 ### Changed
 
+## [0.6.0-dev.3] - 2026-06-18
+
+### Fixed
+
+- **`jr issue comments` no longer stalls on repeated `nextPageToken` (S-525, BC-2.4.043):**
+  `list_comments` in `src/api/jira/issues.rs` now carries the same non-advancing-offset
+  guard that `get_changelog` uses — if `next <= start_at` after a page with `has_more=true`,
+  the paginator aborts with an error instead of looping forever. Mirrors the JRACLOUD-95368
+  pattern already present on the JQL search path. (#531)
+- **Multi-line inline HTML in `--description`/comments no longer causes HTTP 400 (BC-7.2.011,
+  #522):** `push_text`, `push_code`, and `text_to_adf` now enforce the ADF text-node invariant
+  (no raw `\r` or `\n`) at the chokepoint level. In non-codeBlock context `\r\n`, lone `\r`,
+  and bare `\n` are all mapped to a single space — matching `SoftBreak` semantics. In codeBlock
+  context `\r\n`→`\n` and lone `\r`→`\n` (newlines preserved). This closes a reachable HIGH
+  bug where multi-line inline HTML (e.g. `foo <span\nx>bar` in a `--description` or `issue
+  comment`) emitted a raw `\n` into an ADF text node, which Jira rejected with HTTP 400. (#523)
+- **Block-level HTML interior newlines rendered as `hardBreak` nodes instead of raw `\n`
+  (BC-7.2.011, #492):** `markdown_to_adf` now applies Algorithm B to `Tag::HtmlBlock` content:
+  the block is split on line boundaries and emitted as alternating `text`/`hardBreak` nodes
+  (leading/trailing `hardBreak`s trimmed, empty result suppressed). Previously, multi-line
+  block HTML emitted raw `\n` characters inside text nodes — an ADF schema violation that Jira
+  rejected with HTTP 400. (#492)
+
+### Changed
+
+- **`jr issue create --request-type` and `jr project fields` now emit pretty-printed JSON
+  (#526):** All `--output json` paths in `src/cli/` are now routed through
+  `output::render_json`. The two commands that previously used compact `serde_json::json!`
+  Display output — `handle_jsm_create` and `handle_fields` — now emit pretty-printed JSON
+  consistent with every other `jr` command. `jq` and programmatic parsers that accept
+  whitespace-insensitive JSON are unaffected; scripts that did byte-exact comparison against
+  compact output will need updating. (#527, S-526)
+- **`write_cmdb_fields_cache` and `write_object_type_attr_cache` now use model-b
+  error handling (S-525/CR-007):** Both cache writers in `src/cache.rs` swallow disk-write
+  errors with an `eprintln!("warning: …")` and return `Ok(())` rather than propagating via
+  `?`. A failed cache write no longer prevents a successful API call from completing. Call
+  sites updated to use `.ok()` (idiomatic for discarding an always-`Ok` result). (#531)
+- **CI Gate aggregator job added as the single required branch-protection status check
+  (S-CIGATE-1):** `ci.yml` now contains a `ci-gate` job (`needs: [fmt, clippy, test, msrv,
+  deny, spec-guard]`, `if: always()`) that is the only job wired into branch protection on
+  `develop`/`main`. New required CI jobs must be added to `ci-gate.needs`, never directly to
+  branch protection, to prevent the matrix-rename fragility class. (#533 note: `cargo-mutants`
+  examine_globs extended to cover `src/api/jira/issues.rs` and `src/cache.rs`; a keyring-
+  touching test gated behind `JR_RUN_KEYRING_TESTS`.)
+- **Opt-in release operations workflows added (inert by default):** Four new GitHub Actions
+  workflows — Apple binary signing (`sign-and-publish.yml`), release backfill
+  (`backfill-release.yml`), gap-fill (`release-gap-fill.yml`), and fork sync
+  (`sync-upstream.yml`) — are activated only when the corresponding repository variables
+  (`SIGNING_ENABLED`, `HOMEBREW_TAP_REPO`, `RELEASE_GAP_FILL_ENABLED`, `SYNC_UPSTREAM_REPO`)
+  are set. The canonical repo has none of these set; existing CI is unaffected.
+  (`docs/specs/fork-friendly-release-ops.md`, #503)
+- **Documentation accuracy sweep (DRIFT-D1..D12, CR-003/CR-004):** internal doc-only
+  corrections to `CLAUDE.md` and architecture notes; no runtime behavior changed. (#524)
+
 ## [0.6.0-dev.2] - 2026-06-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.6.0-dev.2"
+version = "0.6.0-dev.3"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary

Release-prep for `v0.6.0-dev.3`. Diff is exactly 3 files:

- `Cargo.toml` — version `0.6.0-dev.2` → `0.6.0-dev.3`
- `Cargo.lock` — jr package version line updated
- `CHANGELOG.md` — new `## [0.6.0-dev.3] - 2026-06-18` section composed from the 8 commits merged since the last dev tag

No product source code changes in this PR. The tag `v0.6.0-dev.3` will be pushed after this merges to trigger the release build.

## What's in this release

### Fixed

- **`jr issue comments` anti-stall pagination guard (S-525, BC-2.4.043, #531):** `list_comments` now carries the same non-advancing-offset guard that `get_changelog` uses — infinite-loop on repeated `nextPageToken` (JRACLOUD-95368 pattern) is detected and aborted with an error.
- **ADF CR/LF normalization across `push_text`/`push_code`/`text_to_adf` (#522, #523):** Multi-line inline HTML in `--description` or comments no longer causes HTTP 400. The ADF text-node invariant (no raw `\r`/`\n`) is now enforced at the chokepoint level — in non-codeBlock context both sequences are mapped to a single space.
- **ADF block-HTML interior newlines as `hardBreak` nodes (#492):** `markdown_to_adf` now applies Algorithm B to `Tag::HtmlBlock` — multi-line block HTML is split on line boundaries and emitted as alternating `text`/`hardBreak` nodes instead of raw `\n` characters that Jira rejected with HTTP 400.

### Changed (user-visible)

- **`jr issue create --request-type` and `jr project fields` now emit pretty-printed JSON (#526, #527):** All `--output json` paths are routed through `output::render_json`. Scripts that did byte-exact comparison against compact output will need updating; `jq` and whitespace-insensitive parsers are unaffected.

### Internal / CI

- **CI Gate aggregator job (S-CIGATE-1, #533):** `ci-gate` is now the single required branch-protection status check on `develop`/`main`. New required CI jobs must be added to `ci-gate.needs`.
- **Opt-in release operations workflows (inert by default):** Four new GitHub Actions workflows for Apple binary signing, release backfill, gap-fill, and fork sync — all no-ops unless repository variables are set.
- **`write_cmdb_fields_cache` / `write_object_type_attr_cache` model-b error handling (S-525/CR-007):** Cache disk-write errors are now swallowed with a warning rather than propagated, so a failed cache write never breaks a successful API call.

## Architecture Changes

```mermaid
graph TD
    A[Cargo.toml<br/>version bump] --> B[Cargo.lock<br/>checksum update]
    C[CHANGELOG.md<br/>new dev.3 section] --> D[Release tag v0.6.0-dev.3<br/>triggers release build]
    B --> D
```

## Story Dependencies

No story dependencies. This is a standalone release-prep commit.

## Spec Traceability

```mermaid
flowchart LR
    A[8 merged commits<br/>since dev.2] --> B[CHANGELOG entries<br/>composed] --> C[Cargo.toml<br/>version bump] --> D[PR to develop] --> E[Release tag]
```

## Test Evidence

All tests pass on the underlying commits. This PR contains no source changes — CI validates the repo compiles and tests pass with the new version string.

## Demo Evidence

N/A — release-prep only, no product behavior changes.

## Security Review

N/A — no source code changes. The 3 changed files are a version string, a lock file checksum, and a changelog entry.

## Risk Assessment

- **Blast radius:** Minimal — version string + lock file + changelog only.
- **Performance impact:** None.
- **Rollback:** Revert the squash commit on develop; the tag (pushed post-merge) would need manual deletion.

## AI Pipeline Metadata

- Pipeline mode: release-prep (manual)
- Models used: claude-sonnet-4-6
- Cost: negligible

## Pre-Merge Checklist

- [x] PR description matches actual diff (3 files: Cargo.toml, Cargo.lock, CHANGELOG.md)
- [x] Version bump is correct (0.6.0-dev.2 → 0.6.0-dev.3)
- [x] CHANGELOG date is correct (2026-06-18)
- [x] No product source changes in diff
- [x] Security review: N/A (no source changes)
- [x] Demo evidence: N/A (no behavior changes)
- [x] CI Gate must pass before merge
