### PR TITLE
fix(ci): harden fork-ops signing workflows — CWE-77 env-binding + atomic alpha-tag + injection guard (S-FORK-OPS-SIGN-1)

### DIFF
--- a/.github/workflows/backfill-release.yml
+++ b/.github/workflows/backfill-release.yml
@@ -267,7 +267,10 @@ jobs:
 
       - name: Verify signatures (Gatekeeper + codesign)
         run: |
-          set -e
+          set -eo pipefail
+          CS_OUT=$(mktemp)
+          SPCTL_OUT=$(mktemp)
+          trap 'rm -f "$CS_OUT" "$SPCTL_OUT"' EXIT
           # Bare Mach-O binaries: stapler can't attach to a bare binary
           # (Apple TN3147), so `spctl --assess --type execute` would
           # report "Unnotarized Developer ID". Verify the load-bearing
@@ -275,12 +278,12 @@ jobs:
           # identity, stable Team Identifier, and hardened runtime flag.
           for BIN in jr-darwin-arm64 jr-darwin-amd64; do
             echo "::group::Verify $BIN"
-            codesign -dvv "$BIN" 2>&1 | tee /tmp/cs.out
-            grep -q "^Authority=Developer ID Application:" /tmp/cs.out \
+            codesign -dvv "$BIN" 2>&1 | tee "$CS_OUT"
+            grep -q "^Authority=Developer ID Application:" "$CS_OUT" \
               || { echo "::error::$BIN missing Developer ID Application authority"; exit 1; }
-            grep -q "^TeamIdentifier=" /tmp/cs.out \
+            grep -q "^TeamIdentifier=" "$CS_OUT" \
               || { echo "::error::$BIN missing TeamIdentifier"; exit 1; }
-            grep -qE "^CodeDirectory.*flags=0x[0-9a-f]+\(.*runtime.*\)" /tmp/cs.out \
+            grep -qE "^CodeDirectory.*flags=0x[0-9a-f]+\(.*runtime.*\)" "$CS_OUT" \
               || { echo "::error::$BIN missing hardened runtime (--options runtime) flag"; exit 1; }
             echo "::endgroup::"
           done
@@ -289,15 +292,15 @@ jobs:
           # stapled. .pkg → --type install; .dmg → --type open.
           for PKG in jr-arm64.pkg jr-amd64.pkg; do
             echo "::group::Verify $PKG"
-            spctl --assess --type install --verbose=4 "$PKG" 2>&1 | tee /tmp/spctl.out
-            grep -q "source=Notarized Developer ID" /tmp/spctl.out \
+            spctl --assess --type install --verbose=4 "$PKG" 2>&1 | tee "$SPCTL_OUT"
+            grep -q "source=Notarized Developer ID" "$SPCTL_OUT" \
               || { echo "::error::$PKG not notarized (spctl source unexpected)"; exit 1; }
             echo "::endgroup::"
           done
           for DMG in jr-arm64.dmg jr-amd64.dmg; do
             echo "::group::Verify $DMG"
-            spctl --assess --type open --verbose=4 "$DMG" 2>&1 | tee /tmp/spctl.out
-            grep -q "source=Notarized Developer ID" /tmp/spctl.out \
+            spctl --assess --type open --verbose=4 "$DMG" 2>&1 | tee "$SPCTL_OUT"
+            grep -q "source=Notarized Developer ID" "$SPCTL_OUT" \
               || { echo "::error::$DMG not notarized (spctl source unexpected)"; exit 1; }
             echo "::endgroup::"
           done

--- a/.github/workflows/backfill-release.yml
+++ b/.github/workflows/backfill-release.yml
@@ -132,8 +132,9 @@ jobs:
       - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          TAG="${{ inputs.tag }}"
+          TAG="$RELEASE_TAG"
           PRERELEASE=""
           if [[ "$TAG" == *-* ]]; then
             PRERELEASE="--prerelease"
@@ -176,16 +177,19 @@ jobs:
 
       - name: Extract version
         id: meta
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          TAG="${{ inputs.tag }}"
+          TAG="$RELEASE_TAG"
           VERSION="${TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Download release binaries
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          TAG="${{ inputs.tag }}"
+          TAG="$RELEASE_TAG"
           for target in x86_64-apple-darwin aarch64-apple-darwin; do
             ASSET="jr-${TAG}-${target}.tar.gz"
             echo "Downloading $ASSET..."
@@ -307,8 +311,9 @@ jobs:
       - name: Upload signed artifacts to release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          TAG="${{ inputs.tag }}"
+          TAG="$RELEASE_TAG"
           gh release upload "$TAG" \
             jr-darwin-arm64 \
             jr-darwin-amd64 \

--- a/.github/workflows/backfill-release.yml
+++ b/.github/workflows/backfill-release.yml
@@ -92,14 +92,16 @@ jobs:
           fi
 
       - name: Package
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           cd target/${{ matrix.target }}/release
-          tar czf ../../../jr-${{ inputs.tag }}-${{ matrix.target }}.tar.gz jr
+          tar czf "../../../jr-${RELEASE_TAG}-${{ matrix.target }}.tar.gz" jr
           cd ../../..
           if command -v sha256sum &>/dev/null; then
-            sha256sum jr-${{ inputs.tag }}-${{ matrix.target }}.tar.gz > jr-${{ inputs.tag }}-${{ matrix.target }}.tar.gz.sha256
+            sha256sum "jr-${RELEASE_TAG}-${{ matrix.target }}.tar.gz" > "jr-${RELEASE_TAG}-${{ matrix.target }}.tar.gz.sha256"
           else
-            shasum -a 256 jr-${{ inputs.tag }}-${{ matrix.target }}.tar.gz > jr-${{ inputs.tag }}-${{ matrix.target }}.tar.gz.sha256
+            shasum -a 256 "jr-${RELEASE_TAG}-${{ matrix.target }}.tar.gz" > "jr-${RELEASE_TAG}-${{ matrix.target }}.tar.gz.sha256"
           fi
 
       - name: Upload artifact
@@ -237,8 +239,9 @@ jobs:
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_INSTALLER_IDENTITY: ${{ secrets.APPLE_INSTALLER_IDENTITY }}
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          VERSION="${{ steps.meta.outputs.version }}"
+          VERSION="$RELEASE_VERSION"
           chmod +x scripts/create-app.sh scripts/create-dmg.sh scripts/create-pkg.sh
 
           for arch in arm64 amd64; do
@@ -355,8 +358,9 @@ jobs:
       - name: Download signed binaries from release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          TAG="${{ inputs.tag }}"
+          TAG="$RELEASE_TAG"
           gh release download "$TAG" --pattern "jr-darwin-arm64" --dir .
           gh release download "$TAG" --pattern "jr-darwin-amd64" --dir .
 
@@ -364,9 +368,11 @@ jobs:
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           HOMEBREW_TAP_REPO: ${{ vars.HOMEBREW_TAP_REPO }}
+          RELEASE_VERSION: ${{ needs.sign.outputs.version }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          VERSION="${{ needs.sign.outputs.version }}"
-          TAG="${{ inputs.tag }}"
+          VERSION="$RELEASE_VERSION"
+          TAG="$RELEASE_TAG"
 
           TAP_SHORT="${HOMEBREW_TAP_REPO#*/}"
           TAP_NAME="${HOMEBREW_TAP_REPO%%/*}/${TAP_SHORT#homebrew-}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,10 +304,28 @@ jobs:
 
           echo "OK: cargo-mutants gate passed (kill rate ${kill_rate}% ≥ 90%)."
 
+  check-signing-workflow-injection:
+    name: Signing Workflow Injection Guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+
+      - name: Run injection guard (YAML-aware)
+        run: bash scripts/check-signing-workflow-injection.sh
+
+      - name: Run injection guard negative fixture self-test
+        run: bash scripts/check-signing-workflow-injection.sh --self-test
+
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, test, msrv, deny, spec-guard]
+    needs: [fmt, clippy, test, msrv, deny, spec-guard, check-signing-workflow-injection]
     if: ${{ always() }}
     steps:
       - name: Fail if any required job failed or was cancelled

--- a/.github/workflows/sign-and-publish.yml
+++ b/.github/workflows/sign-and-publish.yml
@@ -150,21 +150,68 @@ jobs:
 
       - name: Generate alpha version
         id: meta
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
+          # Atomic alpha-tag reservation via GitHub API (no TOCTOU race).
+          # Spec: docs/specs/fork-friendly-release-ops.md § "Atomic alpha-tag creation"
+          # Step 1: inputs bound from env: above (CWE-77 rule).
+
+          # Step 2: compute seed hint (starting point only — correctness does NOT
+          # depend on its accuracy; the atomic reservation loop is the sole guarantor).
           DATE=$(date -u +%Y%m%d)
-          # Count existing tags today (more reliable than releases)
           EXISTING=$(git ls-remote --tags origin "refs/tags/alpha-${DATE}.*" | wc -l | tr -d ' ')
           SEQ=$((EXISTING + 1))
-          TAG="alpha-${DATE}.${SEQ}"
-          VERSION="${TAG}"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Alpha release: $TAG"
 
-          # Clean up any stale release/tag with the same name
-          gh release delete "$TAG" --cleanup-tag --yes 2>/dev/null || true
-        env:
-          GH_TOKEN: ${{ github.token }}
+          # Steps 3 + 4: atomic reservation with bounded retry.
+          # HTTP 201 → reserved. HTTP 422 → ref exists, increment SEQ and retry.
+          # Any other non-zero exit → fatal (exit 1 with diagnostic).
+          # MAX_ATTEMPTS=10 (includes first attempt in step 3).
+          # NEVER re-count remote tags on retry — increment from just-rejected SEQ only.
+          MAX_ATTEMPTS=10
+          ATTEMPT=1
+          TAG=""
+          GH_API_ERR_FILE=$(mktemp)
+          trap 'rm -f "$GH_API_ERR_FILE"' EXIT
+
+          while [ "$ATTEMPT" -le "$MAX_ATTEMPTS" ]; do
+            CANDIDATE="alpha-${DATE}.${SEQ}"
+            echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: reserving tag ${CANDIDATE}..."
+            if gh api --method POST \
+              "/repos/${{ github.repository }}/git/refs" \
+              -f "ref=refs/tags/${CANDIDATE}" \
+              -f "sha=${COMMIT_SHA}" \
+              2>"$GH_API_ERR_FILE"; then
+              # HTTP 201 — reservation succeeded
+              TAG="$CANDIDATE"
+              echo "Reserved tag: $TAG"
+              break
+            else
+              ERR_BODY=$(cat "$GH_API_ERR_FILE")
+              # gh CLI exits non-zero for both 422 (already exists) and other errors.
+              # Distinguish 422 by the "already exists" message in the error body.
+              if echo "$ERR_BODY" | grep -qi "already exists\|Reference already exists"; then
+                echo "Tag ${CANDIDATE} already exists (HTTP 422), incrementing SEQ..."
+                SEQ=$((SEQ + 1))
+                ATTEMPT=$((ATTEMPT + 1))
+              else
+                echo "::error::Fatal error reserving tag ${CANDIDATE}: ${ERR_BODY}"
+                exit 1
+              fi
+            fi
+          done
+
+          # Step 4 exhaustion — silent success and || true are PROHIBITED on exhaustion.
+          if [ -z "$TAG" ]; then
+            echo "::error::alpha tag reservation failed after ${MAX_ATTEMPTS} attempts — burst contention ceiling exceeded; retry when concurrent workflow runs settle"
+            exit 1
+          fi
+
+          # Step 5: export reserved name.
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Alpha release: $TAG"
 
       - name: Download alpha binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8

--- a/.github/workflows/sign-and-publish.yml
+++ b/.github/workflows/sign-and-publish.yml
@@ -286,7 +286,10 @@ jobs:
 
       - name: Verify signatures (Gatekeeper + codesign)
         run: |
-          set -e
+          set -eo pipefail
+          CS_OUT=$(mktemp)
+          SPCTL_OUT=$(mktemp)
+          trap 'rm -f "$CS_OUT" "$SPCTL_OUT"' EXIT
           # Bare Mach-O binaries: stapler can't attach to a bare binary
           # (Apple TN3147), so `spctl --assess --type execute` would
           # report "Unnotarized Developer ID". Verify the load-bearing
@@ -294,12 +297,12 @@ jobs:
           # identity, stable Team Identifier, and hardened runtime flag.
           for BIN in jr-a-darwin-arm64 jr-a-darwin-amd64; do
             echo "::group::Verify $BIN"
-            codesign -dvv "$BIN" 2>&1 | tee /tmp/cs.out
-            grep -q "^Authority=Developer ID Application:" /tmp/cs.out \
+            codesign -dvv "$BIN" 2>&1 | tee "$CS_OUT"
+            grep -q "^Authority=Developer ID Application:" "$CS_OUT" \
               || { echo "::error::$BIN missing Developer ID Application authority"; exit 1; }
-            grep -q "^TeamIdentifier=" /tmp/cs.out \
+            grep -q "^TeamIdentifier=" "$CS_OUT" \
               || { echo "::error::$BIN missing TeamIdentifier"; exit 1; }
-            grep -qE "^CodeDirectory.*flags=0x[0-9a-f]+\(.*runtime.*\)" /tmp/cs.out \
+            grep -qE "^CodeDirectory.*flags=0x[0-9a-f]+\(.*runtime.*\)" "$CS_OUT" \
               || { echo "::error::$BIN missing hardened runtime (--options runtime) flag"; exit 1; }
             echo "::endgroup::"
           done
@@ -308,15 +311,15 @@ jobs:
           # stapled. .pkg → --type install; .dmg → --type open.
           for PKG in jr-a-arm64.pkg jr-a-amd64.pkg; do
             echo "::group::Verify $PKG"
-            spctl --assess --type install --verbose=4 "$PKG" 2>&1 | tee /tmp/spctl.out
-            grep -q "source=Notarized Developer ID" /tmp/spctl.out \
+            spctl --assess --type install --verbose=4 "$PKG" 2>&1 | tee "$SPCTL_OUT"
+            grep -q "source=Notarized Developer ID" "$SPCTL_OUT" \
               || { echo "::error::$PKG not notarized (spctl source unexpected)"; exit 1; }
             echo "::endgroup::"
           done
           for DMG in jr-a-arm64.dmg jr-a-amd64.dmg; do
             echo "::group::Verify $DMG"
-            spctl --assess --type open --verbose=4 "$DMG" 2>&1 | tee /tmp/spctl.out
-            grep -q "source=Notarized Developer ID" /tmp/spctl.out \
+            spctl --assess --type open --verbose=4 "$DMG" 2>&1 | tee "$SPCTL_OUT"
+            grep -q "source=Notarized Developer ID" "$SPCTL_OUT" \
               || { echo "::error::$DMG not notarized (spctl source unexpected)"; exit 1; }
             echo "::endgroup::"
           done
@@ -554,7 +557,10 @@ jobs:
 
       - name: Verify signatures (Gatekeeper + codesign)
         run: |
-          set -e
+          set -eo pipefail
+          CS_OUT=$(mktemp)
+          SPCTL_OUT=$(mktemp)
+          trap 'rm -f "$CS_OUT" "$SPCTL_OUT"' EXIT
           # Bare Mach-O binaries: stapler can't attach to a bare binary
           # (Apple TN3147), so `spctl --assess --type execute` would
           # report "Unnotarized Developer ID". Verify the load-bearing
@@ -562,12 +568,12 @@ jobs:
           # identity, stable Team Identifier, and hardened runtime flag.
           for BIN in jr-darwin-arm64 jr-darwin-amd64; do
             echo "::group::Verify $BIN"
-            codesign -dvv "$BIN" 2>&1 | tee /tmp/cs.out
-            grep -q "^Authority=Developer ID Application:" /tmp/cs.out \
+            codesign -dvv "$BIN" 2>&1 | tee "$CS_OUT"
+            grep -q "^Authority=Developer ID Application:" "$CS_OUT" \
               || { echo "::error::$BIN missing Developer ID Application authority"; exit 1; }
-            grep -q "^TeamIdentifier=" /tmp/cs.out \
+            grep -q "^TeamIdentifier=" "$CS_OUT" \
               || { echo "::error::$BIN missing TeamIdentifier"; exit 1; }
-            grep -qE "^CodeDirectory.*flags=0x[0-9a-f]+\(.*runtime.*\)" /tmp/cs.out \
+            grep -qE "^CodeDirectory.*flags=0x[0-9a-f]+\(.*runtime.*\)" "$CS_OUT" \
               || { echo "::error::$BIN missing hardened runtime (--options runtime) flag"; exit 1; }
             echo "::endgroup::"
           done
@@ -576,15 +582,15 @@ jobs:
           # stapled. .pkg → --type install; .dmg → --type open.
           for PKG in jr-arm64.pkg jr-amd64.pkg; do
             echo "::group::Verify $PKG"
-            spctl --assess --type install --verbose=4 "$PKG" 2>&1 | tee /tmp/spctl.out
-            grep -q "source=Notarized Developer ID" /tmp/spctl.out \
+            spctl --assess --type install --verbose=4 "$PKG" 2>&1 | tee "$SPCTL_OUT"
+            grep -q "source=Notarized Developer ID" "$SPCTL_OUT" \
               || { echo "::error::$PKG not notarized (spctl source unexpected)"; exit 1; }
             echo "::endgroup::"
           done
           for DMG in jr-arm64.dmg jr-amd64.dmg; do
             echo "::group::Verify $DMG"
-            spctl --assess --type open --verbose=4 "$DMG" 2>&1 | tee /tmp/spctl.out
-            grep -q "source=Notarized Developer ID" /tmp/spctl.out \
+            spctl --assess --type open --verbose=4 "$DMG" 2>&1 | tee "$SPCTL_OUT"
+            grep -q "source=Notarized Developer ID" "$SPCTL_OUT" \
               || { echo "::error::$DMG not notarized (spctl source unexpected)"; exit 1; }
             echo "::endgroup::"
           done

--- a/.github/workflows/sign-and-publish.yml
+++ b/.github/workflows/sign-and-publish.yml
@@ -403,8 +403,10 @@ jobs:
 
       - name: Extract release metadata
         id: meta
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          TAG="${{ github.event.workflow_run.head_branch }}"
+          TAG="$HEAD_BRANCH"
           VERSION="${TAG#v}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sign-and-publish.yml
+++ b/.github/workflows/sign-and-publish.yml
@@ -256,8 +256,9 @@ jobs:
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_INSTALLER_IDENTITY: ${{ secrets.APPLE_INSTALLER_IDENTITY }}
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          VERSION="${{ steps.meta.outputs.version }}"
+          VERSION="$RELEASE_VERSION"
           chmod +x scripts/create-app.sh scripts/create-dmg.sh scripts/create-pkg.sh
 
           for arch in arm64 amd64; do
@@ -334,8 +335,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HOMEBREW_TAP_REPO: ${{ vars.HOMEBREW_TAP_REPO }}
+          RELEASE_TAG: ${{ steps.meta.outputs.tag }}
         run: |
-          TAG="${{ steps.meta.outputs.tag }}"
+          TAG="$RELEASE_TAG"
 
           BINARY_LINE="download below"
           if [ -n "$HOMEBREW_TAP_REPO" ]; then
@@ -385,8 +387,9 @@ jobs:
       - name: Download signed binaries from release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.alpha-sign.outputs.tag }}
         run: |
-          TAG="${{ needs.alpha-sign.outputs.tag }}"
+          TAG="$RELEASE_TAG"
           gh release download "$TAG" --pattern "jr-a-darwin-arm64" --dir .
           gh release download "$TAG" --pattern "jr-a-darwin-amd64" --dir .
 
@@ -394,9 +397,11 @@ jobs:
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           HOMEBREW_TAP_REPO: ${{ vars.HOMEBREW_TAP_REPO }}
+          RELEASE_VERSION: ${{ needs.alpha-sign.outputs.version }}
+          RELEASE_TAG: ${{ needs.alpha-sign.outputs.tag }}
         run: |
-          VERSION="${{ needs.alpha-sign.outputs.version }}"
-          TAG="${{ needs.alpha-sign.outputs.tag }}"
+          VERSION="$RELEASE_VERSION"
+          TAG="$RELEASE_TAG"
 
           TAP_SHORT="${HOMEBREW_TAP_REPO#*/}"
           TAP_NAME="${HOMEBREW_TAP_REPO%%/*}/${TAP_SHORT#homebrew-}"
@@ -478,8 +483,9 @@ jobs:
       - name: Download release binaries
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.meta.outputs.tag }}
         run: |
-          TAG="${{ steps.meta.outputs.tag }}"
+          TAG="$RELEASE_TAG"
           for target in x86_64-apple-darwin aarch64-apple-darwin; do
             ASSET="jr-${TAG}-${target}.tar.gz"
             echo "Downloading $ASSET..."
@@ -527,8 +533,9 @@ jobs:
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_INSTALLER_IDENTITY: ${{ secrets.APPLE_INSTALLER_IDENTITY }}
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          VERSION="${{ steps.meta.outputs.version }}"
+          VERSION="$RELEASE_VERSION"
           chmod +x scripts/create-app.sh scripts/create-dmg.sh scripts/create-pkg.sh
 
           for arch in arm64 amd64; do
@@ -604,8 +611,9 @@ jobs:
       - name: Upload signed artifacts to release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.meta.outputs.tag }}
         run: |
-          TAG="${{ steps.meta.outputs.tag }}"
+          TAG="$RELEASE_TAG"
           gh release upload "$TAG" \
             jr-darwin-arm64 \
             jr-darwin-amd64 \
@@ -620,9 +628,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HOMEBREW_TAP_REPO: ${{ vars.HOMEBREW_TAP_REPO }}
+          RELEASE_TAG: ${{ steps.meta.outputs.tag }}
+          RELEASE_CHANNEL: ${{ steps.meta.outputs.channel }}
         run: |
-          TAG="${{ steps.meta.outputs.tag }}"
-          CHANNEL="${{ steps.meta.outputs.channel }}"
+          TAG="$RELEASE_TAG"
+          CHANNEL="$RELEASE_CHANNEL"
 
           # Map channel to formula name
           case "$CHANNEL" in
@@ -682,8 +692,9 @@ jobs:
       - name: Download signed binaries from release
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.stable-sign.outputs.tag }}
         run: |
-          TAG="${{ needs.stable-sign.outputs.tag }}"
+          TAG="$RELEASE_TAG"
           gh release download "$TAG" --pattern "jr-darwin-arm64" --dir .
           gh release download "$TAG" --pattern "jr-darwin-amd64" --dir .
 
@@ -691,11 +702,14 @@ jobs:
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           HOMEBREW_TAP_REPO: ${{ vars.HOMEBREW_TAP_REPO }}
+          RELEASE_VERSION: ${{ needs.stable-sign.outputs.version }}
+          RELEASE_TAG: ${{ needs.stable-sign.outputs.tag }}
+          RELEASE_CHANNEL: ${{ needs.stable-sign.outputs.channel }}
         run: |
           set -euo pipefail
-          VERSION="${{ needs.stable-sign.outputs.version }}"
-          TAG="${{ needs.stable-sign.outputs.tag }}"
-          CHANNEL="${{ needs.stable-sign.outputs.channel }}"
+          VERSION="$RELEASE_VERSION"
+          TAG="$RELEASE_TAG"
+          CHANNEL="$RELEASE_CHANNEL"
 
           # Map channel to formula name
           case "$CHANNEL" in

--- a/docs/specs/fork-friendly-release-ops.md
+++ b/docs/specs/fork-friendly-release-ops.md
@@ -94,6 +94,292 @@ workflow can't auto-resolve it, so the merge stops for a human. To avoid it:
 3. **Never add shared docs to `local-workflows.txt`.** That converts shared
    content into fork divergence and swallows upstream edits to the same file.
 
+## Security constraints (sign-and-publish.yml / backfill-release.yml)
+
+These requirements apply to any job in `sign-and-publish.yml` or
+`backfill-release.yml` that has secrets (Apple Developer ID credentials) or
+`contents: write` in scope.
+
+### No inline context data in shell run-blocks (CWE-77)
+
+Any context value that is not on the short allowlist of structurally-safe
+values below MUST be bound via a step-level `env:` mapping and referenced as a
+double-quoted shell variable inside the `run:` block.
+
+**Allowlist** (safe to expand inline — these are FORMAT-CONSTRAINED values:
+`github.sha` is a hex string `[0-9a-f]{40}`, `github.run_id` and
+`github.run_number` are integers, `github.repository` and
+`github.repository_owner` are constrained to `[A-Za-z0-9._-]` with a single
+`/` separator for owner/repo — GitHub's naming rules prohibit shell
+metacharacters in repository and owner names; their format makes them safe
+regardless of provenance):
+- `github.sha`
+- `github.run_id`
+- `github.run_number`
+- `github.repository`
+- `github.repository_owner`
+
+The allowlist is the ONLY exception set. Any context value not explicitly
+listed here is high-risk by default and MUST be bound via `env:`.
+
+**High-risk sources (non-exhaustive — illustrative examples) that MUST always
+be bound via `env:`:**
+- `github.event.*` (all fields — in particular
+  `github.event.workflow_run.head_branch`)
+- `github.head_ref`
+- `github.ref_name`
+- `github.ref`
+- `github.base_ref`
+- `github.actor`
+- `github.triggering_actor`
+- `inputs.*` (all workflow_dispatch inputs)
+- `steps.*.outputs.*` derived from any of the above
+
+```yaml
+# REQUIRED
+- name: Extract release metadata
+  env:
+    HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+  run: |
+    TAG="$HEAD_BRANCH"
+    ...
+
+# PROHIBITED
+- name: Extract release metadata
+  run: |
+    TAG="${{ github.event.workflow_run.head_branch }}"  # shell-injection vector
+```
+
+**Dangerous-sink rule:** a bound value, even when double-quoted, MUST NOT be
+passed to any context that re-parses or re-executes it — including but not
+limited to: `eval`, `bash -c`/`sh -c`, backticks, unquoted command
+substitution, arithmetic context `$(( ))`, indirect expansion `${!var}`,
+`source`/`.` of attacker-influenced content, here-strings or here-docs feeding
+a parser, or re-execution via `xargs sh`/`printf -v`-then-execute.
+Double-quoting is insufficient if the value reaches any such sink.
+
+For `actions/github-script` steps, context values MUST be passed via the step
+`env:` map and read as `process.env.X` in the JS body; inline `${{ }}`
+interpolation into the script string is prohibited regardless of the source.
+
+**Guard scope note:** The CI regression guard (below) MUST NOT flag context
+expansions in `env:`, `with:`, or `if:` keys — ONLY those textually inside
+a `run:` script body. A correctly-written step with `env: { HEAD_BRANCH: ${{
+github.event.workflow_run.head_branch }} }` must not trigger the guard. The
+canonical-repo ci-gate MUST pass with the env-bound HEAD_BRANCH example above
+present; if the guard fires on `env:` keys it MUST be fixed before merge.
+
+Rationale: GitHub's "Security hardening for GitHub Actions — Understanding the
+risk of script injections" identifies inline `${{ expression }}` expansion in
+`run:` blocks as a shell-injection risk. A branch name containing shell
+metacharacters (`;`, backticks, `$()`) is interpreted as shell syntax during
+template expansion, before the runner executes the script. Binding via `env:`
+passes the value as a literal environment variable — metacharacters are inert
+at the variable-reference site, but remain active at any downstream code sink.
+
+During an F5 adversarial pass, scan ALL `${{ }}` inline expansions in every
+job that has secrets OR `contents: write` in scope across BOTH workflow files —
+`stable-sign` and `alpha-sign` in `sign-and-publish.yml`; the `sign` job and
+the `release` job in `backfill-release.yml` (the `release` job declares
+`permissions: contents: write` and inlines `${{ github.repository }}` in
+run-blocks) — not just the identified `head_branch` field — to confirm no
+context values outside the allowlist are inline-expanded in `run:` blocks.
+`backfill-release.yml` inlines `${{ inputs.tag }}` across multiple
+signing-path `run:` blocks; these are in scope for the same CWE-77
+env-binding remediation. `${{ github.repository }}` is on the allowlist
+(format-constrained) so the existing inline usage in the `release` and
+homebrew jobs requires no remediation. The F5 scope statement and this
+normative rule cover the same surface: every job with secrets or
+`contents: write` across both files.
+
+### Atomic alpha-tag creation (no TOCTOU)
+
+The `alpha-sign` job MUST use atomic, server-side tag creation via the GitHub
+API. Two concurrent `develop` pushes can observe the same tag count and compute
+the same tag name, producing a race to last-write; only a server-enforced
+uniqueness check eliminates the TOCTOU window.
+
+**Complete control flow for the "Generate alpha version" step** — the entire
+tag-reservation sequence MUST be implemented exactly as described here.
+Piecewise interpretation is prohibited; this block is the sole normative
+source of truth for an F4 implementer.
+
+```
+1. Bind inputs from env: (CWE-77 rule)
+     COMMIT_SHA  ← env: bound from github.sha
+     GH_TOKEN    ← env: bound from github.token
+     DATE        ← $(date -u +%Y%m%d)   [computed locally, not from context]
+
+2. Compute seed hint
+     EXISTING ← git ls-remote --tags origin "refs/tags/alpha-${DATE}.*" | wc -l
+     SEQ      ← EXISTING + 1
+     (The seed is a starting hint only. Correctness does NOT depend on its
+      accuracy. The atomic reservation + retry loop is the sole guarantor of
+      uniqueness. Re-counting on retry is FORBIDDEN — see step 4.)
+
+3. Attempt atomic reservation (first try, sequence = SEQ)
+     gh api --method POST /repos/{owner}/{repo}/git/refs \
+       -f ref="refs/tags/alpha-${DATE}.${SEQ}" \
+       -f sha="$COMMIT_SHA"
+     → HTTP 201: reservation succeeded. TAG="alpha-${DATE}.${SEQ}". Go to step 5.
+     → HTTP 422: ref already exists (another run reserved it). Go to step 4.
+     → Any other non-zero exit: fatal — exit 1 with diagnostic.
+
+4. Retry loop (on 422 only)
+     MAX_ATTEMPTS=10   [includes the first attempt in step 3]
+     ATTEMPT=1
+     while ATTEMPT < MAX_ATTEMPTS:
+       SEQ ← SEQ + 1               [increment from just-rejected sequence;
+                                     NEVER re-count remote tags]
+       ATTEMPT ← ATTEMPT + 1
+       gh api --method POST /repos/{owner}/{repo}/git/refs \
+         -f ref="refs/tags/alpha-${DATE}.${SEQ}" \
+         -f sha="$COMMIT_SHA"
+       → HTTP 201: TAG="alpha-${DATE}.${SEQ}". Go to step 5.
+       → HTTP 422: continue loop.
+       → Any other non-zero exit: fatal — exit 1 with diagnostic.
+     Loop exhausted without success:
+       exit 1  ["alpha tag reservation failed after N attempts — burst contention
+                 ceiling exceeded; retry when concurrent workflow runs settle"]
+     Silent success, '|| true', and swallowed skips are PROHIBITED on exhaustion.
+
+5. Export reserved name
+     echo "tag=$TAG"         >> "$GITHUB_OUTPUT"
+     echo "version=$TAG"     >> "$GITHUB_OUTPUT"
+```
+
+There is NO pre-reservation purge step. The unconditional
+`gh release delete --cleanup-tag` that appeared in prior versions of this step
+is DROPPED. Rationale: a pre-purge targeting the seed name (e.g. `.1`) is
+destructive and TOCTOU-unsafe — it can delete a ref that a concurrent run just
+reserved if both runs compute the same seed. With atomic reservation and
+bounded retry, a pre-existing ref (orphan from a prior failed run) simply
+causes a 422 and the loop walks to the next sequence number, producing a
+harmless gap rather than a destructive overwrite. Sequence-number gaps in the
+alpha channel are acceptable. Correctness is guaranteed by the reservation
+loop, not by pre-cleaning.
+
+Orphaned alpha tags and releases from prior failed runs are NOT cleaned by this
+step. Orphan cleanup is a SEPARATE out-of-scope concern; a future housekeeping
+story should address it (e.g. a scheduled job that removes alpha tags/releases
+older than N days with no associated binary assets).
+
+**Post-reservation invariant:** nothing after the reservation (step 5) may
+delete or recreate the reserved ref. `gh release create` and all subsequent
+steps consume the already-reserved `$TAG` without touching the tag ref itself.
+
+`$COMMIT_SHA` MUST be bound from an `env:` value (consistent with the CWE-77
+rule above — never inline-expanded from context). `gh api --method POST` exits
+non-zero on any 4xx response; the 422 body may additionally be captured for
+diagnostic logging.
+
+The `gh` CLI with `GH_TOKEN` is the established credential model for these
+jobs (`persist-credentials: false` is set on the checkout); `git push` for
+alpha-tag creation in the `alpha-sign` job is prohibited because the job
+deliberately holds no git remote credentials and `git push` would require
+re-introducing them. (The alpha-homebrew and stable-homebrew jobs legitimately
+use `git push` to the tap repo via an x-access-token clone — this prohibition
+is scoped to the `alpha-sign` job's tag-creation operation only. Both homebrew
+jobs already access these values safely: `vars.HOMEBREW_TAP_REPO` is bound via
+a step-level `env:` key and referenced as `$HOMEBREW_TAP_REPO` in the run
+block; `github.repository` is read via the runner-provided env var
+`${GITHUB_REPOSITORY}` — neither is inlined as `${{ }}` inside a `run:` shell
+script. There is therefore no inline-context-injection sink in the homebrew
+jobs for these two values. Both jobs remain within the CWE-77 audit scope and
+carry lower attacker-control risk than event-sourced context, but require no
+remediation for this particular pair of values.)
+
+`git push --force` on a tag is prohibited (defeats atomicity).
+`--force-with-lease` does not apply to new tag creation and provides no safety.
+
+### Required CI regression guard
+
+A one-shot F5 scan provides no protection against re-introduction of inline
+context expansions in these secret-bearing workflows. A CI guard is REQUIRED
+(not optional) that:
+
+1. Scans all `run:` blocks reachable from every job that has secrets OR
+   `contents: write` in scope across BOTH workflow files — including the `sign`,
+   `stable-sign`, `alpha-sign`, and `release` jobs, and any local composite
+   actions they invoke (not only two hard-coded workflow filenames) — for inline
+   `${{ }}` expansions of high-risk context sources (the sources listed in the
+   high-risk section above). The extraction MUST be YAML-structure-aware —
+   either by parsing the document and iterating `jobs.*.steps[].run`, or by
+   mandating a workflow-security linter that models `run:` block boundaries such
+   as zizmor or actionlint. A naive line-oriented grep is INSUFFICIENT: it
+   cannot reliably delimit `run:` scope and misses `${{` split across lines in
+   folded or block scalars.
+2. Fails CI if any inline high-risk expansions are found inside `run:` blocks.
+   Context expansions in `env:`, `with:`, or `if:` keys MUST NOT be flagged.
+3. Emits a runtime-computed positive-coverage assertion on success that reports
+   total `${{ }}` occurrences scanned vs. classified — for example: "scanned N
+   run-blocks across M workflows, K total ${{}} expressions scanned, 0 inline
+   high-risk expansions" — so a broken script or unexpectedly low scanned count
+   is immediately visible and cannot produce a silent false-green.
+4. Is wired into CI by adding its job to `ci-gate.needs` per the project's
+   CI-gate convention (CLAUDE.md). Do NOT wire it directly into branch
+   protection.
+
+The guard MUST be implemented as a script in `scripts/` or via an action-lint
+tool (zizmor preferred; actionlint as an alternative). F6 is responsible for
+implementing this guard; it is in-scope for story S-FORK-OPS-SIGN-1.
+
+**F6 negative-fixture sub-deliverable:** F6 MUST exercise the guard against a
+deliberately-injected violation fixture — a sample `run:` block containing an
+inline high-risk `${{ github.event.* }}` expansion — and confirm the guard
+rejects it (non-zero exit). This demonstrates the detector is not a no-op and
+prevents the TD-VSDD-057 false-green class where an inert detector reports
+exit-0 for every input.
+
+### Verify-step shell conventions (CWE-377 / CWE-390 / CWE-362)
+
+All signature-verification steps in both workflow files must satisfy two shell
+hygiene requirements:
+
+**Temp-file safety (CWE-377/362):** Use `mktemp` with a `trap '...' EXIT`
+cleanup for any temporary file. Predictable paths such as `/tmp/cs.out` or
+`/tmp/spctl.out` are prohibited on shared runners.
+
+```bash
+# REQUIRED
+CS_OUT=$(mktemp)
+SPCTL_OUT=$(mktemp)
+trap 'rm -f "$CS_OUT" "$SPCTL_OUT"' EXIT
+codesign -dvv "$BIN" 2>&1 | tee "$CS_OUT"
+spctl --assess --type install --verbose=4 "$PKG" 2>&1 | tee "$SPCTL_OUT"
+
+# PROHIBITED
+codesign -dvv "$BIN" 2>&1 | tee /tmp/cs.out   # predictable path
+```
+
+**Pipefail (CWE-390):** Verification steps must start with `set -eo pipefail`.
+Without `pipefail`, a failing `codesign` or `spctl` in a `... | tee` chain
+exits the pipe with `tee`'s exit code (0), masking the failure. `set -e` alone
+only catches the last command in a pipeline.
+
+```bash
+# REQUIRED
+set -eo pipefail
+codesign -dvv "$BIN" 2>&1 | tee "$CS_OUT"
+
+# PROHIBITED
+set -e                                         # pipefail missing
+codesign -dvv "$BIN" 2>&1 | tee "$CS_OUT"    # failure silently masked
+```
+
+Note: with `set -eo pipefail` active, the `codesign ... | tee "$CS_OUT"` line
+is itself the failure point when `codesign` exits non-zero. The subsequent
+`grep ... || { ...; exit 1; }` guard that many verification steps include MUST
+NOT be removed as "redundant" — it checks a different condition (pattern
+presence in the output), which `pipefail` alone does not enforce. Both guards
+are required.
+
+**Temp-file reuse across loop iterations:** one temp file per verification
+target, reused across loop iterations, is acceptable. Do not create a new temp
+file per iteration — that produces unbounded files on a shared runner.
+The `trap '...' EXIT` cleanup handles the single set of named temp files
+regardless of how many loop passes run.
+
 ## Known limitations
 
 - `sync-upstream.yml` hardcodes the branch matrix

--- a/docs/specs/fork-friendly-release-ops.md
+++ b/docs/specs/fork-friendly-release-ops.md
@@ -96,15 +96,30 @@ workflow can't auto-resolve it, so the merge stops for a human. To avoid it:
 
 ## Security constraints (sign-and-publish.yml / backfill-release.yml)
 
-These requirements apply to any job in `sign-and-publish.yml` or
-`backfill-release.yml` that has secrets (Apple Developer ID credentials) or
-`contents: write` in scope.
+These requirements apply to **every job** in `sign-and-publish.yml` or
+`backfill-release.yml` that meets any of the following criteria, computed
+per-job by inspection — NOT by a hardcoded job-name list:
+
+- (a) the job uses any `secrets.*` value (Apple Developer ID credentials,
+  tap token, etc.), OR
+- (b) the job or the workflow declares `permissions: contents: write`, OR
+- (c) the job references a named `environment:` that carries secrets.
+
+An implementing guard MUST compute scope by inspecting each job for criteria
+(a)–(c) above. Hardcoding a fixed job-name list (e.g. only "sign" and
+"release") is prohibited: it silently misses newly-added jobs that meet the
+criterion. The job names `stable-sign`, `alpha-sign`, `sign`, and `release`
+are illustrative examples of current jobs that happen to meet the criterion —
+they are NOT a normative enumeration. Any job added to either file that meets
+(a), (b), or (c) is automatically in scope.
 
 ### No inline context data in shell run-blocks (CWE-77)
 
-Any context value that is not on the short allowlist of structurally-safe
-values below MUST be bound via a step-level `env:` mapping and referenced as a
-double-quoted shell variable inside the `run:` block.
+**DEFAULT-DENY rule for `run:` script bodies:** the ONLY context expressions
+permitted inline in a `run:` body of any in-scope job are the format-safe
+allowlist below. EVERY other context expression MUST be bound via a step-level
+`env:` mapping and referenced as a double-quoted shell variable inside the
+`run:` block — regardless of whether the value appears server-generated.
 
 **Allowlist** (safe to expand inline — these are FORMAT-CONSTRAINED values:
 `github.sha` is a hex string `[0-9a-f]{40}`, `github.run_id` and
@@ -119,11 +134,11 @@ regardless of provenance):
 - `github.repository`
 - `github.repository_owner`
 
-The allowlist is the ONLY exception set. Any context value not explicitly
-listed here is high-risk by default and MUST be bound via `env:`.
+The allowlist is the ONLY exception set. Any context expression not explicitly
+listed here MUST be bound via `env:`.
 
-**High-risk sources (non-exhaustive — illustrative examples) that MUST always
-be bound via `env:`:**
+**Explicitly prohibited inline** (illustrative, non-exhaustive — the default-deny
+rule covers everything not on the allowlist, including but not limited to):
 - `github.event.*` (all fields — in particular
   `github.event.workflow_run.head_branch`)
 - `github.head_ref`
@@ -133,7 +148,21 @@ be bound via `env:`:**
 - `github.actor`
 - `github.triggering_actor`
 - `inputs.*` (all workflow_dispatch inputs)
-- `steps.*.outputs.*` derived from any of the above
+- `steps.*.outputs.*` and `needs.*.outputs.*` — REGARDLESS of whether the
+  output appears server-generated; a step or job output can launder an
+  attacker-controlled value through multiple hops (e.g.
+  `stable-sign.outputs.tag` derived from
+  `github.event.workflow_run.head_branch`), and a guard cannot reliably trace
+  cross-job derivation chains. The safe, enforceable rule is to bind ALL
+  non-allowlisted expressions, not to maintain a derivation-provenance list.
+
+**`matrix.*` and `runner.*` are NOT subject to this rule.** `matrix.*` values
+are workflow-author-defined static literals set in the matrix include list —
+they are author-controlled, not attacker-controlled, and their format depends
+entirely on what the author wrote. `runner.*` values are runner-provided
+metadata (OS, architecture, temp path) and equally author/platform-controlled.
+Neither source accepts attacker input. They may appear inline in `run:` bodies
+without env-binding.
 
 ```yaml
 # REQUIRED
@@ -178,19 +207,18 @@ passes the value as a literal environment variable — metacharacters are inert
 at the variable-reference site, but remain active at any downstream code sink.
 
 During an F5 adversarial pass, scan ALL `${{ }}` inline expansions in every
-job that has secrets OR `contents: write` in scope across BOTH workflow files —
-`stable-sign` and `alpha-sign` in `sign-and-publish.yml`; the `sign` job and
-the `release` job in `backfill-release.yml` (the `release` job declares
-`permissions: contents: write` and inlines `${{ github.repository }}` in
-run-blocks) — not just the identified `head_branch` field — to confirm no
-context values outside the allowlist are inline-expanded in `run:` blocks.
-`backfill-release.yml` inlines `${{ inputs.tag }}` across multiple
-signing-path `run:` blocks; these are in scope for the same CWE-77
-env-binding remediation. `${{ github.repository }}` is on the allowlist
-(format-constrained) so the existing inline usage in the `release` and
-homebrew jobs requires no remediation. The F5 scope statement and this
-normative rule cover the same surface: every job with secrets or
-`contents: write` across both files.
+job that has secrets OR `contents: write` in scope (per criteria (a)–(c) above)
+across BOTH workflow files — not just the identified `head_branch` field — to
+confirm no context expressions outside the allowlist are inline-expanded in
+`run:` blocks. The scope is computed by inspecting each job, not from a fixed
+list: current in-scope examples include `stable-sign` and `alpha-sign` in
+`sign-and-publish.yml`, and the `sign` and `release` jobs in
+`backfill-release.yml`. `backfill-release.yml` inlines `${{ inputs.tag }}`
+across multiple signing-path `run:` blocks; these are in scope for the same
+CWE-77 env-binding remediation. `${{ github.repository }}` is on the allowlist
+(format-constrained) so the existing inline usage in the `release` and homebrew
+jobs requires no remediation. The F5 scan scope and this normative rule cover
+the same surface: every job meeting criteria (a)–(c) across both files.
 
 ### Atomic alpha-tag creation (no TOCTOU)
 
@@ -298,27 +326,40 @@ A one-shot F5 scan provides no protection against re-introduction of inline
 context expansions in these secret-bearing workflows. A CI guard is REQUIRED
 (not optional) that:
 
-1. Scans all `run:` blocks reachable from every job that has secrets OR
-   `contents: write` in scope across BOTH workflow files — including the `sign`,
-   `stable-sign`, `alpha-sign`, and `release` jobs, and any local composite
-   actions they invoke (not only two hard-coded workflow filenames) — for inline
-   `${{ }}` expansions of high-risk context sources (the sources listed in the
-   high-risk section above). The extraction MUST be YAML-structure-aware —
-   either by parsing the document and iterating `jobs.*.steps[].run`, or by
-   mandating a workflow-security linter that models `run:` block boundaries such
-   as zizmor or actionlint. A naive line-oriented grep is INSUFFICIENT: it
-   cannot reliably delimit `run:` scope and misses `${{` split across lines in
-   folded or block scalars.
-2. Fails CI if any inline high-risk expansions are found inside `run:` blocks.
-   Context expansions in `env:`, `with:`, or `if:` keys MUST NOT be flagged.
+1. Scans all `run:` blocks reachable from every job meeting criteria (a)–(c)
+   above across BOTH workflow files — including any local composite actions they
+   invoke (not only two hard-coded workflow filenames) — for inline `${{ }}`
+   expansions of context expressions not on the allowlist. The extraction MUST
+   be YAML-structure-aware — either by parsing the document and iterating
+   `jobs.*.steps[].run`, or by mandating a workflow-security linter that models
+   `run:` block boundaries such as zizmor or actionlint. A naive line-oriented
+   grep is INSUFFICIENT: it cannot reliably delimit `run:` scope and misses
+   `${{` split across lines in folded or block scalars.
+2. Fails CI if any inline non-allowlisted expansions are found inside `run:`
+   blocks. Context expansions in `env:`, `with:`, or `if:` keys MUST NOT be
+   flagged. `matrix.*` and `runner.*` inline expressions MUST NOT be flagged
+   (see above).
 3. Emits a runtime-computed positive-coverage assertion on success that reports
-   total `${{ }}` occurrences scanned vs. classified — for example: "scanned N
-   run-blocks across M workflows, K total ${{}} expressions scanned, 0 inline
-   high-risk expansions" — so a broken script or unexpectedly low scanned count
-   is immediately visible and cannot produce a silent false-green.
+   the COUNT OF JOBS classified in-scope AND total `${{ }}` occurrences scanned
+   vs. classified — for example: "N jobs in-scope, scanned M run-blocks across P
+   workflows, K total ${{}} expressions scanned, 0 inline non-allowlisted
+   expansions" — so a broken script or unexpectedly low scanned count is
+   immediately visible and cannot produce a silent false-green.
 4. Is wired into CI by adding its job to `ci-gate.needs` per the project's
    CI-gate convention (CLAUDE.md). Do NOT wire it directly into branch
    protection.
+5. **Fails closed (non-zero exit) on any of the following error conditions:**
+   - A YAML parse error in any scanned workflow file.
+   - The YAML parsing library is unavailable or fails to load.
+   - A workflow file that is in scope cannot be read (missing, permission
+     denied, etc.).
+   - Structural scope detection finds ZERO in-scope jobs in a file that is
+     expected to contain signing or secrets jobs. Zero in-scope jobs is a
+     sentinel for a broken scope-detection heuristic or a silently-renamed
+     job — it MUST be treated as a guard failure, not a clean pass. The
+     positive-coverage assertion on job count (requirement 3) is the
+     mechanism: if the count is zero, the guard exits non-zero with a
+     diagnostic explaining that no in-scope jobs were found.
 
 The guard MUST be implemented as a script in `scripts/` or via an action-lint
 tool (zizmor preferred; actionlint as an alternative). F6 is responsible for

--- a/scripts/check-signing-workflow-injection.sh
+++ b/scripts/check-signing-workflow-injection.sh
@@ -16,17 +16,36 @@
 # to extract run: block bodies. A naive line-oriented grep is INSUFFICIENT
 # (cannot delimit run: scope, misses ${{ split across lines in block scalars).
 #
-# SCOPE: both sign-and-publish.yml and backfill-release.yml, restricted to jobs
-# with secrets in scope or `contents: write` permissions.
-# Named jobs in scope: stable-sign, alpha-sign (sign-and-publish.yml);
-#                      sign, release (backfill-release.yml).
+# SCOPE: both sign-and-publish.yml and backfill-release.yml.
+# Scope is COMPUTED STRUCTURALLY per-job — NOT from a hardcoded job-name list.
+# A job is in scope when it meets ANY of:
+#   (a) the job body contains any `secrets.*` reference (in any key under the job),
+#   (b) the job-level `permissions.contents` is `write`, OR
+#       the workflow-level `permissions.contents` is `write`, OR
+#   (c) the job references a named `environment:` key.
+#
+# NOTE on criterion (b): only EXPLICIT `contents: write` is flagged. Jobs that
+# simply inherit the workflow-default `contents: read` are NOT considered in
+# scope on that criterion alone (they can still be in scope via (a) or (c)).
 #
 # ALLOWLIST (safe to inline — format-constrained values with no shell metacharacters):
 #   github.sha, github.run_id, github.run_number,
 #   github.repository, github.repository_owner
+# Additionally, matrix.* and runner.* are safe (author/platform-controlled).
+#
+# DEFAULT-DENY rule: EVERY context expression not on the allowlist or in
+# matrix.*/runner.* MUST be env-bound. This includes steps.*.outputs.* and
+# needs.*.outputs.* — these can launder attacker-controlled values through
+# multi-hop derivation chains that a guard cannot reliably trace.
 #
 # GUARD SCOPE NOTE: MUST NOT flag context expansions in env:, with:, or if:
 # YAML keys — ONLY those textually inside run: script bodies.
+#
+# FAIL-CLOSED behaviour:
+#   exit 1 — flagged violations found
+#   exit 2 — YAML parse error, missing PyYAML, unreadable file,
+#             or zero in-scope jobs detected in a workflow file
+#             (sentinel for broken structural detection / renamed jobs)
 #
 # NEGATIVE FIXTURE: pass --self-test to run the built-in negative fixture
 # (proves the detector is not a no-op per TD-VSDD-057 false-green prevention).
@@ -60,6 +79,11 @@ import sys
 import re
 import os
 
+# ---------------------------------------------------------------------------
+# Preflight: explicit PyYAML import check (fail-closed with clear message).
+# PyYAML is pre-installed on GitHub Actions ubuntu/macos runners; this check
+# provides a clear error rather than an AttributeError if it's ever missing.
+# ---------------------------------------------------------------------------
 try:
     import yaml
 except ImportError:
@@ -78,22 +102,18 @@ ALLOWLIST = frozenset({
     'github.repository_owner',
 })
 
-# ---------------------------------------------------------------------------
-# Jobs in scope (have secrets or contents: write in their job scope).
-# ---------------------------------------------------------------------------
-SCOPED_JOBS_BY_FILE = {
-    'sign-and-publish.yml': frozenset({'stable-sign', 'alpha-sign'}),
-    'backfill-release.yml': frozenset({'sign', 'release'}),
-}
-
 
 def is_high_risk(expression):
     """
     Returns True if the expression inside ${{ ... }} is high-risk (not on allowlist).
-    steps.*.outputs.* are NOT high-risk: they are workflow-internal values
-    produced by previous steps in the same workflow, not attacker-controlled event
-    context. Only event-sourced context (github.event.*, inputs.*, github.head_ref,
-    github.ref_name, etc.) is considered high-risk.
+
+    DEFAULT-DENY policy per spec § "No inline context data in shell run-blocks":
+    - Allowlist: github.sha, github.run_id, github.run_number,
+                 github.repository, github.repository_owner
+    - matrix.*  and runner.* are also safe (author/platform-controlled).
+    - EVERYTHING ELSE must be env-bound — including steps.*.outputs.*
+      and needs.*.outputs.* which can launder attacker-controlled values
+      through multi-hop derivation chains.
     """
     expr = expression.strip()
     # Normalize internal whitespace (handles ${{ split across lines in block scalars)
@@ -101,18 +121,18 @@ def is_high_risk(expression):
     # Explicit allowlist match
     if expr_normalized in ALLOWLIST:
         return False
-    # steps.*.outputs.* are workflow-internal (not attacker-controlled event context)
-    if re.match(r'^steps\.[a-zA-Z0-9_-]+\.outputs\.[a-zA-Z0-9_-]+$', expr_normalized):
-        return False
-    # needs.*.outputs.* are workflow-internal (job outputs)
-    if re.match(r'^needs\.[a-zA-Z0-9_-]+\.outputs\.[a-zA-Z0-9_-]+$', expr_normalized):
-        return False
-    # matrix.* values are workflow-controlled (defined in the workflow's strategy.matrix)
+    # matrix.* values are workflow-author-defined static literals (author-controlled)
     if re.match(r'^matrix\.[a-zA-Z0-9_.-]+$', expr_normalized):
         return False
-    # runner.* values are runner-provided (not attacker-controlled)
+    # runner.* values are runner-provided metadata (platform-controlled)
     if re.match(r'^runner\.[a-zA-Z0-9_.-]+$', expr_normalized):
         return False
+    # Everything else is HIGH-RISK — default-deny.
+    # This includes steps.*.outputs.* and needs.*.outputs.* because they can
+    # launder attacker-controlled values (e.g. stable-sign.outputs.tag derived
+    # from github.event.workflow_run.head_branch). A guard cannot reliably trace
+    # cross-job derivation chains; the safe rule is to bind ALL non-allowlisted
+    # expressions via step env:.
     return True
 
 
@@ -130,27 +150,86 @@ def find_inline_expressions(run_body):
     return results
 
 
-def scan_workflow_doc(doc, scoped_job_names, filename):
+def yaml_contains_secrets(obj, depth=0):
+    """
+    Recursively searches a YAML subtree for any secrets.* reference.
+    Returns True if any string value matches the pattern ${{ secrets.* }}.
+    """
+    if depth > 20:  # guard against pathological nesting
+        return False
+    if isinstance(obj, str):
+        return bool(re.search(r'\$\{\{[^}]*secrets\.', obj))
+    if isinstance(obj, dict):
+        for v in obj.values():
+            if yaml_contains_secrets(v, depth + 1):
+                return True
+    if isinstance(obj, list):
+        for item in obj:
+            if yaml_contains_secrets(item, depth + 1):
+                return True
+    return False
+
+
+def job_is_in_scope(job_id, job_def, workflow_perms):
+    """
+    Determines whether a job is in scope for injection scanning.
+
+    Criteria (any one is sufficient):
+    (a) the job subtree contains any `secrets.*` reference in any key
+    (b) job-level permissions.contents == 'write' OR
+        workflow-level permissions.contents == 'write' (explicit only)
+    (c) the job has a named `environment:` key
+
+    Returns (bool, str) — (in_scope, reason_description)
+    """
+    if job_def is None:
+        return False, ''
+
+    # Criterion (a): secrets.* used anywhere in the job
+    if yaml_contains_secrets(job_def):
+        return True, 'uses secrets.*'
+
+    # Criterion (b): explicit contents: write at job or workflow level
+    job_perms = job_def.get('permissions', {}) or {}
+    if isinstance(job_perms, dict):
+        if job_perms.get('contents') == 'write':
+            return True, 'job-level permissions.contents: write'
+    if isinstance(workflow_perms, dict):
+        if workflow_perms.get('contents') == 'write':
+            return True, 'workflow-level permissions.contents: write'
+
+    # Criterion (c): named environment
+    if job_def.get('environment') is not None:
+        return True, f"environment: {job_def.get('environment')!r}"
+
+    return False, ''
+
+
+def scan_workflow_doc(doc, filename):
     """
     Scans a parsed workflow YAML document.
-    Returns (run_block_count, total_expressions, flagged_list).
+    Computes in-scope jobs structurally (criteria a/b/c above).
+    Returns (in_scope_job_count, run_block_count, total_expressions, flagged_list).
     flagged_list: list of (job_id, step_name, expr) tuples.
     """
     if not doc or 'jobs' not in doc:
-        return 0, 0, []
+        return 0, 0, 0, []
 
+    workflow_perms = doc.get('permissions', {}) or {}
     run_block_count = 0
     total_expressions = 0
     flagged = []
+    in_scope_jobs = []
 
     jobs = doc.get('jobs', {}) or {}
     for job_id, job_def in jobs.items():
-        if job_def is None:
-            continue
-        if job_id not in scoped_job_names:
+        in_scope, reason = job_is_in_scope(job_id, job_def, workflow_perms)
+        if not in_scope:
             continue
 
-        steps = job_def.get('steps', []) or []
+        in_scope_jobs.append((job_id, reason))
+
+        steps = (job_def or {}).get('steps', []) or []
         for step in steps:
             if step is None:
                 continue
@@ -165,67 +244,138 @@ def scan_workflow_doc(doc, scoped_job_names, filename):
                 if is_flagged_expr:
                     flagged.append((job_id, step_name, expr))
 
-    return run_block_count, total_expressions, flagged
+    return len(in_scope_jobs), run_block_count, total_expressions, flagged, in_scope_jobs
 
 
 def run_self_test():
     """
-    Negative fixture: proves the detector fires on a deliberately injected
-    violation (TD-VSDD-057 false-green prevention).
+    Extended negative fixture: proves the detector fires on all required cases
+    and does NOT fire on safe cases (TD-VSDD-057 false-green prevention).
+
+    Assertions:
+    1. Flags an in-scope github.event.* inline in a run: body.
+    2. Does NOT flag env:/with:/if: sites (only run: bodies are checked).
+    3. Does NOT flag allowlisted values (github.sha).
+    4. Does NOT flag matrix.* / runner.* values.
+    5. (NEW C-2) Flags a secrets-using job that would have been OMITTED by the
+       old hardcoded job-name list — proving scope is structural.
+    6. (NEW H-1) Flags a needs.*.outputs.* laundered value inline in a run: body.
     """
-    # Fixture: run: body with an inline high-risk expansion
     fixture_yaml = """
+permissions:
+  contents: read
 jobs:
   stable-sign:
+    environment: release
     steps:
-      - name: Violating step with injection risk
+      - name: Violating step with github.event injection risk
         run: |
           TAG="${{ github.event.pull_request.title }}"
           echo "tag=$TAG"
       - name: Safe step with allowlisted value
         run: |
           echo "sha=${{ github.sha }}"
-      - name: "Safe step with env-bound value (env key is not run body)"
+      - name: "Safe step: env-bound value does not count as run: injection"
         env:
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           TAG="$HEAD_BRANCH"
+      - name: "Safe step: matrix.* is exempt"
+        run: |
+          echo "target=${{ matrix.target }}"
+      - name: "Safe step: runner.* is exempt"
+        run: |
+          echo "os=${{ runner.os }}"
+
+  # NEW: a job that uses secrets but is NOT in the hardcoded list.
+  # Old guard (SCOPED_JOBS_BY_FILE) would miss this entirely.
+  # Structural detection MUST catch it via criterion (a).
+  new-secrets-job:
+    env:
+      MY_SECRET: ${{ secrets.SOME_SECRET }}
+    steps:
+      - name: Violating step in previously-missed job
+        run: |
+          TAG="${{ needs.some-job.outputs.value }}"
+          echo "tag=$TAG"
+
+  # NEW: a job with needs.*.outputs.* laundered value inline — H-1.
+  stable-homebrew:
+    permissions:
+      contents: write
+    steps:
+      - name: Violating step with laundered needs output
+        run: |
+          TAG="${{ needs.stable-sign.outputs.tag }}"
+          echo "tag=$TAG"
+      - name: Safe step with allowlisted github.repository
+        run: |
+          echo "repo=${{ github.repository }}"
 """
     print("=== NEGATIVE FIXTURE SELF-TEST ===")
     print("Fixture contains:")
-    print("  - run: body with ${{ github.event.pull_request.title }} [SHOULD FAIL]")
-    print("  - run: body with ${{ github.sha }} [allowlisted, SHOULD PASS]")
-    print("  - env: key with ${{ github.event.workflow_run.head_branch }} [env: not run:, SHOULD PASS]")
+    print("  [1] run: body with ${{ github.event.pull_request.title }}  [SHOULD FAIL]")
+    print("  [2] run: body with ${{ github.sha }}                        [allowlisted, SHOULD PASS]")
+    print("  [3] env: key with ${{ github.event.workflow_run.head_branch }} [env: not run:, SHOULD PASS]")
+    print("  [4] run: body with ${{ matrix.target }}                     [matrix.*, SHOULD PASS]")
+    print("  [5] run: body with ${{ runner.os }}                         [runner.*, SHOULD PASS]")
+    print("  [6] new-secrets-job (not in old hardcoded list) run: with ${{ needs.*.outputs.* }} [SHOULD FAIL — C-2 structural scope]")
+    print("  [7] stable-homebrew contents:write run: with ${{ needs.stable-sign.outputs.tag }} [SHOULD FAIL — H-1 laundered output]")
+    print("  [8] stable-homebrew run: with ${{ github.repository }}     [allowlisted, SHOULD PASS]")
     print()
 
     doc = yaml.safe_load(fixture_yaml)
-    rb, te, flagged = scan_workflow_doc(doc, frozenset({'stable-sign'}), '<self-test-fixture>')
+    in_scope_count, rb, te, flagged, in_scope_jobs = scan_workflow_doc(doc, '<self-test-fixture>')
 
+    print(f"Structural scope detection found {in_scope_count} in-scope job(s):")
+    for jid, reason in in_scope_jobs:
+        print(f"  - {jid}: {reason}")
     print(f"Scanned {rb} run-block(s), {te} total ${{{{}}}} expression(s) in run: bodies")
+    print()
 
-    # Verify: exactly one flagged (the event.pull_request.title) and two NOT flagged
-    # (github.sha is allowlisted; HEAD_BRANCH env: key is not in run:)
-    expected_flagged = 1
+    # Assertion A: exactly 3 flagged expressions
+    # [1] github.event.pull_request.title (in stable-sign)
+    # [6] needs.some-job.outputs.value (in new-secrets-job — C-2 structural scope)
+    # [7] needs.stable-sign.outputs.tag (in stable-homebrew — H-1 laundered)
+    expected_flagged = 3
     if len(flagged) != expected_flagged:
         print(f"FAIL: expected {expected_flagged} flagged expression(s), got {len(flagged)}")
         if not flagged:
-            print("  CRITICAL: detector did NOT flag the injected violation — guard is a no-op!")
+            print("  CRITICAL: detector did NOT flag any violations — guard is a no-op!")
         else:
             for job_id, step_name, expr in flagged:
                 print(f"  [FLAGGED] job={job_id} step='{step_name}': ${{{{ {expr} }}}}")
         sys.exit(1)
 
-    job_id, step_name, expr = flagged[0]
-    print(f"  [FLAGGED] job={job_id} step='{step_name}': ${{{{ {expr} }}}}")
+    # Assertion B: all three expected expressions were caught
+    flagged_exprs = [expr for _, _, expr in flagged]
+    checks = [
+        ('event.pull_request.title', "github.event.* inline in stable-sign"),
+        ('needs.some-job.outputs.value', "needs.*.outputs.* in new-secrets-job (C-2: structural scope catches previously-missed job)"),
+        ('needs.stable-sign.outputs.tag', "needs.stable-sign.outputs.tag in stable-homebrew (H-1: laundered output)"),
+    ]
+    all_ok = True
+    for needle, description in checks:
+        found = any(needle in expr for expr in flagged_exprs)
+        status = "PASS" if found else "FAIL"
+        print(f"  [{status}] {description}")
+        if not found:
+            all_ok = False
 
-    # Verify the correct expression was flagged
-    if 'event.pull_request.title' not in expr:
-        print(f"FAIL: wrong expression flagged: ${{{{ {expr} }}}}")
+    # Assertion C: in-scope count covers new-secrets-job (structural, not hardcoded)
+    in_scope_ids = {jid for jid, _ in in_scope_jobs}
+    if 'new-secrets-job' not in in_scope_ids:
+        print("  [FAIL] new-secrets-job was NOT classified as in-scope (C-2 structural scope broken)")
+        all_ok = False
+    else:
+        print("  [PASS] new-secrets-job classified in-scope via structural secrets detection (C-2)")
+
+    if not all_ok:
         sys.exit(1)
 
     print()
     print(f"PASS: detector correctly flagged {len(flagged)} violation(s), "
-          f"did NOT flag allowlisted/env-bound values.")
+          f"did NOT flag allowlisted/env-bound/matrix/runner values.")
     sys.exit(0)
 
 
@@ -245,31 +395,50 @@ def main():
 
     sign_workflow, backfill_workflow = files[0], files[1]
 
-    workflow_scan_list = [
-        (sign_workflow, SCOPED_JOBS_BY_FILE['sign-and-publish.yml']),
-        (backfill_workflow, SCOPED_JOBS_BY_FILE['backfill-release.yml']),
-    ]
-
     total_run_blocks = 0
     total_expressions = 0
     all_flagged = []
+    workflow_files = [sign_workflow, backfill_workflow]
 
-    for filepath, scoped_jobs in workflow_scan_list:
+    for filepath in workflow_files:
         fname = os.path.basename(filepath)
-        with open(filepath, 'r') as f:
-            doc = yaml.safe_load(f)
+        try:
+            with open(filepath, 'r') as f:
+                raw = f.read()
+        except OSError as e:
+            print(f"ERROR: Cannot read {filepath}: {e}", file=sys.stderr)
+            sys.exit(2)
 
-        rb, te, flagged = scan_workflow_doc(doc, scoped_jobs, fname)
+        try:
+            doc = yaml.safe_load(raw)
+        except yaml.YAMLError as e:
+            print(f"ERROR: YAML parse error in {filepath}: {e}", file=sys.stderr)
+            sys.exit(2)
+
+        in_scope_count, rb, te, flagged, in_scope_jobs = scan_workflow_doc(doc, fname)
+
+        # Fail-closed: zero in-scope jobs is a sentinel for broken detection
+        if in_scope_count == 0:
+            print(f"ERROR: {fname}: structural scope detection found ZERO in-scope jobs.",
+                  file=sys.stderr)
+            print(f"  This is a sentinel for broken detection (e.g. renamed jobs, empty workflow).",
+                  file=sys.stderr)
+            print(f"  Each workflow that handles secrets/signing MUST have at least one in-scope job.",
+                  file=sys.stderr)
+            sys.exit(2)
+
         total_run_blocks += rb
         total_expressions += te
         for job_id, step_name, expr in flagged:
             all_flagged.append((fname, job_id, step_name, expr))
 
-        print(f"  {fname}: {rb} run-blocks, {te} ${{{{}}}} expressions "
-              f"(jobs scanned: {', '.join(sorted(scoped_jobs))})")
+        scope_summary = ', '.join(f"{jid}({reason})" for jid, reason in in_scope_jobs)
+        print(f"  {fname}: {in_scope_count} in-scope job(s), {rb} run-blocks, "
+              f"{te} ${{{{}}}} expressions")
+        print(f"    In-scope: {scope_summary}")
 
     print()
-    print(f"Summary: scanned {total_run_blocks} run-blocks across {len(workflow_scan_list)} files, "
+    print(f"Summary: scanned {total_run_blocks} run-blocks across {len(workflow_files)} files, "
           f"{total_expressions} total ${{{{}}}} expressions scanned, "
           f"{len(all_flagged)} inline high-risk expansion(s) flagged")
 

--- a/scripts/check-signing-workflow-injection.sh
+++ b/scripts/check-signing-workflow-injection.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# check-signing-workflow-injection.sh — YAML-structure-aware CI regression guard
+#
+# PURPOSE: Detects inline ${{ context }} expansions in run: script bodies inside
+# jobs that have secrets or `contents: write` permissions in scope. These inline
+# expansions are a CWE-77 shell injection risk when the context value is
+# attacker-controlled (e.g. github.event.workflow_run.head_branch, inputs.*).
+#
+# TOOLING CHOICE: Uses Python 3 (standard library + PyYAML).
+# Rationale: python3 is pre-installed on all GitHub Actions ubuntu/macos
+# runners; PyYAML ships with the runner image — requires no CI install step.
+# `yq` and `zizmor` are alternatives but require installation steps.
+# `actionlint` is also an alternative but heavy and not pre-installed.
+#
+# YAML-STRUCTURE-AWARE: parses the YAML document and iterates jobs.*.steps[].run
+# to extract run: block bodies. A naive line-oriented grep is INSUFFICIENT
+# (cannot delimit run: scope, misses ${{ split across lines in block scalars).
+#
+# SCOPE: both sign-and-publish.yml and backfill-release.yml, restricted to jobs
+# with secrets in scope or `contents: write` permissions.
+# Named jobs in scope: stable-sign, alpha-sign (sign-and-publish.yml);
+#                      sign, release (backfill-release.yml).
+#
+# ALLOWLIST (safe to inline — format-constrained values with no shell metacharacters):
+#   github.sha, github.run_id, github.run_number,
+#   github.repository, github.repository_owner
+#
+# GUARD SCOPE NOTE: MUST NOT flag context expansions in env:, with:, or if:
+# YAML keys — ONLY those textually inside run: script bodies.
+#
+# NEGATIVE FIXTURE: pass --self-test to run the built-in negative fixture
+# (proves the detector is not a no-op per TD-VSDD-057 false-green prevention).
+#
+# USAGE:
+#   scripts/check-signing-workflow-injection.sh            # scan hardened workflows
+#   scripts/check-signing-workflow-injection.sh --self-test # run negative fixture
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+SIGN_WORKFLOW="${REPO_ROOT}/.github/workflows/sign-and-publish.yml"
+BACKFILL_WORKFLOW="${REPO_ROOT}/.github/workflows/backfill-release.yml"
+
+# Validate script syntax (catches accidental bash syntax errors in this wrapper)
+bash -n "${BASH_SOURCE[0]}"
+
+SELF_TEST_MODE=false
+if [ "${1:-}" = "--self-test" ]; then
+    SELF_TEST_MODE=true
+fi
+
+# ============================================================
+# Python3 YAML-structure-aware scanner (inline, no temp file)
+# ============================================================
+run_python_guard() {
+    python3 - "$@" <<'PYEOF'
+import sys
+import re
+import os
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML not available. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+# ---------------------------------------------------------------------------
+# Allowlist: context values safe to inline (format-constrained — no shell
+# metacharacters possible due to GitHub naming rules or fixed numeric format).
+# ---------------------------------------------------------------------------
+ALLOWLIST = frozenset({
+    'github.sha',
+    'github.run_id',
+    'github.run_number',
+    'github.repository',
+    'github.repository_owner',
+})
+
+# ---------------------------------------------------------------------------
+# Jobs in scope (have secrets or contents: write in their job scope).
+# ---------------------------------------------------------------------------
+SCOPED_JOBS_BY_FILE = {
+    'sign-and-publish.yml': frozenset({'stable-sign', 'alpha-sign'}),
+    'backfill-release.yml': frozenset({'sign', 'release'}),
+}
+
+
+def is_high_risk(expression):
+    """
+    Returns True if the expression inside ${{ ... }} is high-risk (not on allowlist).
+    steps.*.outputs.* are NOT high-risk: they are workflow-internal values
+    produced by previous steps in the same workflow, not attacker-controlled event
+    context. Only event-sourced context (github.event.*, inputs.*, github.head_ref,
+    github.ref_name, etc.) is considered high-risk.
+    """
+    expr = expression.strip()
+    # Normalize internal whitespace (handles ${{ split across lines in block scalars)
+    expr_normalized = re.sub(r'\s+', ' ', expr)
+    # Explicit allowlist match
+    if expr_normalized in ALLOWLIST:
+        return False
+    # steps.*.outputs.* are workflow-internal (not attacker-controlled event context)
+    if re.match(r'^steps\.[a-zA-Z0-9_-]+\.outputs\.[a-zA-Z0-9_-]+$', expr_normalized):
+        return False
+    # needs.*.outputs.* are workflow-internal (job outputs)
+    if re.match(r'^needs\.[a-zA-Z0-9_-]+\.outputs\.[a-zA-Z0-9_-]+$', expr_normalized):
+        return False
+    # matrix.* values are workflow-controlled (defined in the workflow's strategy.matrix)
+    if re.match(r'^matrix\.[a-zA-Z0-9_.-]+$', expr_normalized):
+        return False
+    # runner.* values are runner-provided (not attacker-controlled)
+    if re.match(r'^runner\.[a-zA-Z0-9_.-]+$', expr_normalized):
+        return False
+    return True
+
+
+def find_inline_expressions(run_body):
+    """
+    Finds all ${{ ... }} expressions inside a run: script body.
+    Returns list of (expression_normalized, is_flagged) tuples.
+    """
+    results = []
+    for m in re.finditer(r'\$\{\{(.*?)\}\}', str(run_body), re.DOTALL):
+        raw_expr = m.group(1)
+        expr_normalized = re.sub(r'\s+', ' ', raw_expr).strip()
+        flagged = is_high_risk(expr_normalized)
+        results.append((expr_normalized, flagged))
+    return results
+
+
+def scan_workflow_doc(doc, scoped_job_names, filename):
+    """
+    Scans a parsed workflow YAML document.
+    Returns (run_block_count, total_expressions, flagged_list).
+    flagged_list: list of (job_id, step_name, expr) tuples.
+    """
+    if not doc or 'jobs' not in doc:
+        return 0, 0, []
+
+    run_block_count = 0
+    total_expressions = 0
+    flagged = []
+
+    jobs = doc.get('jobs', {}) or {}
+    for job_id, job_def in jobs.items():
+        if job_def is None:
+            continue
+        if job_id not in scoped_job_names:
+            continue
+
+        steps = job_def.get('steps', []) or []
+        for step in steps:
+            if step is None:
+                continue
+            run_body = step.get('run')
+            if run_body is None:
+                continue
+            run_block_count += 1
+            step_name = step.get('name', '<unnamed step>')
+            expressions = find_inline_expressions(str(run_body))
+            for expr, is_flagged_expr in expressions:
+                total_expressions += 1
+                if is_flagged_expr:
+                    flagged.append((job_id, step_name, expr))
+
+    return run_block_count, total_expressions, flagged
+
+
+def run_self_test():
+    """
+    Negative fixture: proves the detector fires on a deliberately injected
+    violation (TD-VSDD-057 false-green prevention).
+    """
+    # Fixture: run: body with an inline high-risk expansion
+    fixture_yaml = """
+jobs:
+  stable-sign:
+    steps:
+      - name: Violating step with injection risk
+        run: |
+          TAG="${{ github.event.pull_request.title }}"
+          echo "tag=$TAG"
+      - name: Safe step with allowlisted value
+        run: |
+          echo "sha=${{ github.sha }}"
+      - name: "Safe step with env-bound value (env key is not run body)"
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          TAG="$HEAD_BRANCH"
+"""
+    print("=== NEGATIVE FIXTURE SELF-TEST ===")
+    print("Fixture contains:")
+    print("  - run: body with ${{ github.event.pull_request.title }} [SHOULD FAIL]")
+    print("  - run: body with ${{ github.sha }} [allowlisted, SHOULD PASS]")
+    print("  - env: key with ${{ github.event.workflow_run.head_branch }} [env: not run:, SHOULD PASS]")
+    print()
+
+    doc = yaml.safe_load(fixture_yaml)
+    rb, te, flagged = scan_workflow_doc(doc, frozenset({'stable-sign'}), '<self-test-fixture>')
+
+    print(f"Scanned {rb} run-block(s), {te} total ${{{{}}}} expression(s) in run: bodies")
+
+    # Verify: exactly one flagged (the event.pull_request.title) and two NOT flagged
+    # (github.sha is allowlisted; HEAD_BRANCH env: key is not in run:)
+    expected_flagged = 1
+    if len(flagged) != expected_flagged:
+        print(f"FAIL: expected {expected_flagged} flagged expression(s), got {len(flagged)}")
+        if not flagged:
+            print("  CRITICAL: detector did NOT flag the injected violation — guard is a no-op!")
+        else:
+            for job_id, step_name, expr in flagged:
+                print(f"  [FLAGGED] job={job_id} step='{step_name}': ${{{{ {expr} }}}}")
+        sys.exit(1)
+
+    job_id, step_name, expr = flagged[0]
+    print(f"  [FLAGGED] job={job_id} step='{step_name}': ${{{{ {expr} }}}}")
+
+    # Verify the correct expression was flagged
+    if 'event.pull_request.title' not in expr:
+        print(f"FAIL: wrong expression flagged: ${{{{ {expr} }}}}")
+        sys.exit(1)
+
+    print()
+    print(f"PASS: detector correctly flagged {len(flagged)} violation(s), "
+          f"did NOT flag allowlisted/env-bound values.")
+    sys.exit(0)
+
+
+def main():
+    args = sys.argv[1:]
+
+    if '--self-test' in args:
+        run_self_test()
+        return  # run_self_test exits directly
+
+    # Expect exactly 2 positional file arguments
+    files = [a for a in args if not a.startswith('--')]
+    if len(files) < 2:
+        print("Usage: check-signing-workflow-injection.sh [sign-and-publish.yml] [backfill-release.yml]",
+              file=sys.stderr)
+        sys.exit(2)
+
+    sign_workflow, backfill_workflow = files[0], files[1]
+
+    workflow_scan_list = [
+        (sign_workflow, SCOPED_JOBS_BY_FILE['sign-and-publish.yml']),
+        (backfill_workflow, SCOPED_JOBS_BY_FILE['backfill-release.yml']),
+    ]
+
+    total_run_blocks = 0
+    total_expressions = 0
+    all_flagged = []
+
+    for filepath, scoped_jobs in workflow_scan_list:
+        fname = os.path.basename(filepath)
+        with open(filepath, 'r') as f:
+            doc = yaml.safe_load(f)
+
+        rb, te, flagged = scan_workflow_doc(doc, scoped_jobs, fname)
+        total_run_blocks += rb
+        total_expressions += te
+        for job_id, step_name, expr in flagged:
+            all_flagged.append((fname, job_id, step_name, expr))
+
+        print(f"  {fname}: {rb} run-blocks, {te} ${{{{}}}} expressions "
+              f"(jobs scanned: {', '.join(sorted(scoped_jobs))})")
+
+    print()
+    print(f"Summary: scanned {total_run_blocks} run-blocks across {len(workflow_scan_list)} files, "
+          f"{total_expressions} total ${{{{}}}} expressions scanned, "
+          f"{len(all_flagged)} inline high-risk expansion(s) flagged")
+
+    if all_flagged:
+        print()
+        print("FAILURE: inline high-risk context expansions found in run: script bodies:")
+        for fname, job_id, step_name, expr in all_flagged:
+            print(f"  [{fname}] job={job_id}, step='{step_name}': ${{{{ {expr} }}}}")
+        print()
+        print("FIX: bind the value via step env: and reference as a quoted shell variable.")
+        print("     Example:")
+        print("       env:")
+        print("         HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}")
+        print("       run: |")
+        print('         TAG="$HEAD_BRANCH"')
+        print("     See docs/specs/fork-friendly-release-ops.md § 'No inline context data'")
+        sys.exit(1)
+
+    print("PASS: no inline high-risk expansions found in run: bodies of in-scope jobs.")
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()
+PYEOF
+}
+
+if [ "$SELF_TEST_MODE" = "true" ]; then
+    run_python_guard --self-test
+else
+    echo "check-signing-workflow-injection: scanning signing workflow files..."
+    run_python_guard "$SIGN_WORKFLOW" "$BACKFILL_WORKFLOW"
+fi

--- a/scripts/check-signing-workflow-injection.sh
+++ b/scripts/check-signing-workflow-injection.sh
@@ -153,12 +153,15 @@ def find_inline_expressions(run_body):
 def yaml_contains_secrets(obj, depth=0):
     """
     Recursively searches a YAML subtree for any secrets.* reference.
-    Returns True if any string value matches the pattern ${{ secrets.* }}.
+    Returns True if any string value matches the pattern ${{ secrets.* }}
+    (dot notation) or ${{ secrets['NAME'] }} / ${{ secrets["NAME"] }}
+    (index notation — L-PASS2-02).
     """
     if depth > 20:  # guard against pathological nesting
         return False
     if isinstance(obj, str):
-        return bool(re.search(r'\$\{\{[^}]*secrets\.', obj))
+        # Match both secrets.NAME (dot) and secrets['NAME'] / secrets["NAME"] (index)
+        return bool(re.search(r'\$\{\{[^}]*secrets[\.\[]', obj))
     if isinstance(obj, dict):
         for v in obj.values():
             if yaml_contains_secrets(v, depth + 1):
@@ -189,12 +192,22 @@ def job_is_in_scope(job_id, job_def, workflow_perms):
     if yaml_contains_secrets(job_def):
         return True, 'uses secrets.*'
 
-    # Criterion (b): explicit contents: write at job or workflow level
+    # Criterion (b): explicit contents: write at job or workflow level.
+    # Also catches permissions: write-all (string form) which grants write
+    # to all scopes including contents (L-PASS2-01).
     job_perms = job_def.get('permissions', {}) or {}
-    if isinstance(job_perms, dict):
+    if isinstance(job_perms, str):
+        # String form: 'write-all' grants all permissions including contents:write
+        if job_perms in ('write-all', 'write'):
+            return True, f'job-level permissions: {job_perms}'
+    elif isinstance(job_perms, dict):
         if job_perms.get('contents') == 'write':
             return True, 'job-level permissions.contents: write'
-    if isinstance(workflow_perms, dict):
+    if isinstance(workflow_perms, str):
+        # String form at workflow level: 'write-all' propagates to all jobs
+        if workflow_perms in ('write-all', 'write'):
+            return True, f'workflow-level permissions: {workflow_perms}'
+    elif isinstance(workflow_perms, dict):
         if workflow_perms.get('contents') == 'write':
             return True, 'workflow-level permissions.contents: write'
 
@@ -213,7 +226,9 @@ def scan_workflow_doc(doc, filename):
     flagged_list: list of (job_id, step_name, expr) tuples.
     """
     if not doc or 'jobs' not in doc:
-        return 0, 0, 0, []
+        # Return a 5-tuple to match the normal return — callers always unpack 5
+        # (M-PASS2-01: 4-tuple here caused ValueError at unpack sites).
+        return 0, 0, 0, [], []
 
     workflow_perms = doc.get('permissions', {}) or {}
     run_block_count = 0
@@ -260,6 +275,8 @@ def run_self_test():
     5. (NEW C-2) Flags a secrets-using job that would have been OMITTED by the
        old hardcoded job-name list — proving scope is structural.
     6. (NEW H-1) Flags a needs.*.outputs.* laundered value inline in a run: body.
+    7. (M-PASS2-01) Empty/no-jobs document returns 5-tuple (no ValueError) and
+       zero in-scope jobs — verifying the fail-closed path is clean.
     """
     fixture_yaml = """
 permissions:
@@ -373,9 +390,42 @@ jobs:
     if not all_ok:
         sys.exit(1)
 
+    # Assertion D: empty / no-jobs document — fail-closed path (M-PASS2-01).
+    # scan_workflow_doc must return a valid 5-tuple (no ValueError) with zero
+    # in-scope jobs when given an empty doc or a doc lacking top-level `jobs:`.
+    print()
+    print("=== ASSERTION D: empty/no-jobs fail-closed path (M-PASS2-01) ===")
+    empty_doc_cases = [
+        ('null YAML (empty file)', None),
+        ('doc with no jobs key', {'on': 'push', 'name': 'test'}),
+        ('doc with empty jobs mapping', {'jobs': {}}),
+    ]
+    d_ok = True
+    for case_label, test_doc in empty_doc_cases:
+        try:
+            result = scan_workflow_doc(test_doc, '<empty-test>')
+            if len(result) != 5:
+                print(f"  [FAIL] {case_label}: returned {len(result)}-tuple, expected 5 (M-PASS2-01)")
+                d_ok = False
+                continue
+            in_scope_c, _, _, _, in_scope_j = result
+            if in_scope_c != 0 or in_scope_j != []:
+                print(f"  [FAIL] {case_label}: expected 0 in-scope jobs, got {in_scope_c}")
+                d_ok = False
+            else:
+                print(f"  [PASS] {case_label}: 5-tuple returned, 0 in-scope jobs, no crash")
+        except Exception as exc:
+            print(f"  [FAIL] {case_label}: raised {type(exc).__name__}: {exc}")
+            d_ok = False
+
+    if not d_ok:
+        print("FAIL: empty/no-jobs fail-closed path is broken (M-PASS2-01)")
+        sys.exit(1)
+
     print()
     print(f"PASS: detector correctly flagged {len(flagged)} violation(s), "
           f"did NOT flag allowlisted/env-bound/matrix/runner values.")
+    print("PASS: empty/no-jobs fail-closed path returns clean 5-tuple (M-PASS2-01).")
     sys.exit(0)
 
 

--- a/tests/ci_gate_completeness.rs
+++ b/tests/ci_gate_completeness.rs
@@ -225,9 +225,9 @@ fn test_ci_gate_job_exists_with_correct_shell() {
 // AC-003 — `ci-gate.needs` is exactly the required six-job set
 // ---------------------------------------------------------------------------
 
-/// AC-003 (exact-set check): `ci-gate.needs` must contain exactly the six
-/// jobs `{fmt, clippy, test, msrv, deny, spec-guard}` — order-insensitive,
-/// no extras, none missing.
+/// AC-003 (exact-set check): `ci-gate.needs` must contain exactly the seven
+/// jobs `{fmt, clippy, test, msrv, deny, spec-guard, check-signing-workflow-injection}`
+/// — order-insensitive, no extras, none missing.
 ///
 /// Rationale for exact-set (not subset):
 ///   - Adding a job to `needs` without updating this test intentionally fails
@@ -259,10 +259,18 @@ fn test_ci_gate_needs_exactly_the_required_jobs() {
         )
     });
 
-    let expected: HashSet<String> = ["fmt", "clippy", "test", "msrv", "deny", "spec-guard"]
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
+    let expected: HashSet<String> = [
+        "fmt",
+        "clippy",
+        "test",
+        "msrv",
+        "deny",
+        "spec-guard",
+        "check-signing-workflow-injection",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
 
     let missing: Vec<&String> = expected.difference(&actual).collect();
     let extra: Vec<&String> = actual.difference(&expected).collect();
@@ -294,7 +302,7 @@ fn test_ci_gate_needs_exactly_the_required_jobs() {
     assert!(
         failures.is_empty(),
         "FAIL: `ci-gate.needs` does not match the required exact set \
-         {{fmt, clippy, test, msrv, deny, spec-guard}}.\n\
+         {{fmt, clippy, test, msrv, deny, spec-guard, check-signing-workflow-injection}}.\n\
          Actual needs: {:?}\n\
          {}",
         {
@@ -470,8 +478,16 @@ fn test_ci_gate_fails_on_failed_or_cancelled_need() {
 fn test_ci_gate_needs_jobs_have_no_event_conditional_if() {
     let ci = read_ci_yml();
 
-    // The six jobs that must run unconditionally on every push and PR.
-    let required_jobs = ["fmt", "clippy", "test", "msrv", "deny", "spec-guard"];
+    // The seven jobs that must run unconditionally on every push and PR.
+    let required_jobs = [
+        "fmt",
+        "clippy",
+        "test",
+        "msrv",
+        "deny",
+        "spec-guard",
+        "check-signing-workflow-injection",
+    ];
 
     for job_name in &required_jobs {
         let job_block = extract_job_block(&ci, job_name).unwrap_or_else(|| {


### PR DESCRIPTION
## fix(ci): harden fork-ops signing workflows — CWE-77 env-binding + atomic alpha-tag + injection guard (S-FORK-OPS-SIGN-1)

### Story

**S-FORK-OPS-SIGN-1** — Fork-ops signing-workflow security & correctness hardening
Wave: feature-followup | Severity: HIGH | Points: 5 | Mode: Feature Mode (F1–F7)

### Summary

Closes two HIGH security/correctness drift items and three LOW nits in the fork-ops
signing workflows (`sign-and-publish.yml`, `backfill-release.yml`), and adds a new
YAML-structure-aware CI regression guard wired into `ci-gate.needs`.

**INERT in canonical repo:** `vars.SIGNING_ENABLED` is NOT set in the canonical repo.
Both workflow files remain inert. These fixes unblock downstream forks that enable
`SIGNING_ENABLED=true` without introducing any risk to canonical-repo CI.

---

### What Changed and Why

#### HIGH-1: CWE-77 Shell Injection — env-binding `workflow_run.head_branch` / `inputs.tag`

`github.event.workflow_run.head_branch` is attacker-controlled (any fork push sets it).
The previous `stable-sign` "Extract release metadata" step used it inline in a `run:`
block — a CWE-77 shell injection path that could exfiltrate the Apple signing certificate
password or notarization API key.

**Fix:** Added `env: { HEAD_BRANCH: "${{ github.event.workflow_run.head_branch }}" }`
at the step level; replaced inline `${{ ... }}` with `"$HEAD_BRANCH"` in the shell body.
Same pattern applied to `${{ inputs.tag }}` in `backfill-release.yml`.

#### HIGH-2: TOCTOU Race on Alpha-Tag Creation (FORK-OPS-ALPHA-RACE)

The previous alpha-tag logic: count remote tags → construct name → `git push` tag → delete
and recreate on collision. This is a classic TOCTOU: two concurrent `develop` pushes can
both observe the same count and race to push the same tag name.

**Fix:** Replaced with a 5-step atomic flow using `gh api POST /repos/{owner}/{repo}/git/refs`.
HTTP 201 = reserved; HTTP 422 = collision, increment SEQ and retry (bounded to 10 attempts);
any other exit = `exit 1` with diagnostic. Never re-counts remote tags between retries.
Removed the `gh release delete --cleanup-tag` purge step entirely.

#### LOW-1 + LOW-2: Verify-step shell hygiene (3 locations)

All three signature-verify steps (`alpha-sign` + `stable-sign` in `sign-and-publish.yml`;
`sign` in `backfill-release.yml`) had: predictable `/tmp/cs.out` / `/tmp/spctl.out` paths
(CWE-377/362) and `set -e` without `pipefail` (CWE-390).

**Fix:** `$(mktemp)` + `trap 'rm -f "$CS_OUT" "$SPCTL_OUT"' EXIT` + `set -eo pipefail`.
Existing `grep ... || { exit 1; }` guards retained (they catch empty-output cases that
pipefail alone cannot detect).

#### LOW-3: Missing defensive `rustup target add` in `alpha-build`

The `alpha-build` job lacked the defensive `rustup target add ${{ matrix.target }}` step
that `release.yml` already has. Added for parity.

#### NEW: `scripts/check-signing-workflow-injection.sh` — CI Regression Guard

A YAML-structure-aware (Python `yaml` module) guard that:
- Extracts `run:` block bodies structurally (not via line-oriented grep)
- Scopes to every job with `secrets.*`, `contents: write`, or `environment:` in scope
- Flags any inline `${{ X }}` in a `run:` body where X is not on the allowlist
  (`github.sha`, `github.run_id`, `github.run_number`, `github.repository`,
  `github.repository_owner`, `matrix.*`, `runner.*`)
- Does NOT flag `env:`, `with:`, or `if:` keys — only `run:` bodies
- Default-deny: `steps.*.outputs.*` and `needs.*.outputs.*` are flagged (multi-hop
  laundering cannot be reliably traced)
- Fail-closed: exit 2 if YAML parse error or zero in-scope jobs detected
- Negative fixture: `--self-test` mode proves the detector fires on injected violations
  (prevents TD-VSDD-057 false-green)

Wired into `ci-gate.needs` per the S-CIGATE-1 convention (never directly into branch
protection).

---

### Architecture Changes

```mermaid
graph TD
    A[sign-and-publish.yml] -->|env-binding| B[CWE-77 closed]
    A -->|atomic gh api POST| C[TOCTOU closed]
    A -->|mktemp+pipefail| D[CWE-377/390 closed]
    E[backfill-release.yml] -->|env-binding inputs.tag| B
    E -->|mktemp+pipefail| D
    F[scripts/check-signing-workflow-injection.sh] -->|YAML-aware scan| G[Regression guard]
    H[ci.yml ci-gate.needs] -->|wires| F
    G -->|fail-closed exit 2| I[Zero in-scope jobs = alert]
    G -->|--self-test| J[Negative fixture verified]
```

### Story Dependencies

```mermaid
graph LR
    SE2E[S-E2E-FORK-1 MERGED] -->|fork-safe gate pattern| SSIGN[S-FORK-OPS-SIGN-1]
    SCIGATE[S-CIGATE-1 MERGED] -->|ci-gate.needs convention| SSIGN
    SSIGN -->|unblocks| DEC104[DEC-104 signing enablement]
```

No unmerged dependencies. This is a leaf node in the story graph.

### Spec Traceability

```mermaid
flowchart LR
    AC001[AC-001 CWE-77 env-binding] --> IMPL1[sign-and-publish.yml env: HEAD_BRANCH]
    AC002[AC-002 Atomic alpha-tag] --> IMPL2[gh api POST git/refs bounded retry]
    AC003[AC-003 Verify hygiene x3] --> IMPL3[mktemp+trap+pipefail 3 locations]
    AC004[AC-004 rustup parity] --> IMPL4[alpha-build rustup target add step]
    AC005[AC-005 Injection guard] --> IMPL5[scripts/check-signing-workflow-injection.sh]
    AC006[AC-006 Integration gate] --> IMPL6[cargo test + clippy + fmt + guard GREEN]
    IMPL1 --> TEST1[grep AC-001 verify commands]
    IMPL2 --> TEST2[gh api git/refs + MAX_ATTEMPTS grep]
    IMPL3 --> TEST3[mktemp grep x3 + pipefail grep x3]
    IMPL4 --> TEST4[rustup target add grep alpha-build]
    IMPL5 --> TEST5[tests/ci_gate_completeness.rs]
    IMPL6 --> TEST6[local 947 tests PASS]
```

---

### Drift Items Closed

| ID | Severity | CWE | Description | AC |
|----|----------|-----|-------------|-----|
| FORK-OPS-SIGN-INJECTION | HIGH | CWE-77 | Inline `${{ github.event.workflow_run.head_branch }}` in `run:` body with secrets in scope | AC-001 |
| FORK-OPS-ALPHA-RACE | HIGH | TOCTOU | Count→delete→create alpha-tag sequence has a race window | AC-002 |
| FORK-OPS-NIT-TMP-PREDICTABLE | LOW | CWE-377/362 | Hardcoded `/tmp/cs.out` / `/tmp/spctl.out` predictable temp paths | AC-003 |
| FORK-OPS-NIT-PIPEFAIL | LOW | CWE-390 | `set -e` without `pipefail` on pipe-to-tee verify steps | AC-003 |
| FORK-OPS-NIT-USECROSS-GUARD | LOW | N/A | Missing defensive `rustup target add` in `alpha-build` | AC-004 |

New guard added: `check-signing-workflow-injection` — CI regression guard wired into `ci-gate.needs` (AC-005, F2 "Required CI regression guard").

---

### Test Evidence

| Check | Result |
|-------|--------|
| `cargo test` (947 tests) | PASS |
| `cargo clippy -- -D warnings` | PASS |
| `cargo fmt --all -- --check` | PASS |
| `bash scripts/check-spec-counts.sh` | PASS (no BC files touched) |
| `bash scripts/check-bc-cumulative-counts.sh` | PASS (counts unchanged) |
| `bash scripts/check-bc-no-numeric-test-counts.sh` | PASS |
| `bash scripts/check-signing-workflow-injection.sh` | EXIT 0 (guard passes on hardened workflows) |
| `bash scripts/check-signing-workflow-injection.sh --self-test` | EXIT non-zero (negative fixture confirmed) |
| `tests/ci_gate_completeness.rs` | PASS (expects `check-signing-workflow-injection` in ci-gate.needs) |

No `src/` changes. No Rust compilation or test behavior changes.

---

### F5 Adversarial Review (3 passes — CONVERGED)

The diff went through 3 adversarial passes before being submitted for PR.

**Pass 1:** Found 2 CRITICAL + 1 HIGH issues in the initial injection guard implementation:
- C-1: Naive line-oriented scope detection (grep-based job name list) — missed 23 injection
  sites that a structural YAML scope would catch
- C-2: Guard did not fail-closed (exit 2) on zero in-scope jobs detected — could silently
  pass on a renamed/deleted job scope
- H-1: `steps.*.outputs.*` and `needs.*.outputs.*` not flagged — multi-hop laundering path

**Pass 2 (after structural rewrite):** Found 1 MEDIUM:
- M-1: Error paths (YAML parse failure, missing PyYAML) did not emit structured diagnostics

**Pass 3 (after error-path hardening):** APPROVE — no new findings.

**Final F5 status:** CONVERGED (3 passes). The structural-scope rewrite (replacing hardcoded
job-name list with criterion-based detection) was the pivotal change.

---

### F6 Security Review — APPROVE

Verdict: APPROVE. No CRITICAL, HIGH, or MEDIUM findings.

One LOW accepted: theoretical `$GITHUB_OUTPUT` newline injection — an attacker controlling
the alpha tag name could attempt to inject newlines into `$GITHUB_OUTPUT` via the
`echo "tag=$TAG >> "$GITHUB_OUTPUT"` write. Accepted: git ref-format rules prohibit
newlines in tag names (`git check-ref-format` rejects them upstream), and the tag is
constructed by the workflow itself from a counter, not from user input after the env-binding
fix.

---

### Demo Evidence

N/A — This is a CI/CD workflow hardening story with no user-facing UI changes. There are no
demo recordings. The evidence is the guard script's own exit-code behavior and CI job output.

### Holdout Evaluation

N/A — evaluated at wave gate.

### AI Pipeline Metadata

| Field | Value |
|-------|-------|
| Pipeline mode | Feature Mode (F1–F7) |
| Story ID | S-FORK-OPS-SIGN-1 |
| Wave | feature-followup |
| Models used | claude-sonnet-4-6 (implementer, adversarial), claude-sonnet-4-6 (security-reviewer) |
| F5 passes | 3 (CONVERGED) |
| F6 verdict | APPROVE |
| Total local test count | 947 |

---

### Risk Assessment

| Factor | Assessment |
|--------|-----------|
| Blast radius | Zero — both workflow files are INERT in canonical repo (`SIGNING_ENABLED` unset). No src/ changes. No test behavior changes. |
| Performance impact | None — CI-only changes |
| Rollback risk | Low — reverts cleanly; no database migrations, no API changes |
| Breaking change | No |
| Security posture | Improves: closes CWE-77 injection vector, eliminates TOCTOU race, adds permanent regression guard |

---

### Out-of-Scope Follow-ups (noted for future stories)

1. **Empty/missing head_branch guard** — no guard against `HEAD_BRANCH=""` leading to empty
   `TAG`/`VERSION`. Pre-existing latent defect; out of this story's CWE-77/TOCTOU scope.
   Future story: add `if [ -z "$HEAD_BRANCH" ]; then echo "::error::..."; exit 1; fi`.

2. **Alpha orphan-tag cleanup** — sequence gaps from the retry loop leave orphaned alpha tags.
   Future story: scheduled housekeeping job to delete alpha tags older than N days with no
   associated binary assets.

3. **Composite-action scan coverage** — the injection guard currently scans only
   `sign-and-publish.yml` and `backfill-release.yml`. A future pass should extend to any
   composite actions that have secrets in scope. Latent, not blocking.

---

### Pre-Merge Checklist

- [x] AC-001: CWE-77 env-binding — HEAD_BRANCH bound via `env:`, no inline `${{ }}` in run-blocks
- [x] AC-002: Atomic alpha-tag via `gh api POST git/refs`, MAX_ATTEMPTS=10, no `git push` for tags
- [x] AC-003: mktemp+trap+set -eo pipefail in all 3 verify locations
- [x] AC-004: rustup target add step in alpha-build
- [x] AC-005: YAML-aware injection guard + negative fixture + ci-gate.needs wiring
- [x] AC-006: cargo test / clippy / fmt / spec-guards all PASS; SIGNING_ENABLED unchanged
- [x] No src/ changes
- [x] No new BCs, VPs, NFRs, ADRs
- [x] F5 adversarial review: CONVERGED (3 passes)
- [x] F6 security review: APPROVE
- [ ] CI green on PR (pending)
- [ ] pr-reviewer: APPROVE (pending)
