### PR TITLE
fix(ci): make verify-signatures step actually exercise correctly in a signing-configured fork

### DIFF
--- a/.github/workflows/backfill-release.yml
+++ b/.github/workflows/backfill-release.yml
@@ -314,11 +314,16 @@ jobs:
               || { echo "::error::$PKG not notarized (spctl source unexpected)"; exit 1; }
             echo "::endgroup::"
           done
+          # `spctl --assess --type open` on a notarized .dmg returns
+          # "rejected: source=Insufficient Context" on macOS 15+ — Gatekeeper
+          # assesses the *mounted* contents, not the .dmg file. `stapler
+          # validate` is the canonical check: it verifies the notarization
+          # ticket is locally attached to the .dmg and references a valid
+          # Apple notarization record. Non-zero exit on missing/invalid
+          # staple fails the step.
           for DMG in jr-arm64.dmg jr-amd64.dmg; do
             echo "::group::Verify $DMG"
-            spctl --assess --type open --verbose=4 "$DMG" 2>&1 | tee "$SPCTL_OUT"
-            grep -q "source=Notarized Developer ID" "$SPCTL_OUT" \
-              || { echo "::error::$DMG not notarized (spctl source unexpected)"; exit 1; }
+            xcrun stapler validate "$DMG"
             echo "::endgroup::"
           done
 

--- a/.github/workflows/backfill-release.yml
+++ b/.github/workflows/backfill-release.yml
@@ -282,10 +282,18 @@ jobs:
           for BIN in jr-darwin-arm64 jr-darwin-amd64; do
             echo "::group::Verify $BIN"
             codesign -dvv "$BIN" 2>&1 | tee "$CS_OUT"
-            grep -q "^Authority=Developer ID Application:" "$CS_OUT" \
-              || { echo "::error::$BIN missing Developer ID Application authority"; exit 1; }
-            grep -q "^TeamIdentifier=" "$CS_OUT" \
-              || { echo "::error::$BIN missing TeamIdentifier"; exit 1; }
+            # GHA log-masks the leaf cert CN (it matches APPLE_SIGNING_IDENTITY
+            # secret), so `Authority=Developer ID Application: ...` becomes
+            # `Authority=***`. Anchor instead on the intermediate cert in the
+            # Developer ID chain, which is a public Apple CA name and never
+            # masked. Its presence proves the chain.
+            grep -q "^Authority=Developer ID Certification Authority$" "$CS_OUT" \
+              || { echo "::error::$BIN missing Developer ID chain (intermediate CA)"; exit 1; }
+            # TeamIdentifier value matches APPLE_NOTARIZATION_TEAM_ID and is
+            # masked to "***" — accept either a real team-id format or the
+            # masked marker, but reject "not set" (the ad-hoc sentinel).
+            grep -qE "^TeamIdentifier=([A-Z0-9]{6,}|\*+)$" "$CS_OUT" \
+              || { echo "::error::$BIN: TeamIdentifier missing, ad-hoc, or unexpected format"; exit 1; }
             grep -qE "^CodeDirectory.*flags=0x[0-9a-f]+\(.*runtime.*\)" "$CS_OUT" \
               || { echo "::error::$BIN missing hardened runtime (--options runtime) flag"; exit 1; }
             echo "::endgroup::"

--- a/.github/workflows/backfill-release.yml
+++ b/.github/workflows/backfill-release.yml
@@ -248,6 +248,12 @@ jobs:
             ./scripts/create-app.sh "jr-darwin-${arch}" "$VERSION" .
             codesign --force --deep --options runtime --sign "$APPLE_SIGNING_IDENTITY" --timestamp Jr.app
             ./scripts/create-dmg.sh Jr.app "$VERSION" "jr-${arch}.dmg"
+            # Sign the DMG container itself. Required for stapler to attach a
+            # Gatekeeper-recognized notarization ticket, and routes the
+            # notarytool submission through Apple's fast path (signed-image
+            # validation) instead of the slow "discovery" path that hangs at
+            # pre-submission under burst load.
+            codesign --force --sign "$APPLE_SIGNING_IDENTITY" --timestamp "jr-${arch}.dmg"
             ./scripts/create-pkg.sh "jr-darwin-${arch}" "$VERSION" "$APPLE_INSTALLER_IDENTITY" "jr-${arch}.pkg"
             rm -rf Jr.app
           done

--- a/.github/workflows/sign-and-publish.yml
+++ b/.github/workflows/sign-and-publish.yml
@@ -265,6 +265,12 @@ jobs:
             ./scripts/create-app.sh "jr-a-darwin-${arch}" "$VERSION" .
             codesign --force --deep --options runtime --sign "$APPLE_SIGNING_IDENTITY" --timestamp Jr.app
             ./scripts/create-dmg.sh Jr.app "$VERSION" "jr-a-${arch}.dmg"
+            # Sign the DMG container itself. Required for stapler to attach a
+            # Gatekeeper-recognized notarization ticket, and routes the
+            # notarytool submission through Apple's fast path (signed-image
+            # validation) instead of the slow "discovery" path that hangs at
+            # pre-submission under burst load (observed in run 27797831466).
+            codesign --force --sign "$APPLE_SIGNING_IDENTITY" --timestamp "jr-a-${arch}.dmg"
             ./scripts/create-pkg.sh "jr-a-darwin-${arch}" "$VERSION" "$APPLE_INSTALLER_IDENTITY" "jr-a-${arch}.pkg"
             rm -rf Jr.app
           done
@@ -550,6 +556,12 @@ jobs:
             ./scripts/create-app.sh "jr-darwin-${arch}" "$VERSION" .
             codesign --force --deep --options runtime --sign "$APPLE_SIGNING_IDENTITY" --timestamp Jr.app
             ./scripts/create-dmg.sh Jr.app "$VERSION" "jr-${arch}.dmg"
+            # Sign the DMG container itself. Required for stapler to attach a
+            # Gatekeeper-recognized notarization ticket, and routes the
+            # notarytool submission through Apple's fast path (signed-image
+            # validation) instead of the slow "discovery" path that hangs at
+            # pre-submission under burst load.
+            codesign --force --sign "$APPLE_SIGNING_IDENTITY" --timestamp "jr-${arch}.dmg"
             ./scripts/create-pkg.sh "jr-darwin-${arch}" "$VERSION" "$APPLE_INSTALLER_IDENTITY" "jr-${arch}.pkg"
             rm -rf Jr.app
           done

--- a/.github/workflows/sign-and-publish.yml
+++ b/.github/workflows/sign-and-publish.yml
@@ -331,11 +331,16 @@ jobs:
               || { echo "::error::$PKG not notarized (spctl source unexpected)"; exit 1; }
             echo "::endgroup::"
           done
+          # `spctl --assess --type open` on a notarized .dmg returns
+          # "rejected: source=Insufficient Context" on macOS 15+ — Gatekeeper
+          # assesses the *mounted* contents, not the .dmg file. `stapler
+          # validate` is the canonical check: it verifies the notarization
+          # ticket is locally attached to the .dmg and references a valid
+          # Apple notarization record. Non-zero exit on missing/invalid
+          # staple fails the step.
           for DMG in jr-a-arm64.dmg jr-a-amd64.dmg; do
             echo "::group::Verify $DMG"
-            spctl --assess --type open --verbose=4 "$DMG" 2>&1 | tee "$SPCTL_OUT"
-            grep -q "source=Notarized Developer ID" "$SPCTL_OUT" \
-              || { echo "::error::$DMG not notarized (spctl source unexpected)"; exit 1; }
+            xcrun stapler validate "$DMG"
             echo "::endgroup::"
           done
 
@@ -622,11 +627,16 @@ jobs:
               || { echo "::error::$PKG not notarized (spctl source unexpected)"; exit 1; }
             echo "::endgroup::"
           done
+          # `spctl --assess --type open` on a notarized .dmg returns
+          # "rejected: source=Insufficient Context" on macOS 15+ — Gatekeeper
+          # assesses the *mounted* contents, not the .dmg file. `stapler
+          # validate` is the canonical check: it verifies the notarization
+          # ticket is locally attached to the .dmg and references a valid
+          # Apple notarization record. Non-zero exit on missing/invalid
+          # staple fails the step.
           for DMG in jr-arm64.dmg jr-amd64.dmg; do
             echo "::group::Verify $DMG"
-            spctl --assess --type open --verbose=4 "$DMG" 2>&1 | tee "$SPCTL_OUT"
-            grep -q "source=Notarized Developer ID" "$SPCTL_OUT" \
-              || { echo "::error::$DMG not notarized (spctl source unexpected)"; exit 1; }
+            xcrun stapler validate "$DMG"
             echo "::endgroup::"
           done
 

--- a/.github/workflows/sign-and-publish.yml
+++ b/.github/workflows/sign-and-publish.yml
@@ -299,10 +299,18 @@ jobs:
           for BIN in jr-a-darwin-arm64 jr-a-darwin-amd64; do
             echo "::group::Verify $BIN"
             codesign -dvv "$BIN" 2>&1 | tee "$CS_OUT"
-            grep -q "^Authority=Developer ID Application:" "$CS_OUT" \
-              || { echo "::error::$BIN missing Developer ID Application authority"; exit 1; }
-            grep -q "^TeamIdentifier=" "$CS_OUT" \
-              || { echo "::error::$BIN missing TeamIdentifier"; exit 1; }
+            # GHA log-masks the leaf cert CN (it matches APPLE_SIGNING_IDENTITY
+            # secret), so `Authority=Developer ID Application: ...` becomes
+            # `Authority=***`. Anchor instead on the intermediate cert in the
+            # Developer ID chain, which is a public Apple CA name and never
+            # masked. Its presence proves the chain.
+            grep -q "^Authority=Developer ID Certification Authority$" "$CS_OUT" \
+              || { echo "::error::$BIN missing Developer ID chain (intermediate CA)"; exit 1; }
+            # TeamIdentifier value matches APPLE_NOTARIZATION_TEAM_ID and is
+            # masked to "***" — accept either a real team-id format or the
+            # masked marker, but reject "not set" (the ad-hoc sentinel).
+            grep -qE "^TeamIdentifier=([A-Z0-9]{6,}|\*+)$" "$CS_OUT" \
+              || { echo "::error::$BIN: TeamIdentifier missing, ad-hoc, or unexpected format"; exit 1; }
             grep -qE "^CodeDirectory.*flags=0x[0-9a-f]+\(.*runtime.*\)" "$CS_OUT" \
               || { echo "::error::$BIN missing hardened runtime (--options runtime) flag"; exit 1; }
             echo "::endgroup::"
@@ -576,10 +584,18 @@ jobs:
           for BIN in jr-darwin-arm64 jr-darwin-amd64; do
             echo "::group::Verify $BIN"
             codesign -dvv "$BIN" 2>&1 | tee "$CS_OUT"
-            grep -q "^Authority=Developer ID Application:" "$CS_OUT" \
-              || { echo "::error::$BIN missing Developer ID Application authority"; exit 1; }
-            grep -q "^TeamIdentifier=" "$CS_OUT" \
-              || { echo "::error::$BIN missing TeamIdentifier"; exit 1; }
+            # GHA log-masks the leaf cert CN (it matches APPLE_SIGNING_IDENTITY
+            # secret), so `Authority=Developer ID Application: ...` becomes
+            # `Authority=***`. Anchor instead on the intermediate cert in the
+            # Developer ID chain, which is a public Apple CA name and never
+            # masked. Its presence proves the chain.
+            grep -q "^Authority=Developer ID Certification Authority$" "$CS_OUT" \
+              || { echo "::error::$BIN missing Developer ID chain (intermediate CA)"; exit 1; }
+            # TeamIdentifier value matches APPLE_NOTARIZATION_TEAM_ID and is
+            # masked to "***" — accept either a real team-id format or the
+            # masked marker, but reject "not set" (the ad-hoc sentinel).
+            grep -qE "^TeamIdentifier=([A-Z0-9]{6,}|\*+)$" "$CS_OUT" \
+              || { echo "::error::$BIN: TeamIdentifier missing, ad-hoc, or unexpected format"; exit 1; }
             grep -qE "^CodeDirectory.*flags=0x[0-9a-f]+\(.*runtime.*\)" "$CS_OUT" \
               || { echo "::error::$BIN missing hardened runtime (--options runtime) flag"; exit 1; }
             echo "::endgroup::"


### PR DESCRIPTION
## Summary

Follow-up to #530 (commit `99f212d`). The verify-signatures step has been silently broken in any fork that opts into signing — three distinct issues, none of which surface in this repo because `SIGNING_ENABLED` is unset. All three were uncovered while verifying the fix end-to-end on the downstream `ArcavenAE/jira-cli` fork; final run [27825933805](https://github.com/ArcavenAE/jira-cli/actions/runs/27825933805) is green start-to-finish.

## Bugs fixed

### 1. GHA log-masking blinds the codesign greps (commit `8b645e5`)

`codesign -dvv` emits two lines that contain the verbatim values of `APPLE_SIGNING_IDENTITY` and `APPLE_NOTARIZATION_TEAM_ID` secrets:

```
Authority=Developer ID Application: <name> (<teamid>)   ← masked: Authority=***
TeamIdentifier=<teamid>                                 ← masked: TeamIdentifier=***
```

#530 anchored greps on the secret-bearing substrings, so they could never match. Fix:

- Anchor on `Authority=Developer ID Certification Authority$` — the intermediate cert in the Developer ID chain. Public Apple CA name, never masked, still proves the leaf is in the Developer ID hierarchy.
- Accept `TeamIdentifier=([A-Z0-9]{6,}|\*+)$` — real team-id format OR masked marker; rejects the literal `TeamIdentifier=not set` (ad-hoc sentinel).

### 2. Unsigned .dmg containers wedged notarytool under burst load (commit `8b59bec`)

`scripts/create-dmg.sh` produces unsigned DMGs (`hdiutil create -format UDZO`, no signing step), and we submit them straight to `notarytool`. Apple accepts unsigned DMG submissions but routes them through a slow "discovery" path that has documented hang failure modes under burst load — confirmed in fork run [27797831466](https://github.com/ArcavenAE/jira-cli/actions/runs/27797831466), where the 4th rapid submission (`jr-a-amd64.dmg`) hung at "Conducting pre-submission checks…" for 5h58m and was killed by GHA's 6h job timeout, never receiving a Submission ID.

The `.pkg` path didn't hit this because `pkgbuild --sign` (in `scripts/create-pkg.sh`) signs the package as part of creation. The `.dmg` path has no equivalent.

Fix: `codesign --force --sign "$APPLE_SIGNING_IDENTITY" --timestamp` the `.dmg` immediately after `create-dmg.sh` produces it, before the notarize loop runs. Signed DMGs go through Apple's validated-signature fast path — confirmed run 27825933805 has all four notarytool submissions complete in well under a minute each.

### 3. `spctl --assess --type open` is the wrong tool for `.dmg` on macOS 15+ (commit `8a9f170`)

On modern macOS, `spctl --assess --type open <dmg>` returns:

```
jr-a-arm64.dmg: rejected
source=Insufficient Context
```

Gatekeeper applies its policy against the *mounted* contents (the `.app` inside), not the `.dmg` file itself. With no mount context, spctl can't return a verdict — regardless of how properly the `.dmg` is signed, notarized, and stapled.

Fix: replace `.dmg` verification with `xcrun stapler validate`, the canonical check for a notarized container. It confirms a notarization ticket is locally attached and references a valid Apple notarization record. Exit 0 on valid, non-zero on missing/invalid — works directly with `set -e`, no grep needed.

`.pkg` verification stays on `spctl --assess --type install` because that one works correctly (Gatekeeper *can* assess a `.pkg` file directly; the install action has a sane evaluation context).

## Test plan

- [x] YAML parses
- [x] Each inline shell parses with `bash -n`
- [x] Inert in this repo (`SIGNING_ENABLED` unset)
- [x] **Verified end-to-end in `ArcavenAE/jira-cli`:** run [27825933805](https://github.com/ArcavenAE/jira-cli/actions/runs/27825933805) is green from build → sign → notarize → verify → release → homebrew tap, in 9 minutes. Verify step exercised correctly on all artifacts (bare binaries, both `.pkg`, both `.dmg`).

Refs: #210, #530