### PR TITLE
test: anchor backfill zip-asset guard to distinct upsert branches (FIX-F5-001)

### DIFF
--- a/tests/backfill_matrix_parity.rs
+++ b/tests/backfill_matrix_parity.rs
@@ -560,19 +560,28 @@ fn test_backfill_release_job_has_upsert_upload_branch() {
     );
 }
 
-/// AC-002 (asset completeness — zip in both branches): `jr-*.zip` must appear
-/// in BOTH the upload (exists) branch AND the create (new release) branch of the
-/// check-then-upsert block in the `release` job.
+/// AC-002 (asset completeness — zip in DISTINCT upsert branches): `jr-*.zip`
+/// must appear in the upload (exists) branch AND in the create (new release)
+/// branch of the check-then-upsert `if/else/fi` block in the `release` job —
+/// each occurrence anchored to its own distinct branch slice.
 ///
 /// Adding `jr-*.zip` to only one branch creates an asset-completeness bug on the
 /// other path — backfilled releases created for the first time would be missing
 /// the Windows binary, or re-run releases would be missing it on upsert.
 ///
-/// The assertion counts occurrences of `jr-*.zip` in the release job block and
-/// requires at least two — one per branch. (The Upload artifact step in the build
-/// job also uses `jr-*.zip`, but that is in the `build` job block, not `release`.)
+/// Anchoring strategy (stronger than a raw occurrence count):
+///   1. Extract the `release` job block.
+///   2. Locate the `else` line inside that block — this is the boundary between
+///      the upload (exists) branch and the create (new release) branch.
+///   3. Split the block into `pre_else` (upload branch) and `post_else` (create
+///      branch).
+///   4. Assert `jr-*.zip` is present in EACH slice independently.
 ///
-/// Anchoring: assertion is scoped to the `release` job block.
+/// This prevents the over-permissive "≥2 anywhere" form from passing when both
+/// occurrences fall in the same branch (the exact data-loss class being guarded).
+///
+/// Anchoring: assertion is scoped to the `release` job block; branch slices are
+/// anchored to the `else` token.
 ///
 /// RED GATE: `jr-*.zip` is NOT present in the current `release` job (the old
 /// delete+create pattern does not include it). This test FAILS on the current
@@ -591,25 +600,74 @@ fn test_backfill_release_job_zip_in_both_upsert_branches() {
         )
     });
 
-    let zip_count = release_block.matches("jr-*.zip").count();
+    // Locate the `else` line that separates the upload branch (release exists)
+    // from the create branch (release does not exist yet).  We search for a
+    // line whose trimmed content is exactly `else` — robust to any indentation.
+    let else_byte_offset = release_block
+        .lines()
+        .scan(0usize, |pos, line| {
+            let start = *pos;
+            *pos += line.len() + 1; // +1 for the '\n' stripped by .lines()
+            Some((start, line))
+        })
+        .find(|(_start, line)| line.trim() == "else")
+        .map(|(start, _line)| start)
+        .unwrap_or_else(|| {
+            panic!(
+                "FAIL: The `release` job in `.github/workflows/backfill-release.yml` \
+                 does not contain a bare `else` line.\n\
+                 \n\
+                 The check-then-upsert block must have an `if/else/fi` structure:\n\
+                   if gh release view \"$TAG\" ...; then\n\
+                     <upload branch>\n\
+                   else\n\
+                     <create branch>\n\
+                   fi\n\
+                 \n\
+                 Without an `else`, the test cannot anchor `jr-*.zip` to distinct \
+                 branches.\n\
+                 \n\
+                 (S-FORK-OPS-BACKFILL-1 AC-002 / spec-delta DESTRUCTIVE §Replacement)"
+            )
+        });
+
+    let upload_branch = &release_block[..else_byte_offset];
+    let create_branch = &release_block[else_byte_offset..];
 
     assert!(
-        zip_count >= 2,
-        "FAIL (RED GATE): `jr-*.zip` appears fewer than 2 times in the `release` \
-         job block of `.github/workflows/backfill-release.yml` \
-         (found {} occurrence{}).\n\
+        upload_branch.contains("jr-*.zip"),
+        "FAIL (RED GATE): `jr-*.zip` is absent from the UPLOAD (exists) branch of \
+         the check-then-upsert block in the `release` job of \
+         `.github/workflows/backfill-release.yml`.\n\
          \n\
-         `jr-*.zip` MUST appear in BOTH branches of the check-then-upsert block:\n\
-           1. The upload branch (`gh release upload ... jr-*.tar.gz jr-*.zip jr-*.sha256`)\n\
-           2. The create branch (`gh release create ... jr-*.tar.gz jr-*.zip jr-*.sha256`)\n\
+         The upload branch runs when the release already exists and uploads/replaces \
+         assets via `gh release upload --clobber`. It must include `jr-*.zip` so \
+         that a re-run release ships the Windows binary.\n\
          \n\
-         Adding it to only one branch creates an asset-completeness bug: \
-         a first-run release would be missing the Windows binary, or a re-run \
-         release would be missing it on upsert (Invariant 3).\n\
+         Required form (exists-branch):\n\
+           gh release upload \"$TAG\" --repo \"...\" --clobber \\\n\
+             jr-*.tar.gz jr-*.zip jr-*.sha256\n\
          \n\
-         (S-FORK-OPS-BACKFILL-1 AC-002 / spec-delta DESTRUCTIVE Invariant 3)",
-        zip_count,
-        if zip_count == 1 { "" } else { "s" }
+         (S-FORK-OPS-BACKFILL-1 AC-002 / spec-delta DESTRUCTIVE Invariant 3 — \
+         upload branch anchor)"
+    );
+
+    assert!(
+        create_branch.contains("jr-*.zip"),
+        "FAIL (RED GATE): `jr-*.zip` is absent from the CREATE (new release) branch \
+         of the check-then-upsert block in the `release` job of \
+         `.github/workflows/backfill-release.yml`.\n\
+         \n\
+         The create branch runs when no release exists yet and creates one via \
+         `gh release create`. It must include `jr-*.zip` so that a first-run \
+         backfilled release ships the Windows binary.\n\
+         \n\
+         Required form (create-branch):\n\
+           gh release create \"$TAG\" --repo \"...\" --generate-notes \\\n\
+             jr-*.tar.gz jr-*.zip jr-*.sha256\n\
+         \n\
+         (S-FORK-OPS-BACKFILL-1 AC-002 / spec-delta DESTRUCTIVE Invariant 3 — \
+         create branch anchor)"
     );
 }
 


### PR DESCRIPTION
# test: anchor backfill zip-asset guard to distinct upsert branches (FIX-F5-001)

**Epic:** S-FORK-OPS-BACKFILL — Backfill-release Windows parity & safe upsert
**Mode:** feature (F5 adversarial-review fix, test-only)
**Convergence:** F5 Pass 1 finding M4 → resolved

![Tests](https://img.shields.io/badge/tests-11%2F11-brightgreen)
![Coverage](https://img.shields.io/badge/coverage-test--only-brightgreen)
![Mutation](https://img.shields.io/badge/mutation-N%2FA-lightgrey)
![Security](https://img.shields.io/badge/security-N%2FA%20(test--only)-lightgrey)

F5 adversarial review (Pass 1) flagged finding **M4**: the `test_backfill_release_job_zip_in_both_upsert_branches` guard in `tests/backfill_matrix_parity.rs` was over-permissive — it counted `jr-*.zip` ≥2 occurrences *anywhere* in the release job block, which passes even when both occurrences fall in the same upsert branch (an asset-completeness bug the test was designed to prevent). This PR rewrites the assertion to split the release-job block at the `else` boundary and independently assert `jr-*.zip` in BOTH the upload (exists) branch and the create (new release) branch. Non-vacuity is proven: the test fails when both occurrences are placed in the upload branch only.

---

## Architecture Changes

```mermaid
graph TD
    BackfillTest["tests/backfill_matrix_parity.rs"]
    WorkflowFile[".github/workflows/backfill-release.yml"]
    BackfillTest -->|reads + parses| WorkflowFile
    BackfillTest -->|split at else boundary NEW| ElseSlice["upload_branch / create_branch slices"]
    style ElseSlice fill:#90EE90
```

<details>
<summary><strong>Architecture Decision Record</strong></summary>

### ADR: Anchor zip-asset guard to distinct upsert branches via else-split

**Context:** AC-002 of S-FORK-OPS-BACKFILL-1 requires `jr-*.zip` in BOTH branches of the `if/else/fi` upsert block. The original assertion (count ≥ 2) is over-permissive: two occurrences in the same branch satisfies it while leaving the other branch unguarded.

**Decision:** Locate the bare `else` line inside the release job block, split into `upload_branch` (pre-else) and `create_branch` (post-else), and assert `contains("jr-*.zip")` independently on each slice.

**Rationale:** Each slice independently fails if the branch is missing the asset, exactly matching the invariant. A missing `else` panics with a clear diagnostic — this is a structural workflow invariant, not optional.

**Alternatives Considered:**
1. Regex capture groups — more complex, still needs else-anchoring; rejected for simplicity.
2. Keep count ≥ 2 but add a cross-branch uniqueness check — awkward and brittle; rejected.

**Consequences:**
- The guard now catches the exact class of bug (asset in one branch only) it was intended to prevent.
- A workflow refactor that removes the `else` (e.g. merges branches) will cause a clear panic with explanation.

</details>

---

## Story Dependencies

```mermaid
graph LR
    BACKFILL["S-FORK-OPS-BACKFILL-1<br/>merged develop"] --> FIX["FIX-F5-001<br/>this PR"]
    style FIX fill:#FFD700
```

This PR depends on `S-FORK-OPS-BACKFILL-1` (merged, commit `2756050`). No downstream PRs blocked.

---

## Spec Traceability

```mermaid
flowchart LR
    AC002["S-FORK-OPS-BACKFILL-1<br/>AC-002: zip in BOTH branches"] --> T1["test_backfill_release_job_zip_in_both_upsert_branches"]
    T1 -->|split at else| UB["upload_branch.contains(jr-*.zip)"]
    T1 -->|split at else| CB["create_branch.contains(jr-*.zip)"]
    UB --> WF[".github/workflows/backfill-release.yml"]
    CB --> WF
```

---

## Test Evidence

### Coverage Summary

| Metric | Value | Threshold | Status |
|--------|-------|-----------|--------|
| Test suite (backfill_matrix_parity) | 11/11 pass | 100% | PASS |
| Coverage | test-only change | N/A | N/A |
| Mutation kill rate | N/A (test-only, no production code delta) | N/A | N/A |
| Holdout satisfaction | N/A — evaluated at wave gate | N/A | N/A |

<details>
<summary><strong>Detailed Test Results</strong></summary>

### Full backfill_matrix_parity test suite (11/11 pass)

| Test | Result |
|------|--------|
| `test_backfill_build_matrix_contains_windows_target` | PASS |
| `test_backfill_release_job_has_draft_detection` | PASS |
| `test_backfill_build_step_declares_shell_bash` | PASS |
| `test_backfill_release_job_has_upsert_view_check` | PASS |
| `test_backfill_release_job_has_no_delete_command` | PASS |
| `test_backfill_matrix_parity_matches_release_yml` | PASS |
| `test_backfill_release_job_has_upsert_upload_branch` | PASS |
| `test_backfill_unix_package_step_declares_shell_bash` | PASS |
| `test_backfill_release_job_has_no_or_true_silencer` | PASS |
| `test_backfill_upload_artifact_includes_zip` | PASS |
| `test_backfill_release_job_zip_in_both_upsert_branches` | PASS |

### Non-vacuity proof

The rewritten test was verified to fail when `jr-*.zip` is present only in the upload branch (both occurrences placed in `pre_else`). This confirms the guard is not trivially satisfied by the existing structure and would catch a future regression where one branch loses the asset.

</details>

---

## Holdout Evaluation

N/A — evaluated at wave gate (this is a test-hardening fix, not a feature).

---

## Adversarial Review

| Pass | Finding | Category | Severity | Status |
|------|---------|----------|----------|--------|
| F5 Pass 1 | M4: over-permissive zip count (≥2 anywhere) | test-quality | MEDIUM | Fixed (this PR) |

**F5 Pass 1 finding M4 (verbatim):** The `test_backfill_release_job_zip_in_both_upsert_branches` guard counts occurrences of `jr-*.zip` and asserts `≥2`, but this passes even when both occurrences fall in the same branch. The test does not independently verify each branch of the upsert `if/else/fi` block.

**Resolution:** Split the release-job block at the bare `else` line; assert `contains("jr-*.zip")` independently on each slice. Missing `else` panics with structural-invariant explanation.

---

## Security Review

N/A — test-only change. No production code, no workflow YAML, no secret surface, no shell execution paths modified. Security review skipped per DF-025 (fix-pr-delivery lifecycle for test-only changes).

---

## Risk Assessment & Deployment

### Blast Radius
- **Systems affected:** `tests/backfill_matrix_parity.rs` only — test file, no production code.
- **User impact:** None (CI guard only; no runtime behavior change).
- **Data impact:** None.
- **Risk Level:** LOW

### Performance Impact
No performance impact — test-only change. Test runtime: ~0.00s (file parse, no network I/O).

---

## Traceability

| Requirement | AC | Test | Status |
|-------------|-----|------|--------|
| S-FORK-OPS-BACKFILL-1 AC-002 | zip in BOTH upsert branches | `test_backfill_release_job_zip_in_both_upsert_branches` | PASS |

---

## AI Pipeline Metadata

<details>
<summary><strong>Pipeline Details</strong></summary>

```yaml
ai-generated: true
pipeline-mode: feature (fix-pr-delivery, DF-025)
factory-version: "1.0.0"
pipeline-stages:
  spec-crystallization: completed (S-FORK-OPS-BACKFILL-1)
  story-decomposition: N/A (single-test fix)
  tdd-implementation: completed
  holdout-evaluation: N/A (test-only)
  adversarial-review: F5 Pass 1 finding M4 resolved
  formal-verification: N/A (test-only)
  convergence: achieved
convergence-metrics:
  adversarial-passes: 1 (F5 Pass 1)
models-used:
  builder: claude-sonnet-4-6
generated-at: "2026-06-19T00:00:00Z"
```

</details>

---

## Pre-Merge Checklist

- [ ] All CI status checks passing (`ci-gate`)
- [x] Coverage delta is positive or neutral (test-only: neutral)
- [x] No critical/high security findings unresolved (N/A — test-only)
- [x] Rollback procedure validated (revert one commit — test-only, zero blast radius)
- [x] No feature flag required (test-only change)
- [x] Human review completed per autonomy level
