### PR TITLE
chore(release): v0.6.0-dev.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,34 @@ All notable changes to jr will be documented here.
 
 ### Changed
 
+## [0.6.0-dev.5] - 2026-06-19
+
+### Fixed
+
+- **`backfill-release.yml` safe release upsert — check-then-upsert replaces destructive
+  delete+recreate (#539, S-FORK-OPS-BACKFILL-1):** `backfill-release.yml` now checks
+  whether a GitHub Release for the tag already exists before touching it. If a release
+  exists, it upserts assets individually (skipping already-present files); if it does not
+  exist, it creates a new release. This eliminates the previous destructive
+  `gh release delete` + `gh release create` pattern, which permanently discarded any
+  curated release notes that had been written for an existing release.
+- **`backfill-release.yml` Windows target parity (#539, S-FORK-OPS-BACKFILL-1):**
+  Backfilled releases now include the `x86_64-pc-windows-msvc` `.zip` asset alongside
+  the macOS and Linux tarballs, matching the asset matrix produced by `release.yml`.
+
+### Changed
+
+- **`GITLEAKS_DISABLED` fork-ops opt-out documented (#538):** Added `GITLEAKS_DISABLED`
+  to the repository-variable reference in `docs/specs/fork-friendly-release-ops.md`.
+  Fork maintainers who hit false-positive gitleaks alerts on the signing workflows can
+  set this variable to skip the gitleaks scan step. No runtime behavior changed in the
+  canonical repo.
+- **Backfill matrix-parity test guard anchored to distinct upsert branches (#540,
+  FIX-F5-001):** The CI test that verifies zip assets are produced and upserted by
+  `backfill-release.yml` now creates isolated branches per test scenario so each upsert
+  operation targets a distinct branch, eliminating false-pass conditions that could arise
+  from shared branch state across test cases.
+
 ## [0.6.0-dev.4] - 2026-06-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.6.0-dev.4"
+version = "0.6.0-dev.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.6.0-dev.4"
+version = "0.6.0-dev.5"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary

Cuts dev release `v0.6.0-dev.5`, promoting 3 commits that landed on `develop` since `v0.6.0-dev.4` (tag `45ddf7a`).

### Included changes

- **fix(ci) #539 — `backfill-release.yml` safe upsert + Windows parity (S-FORK-OPS-BACKFILL-1):** Replaces the destructive `gh release delete` + `gh release create` pattern with a check-then-upsert flow that preserves existing curated release notes. Adds `x86_64-pc-windows-msvc` `.zip` to the backfill asset matrix to match `release.yml` output.
- **docs #538 — `GITLEAKS_DISABLED` opt-out documented:** Adds `GITLEAKS_DISABLED` repository-variable guidance to `docs/specs/fork-friendly-release-ops.md` for fork maintainers hitting false-positive gitleaks alerts on signing workflows.
- **test #540 — backfill matrix-parity guard anchored to distinct upsert branches (FIX-F5-001):** Strengthens the CI test that verifies zip-asset production by isolating each upsert operation to its own branch, eliminating false-pass conditions from shared branch state.

### Files changed

- `Cargo.toml` — version `0.6.0-dev.4` → `0.6.0-dev.5`
- `Cargo.lock` — `jr` package version line updated
- `CHANGELOG.md` — `[0.6.0-dev.5]` section added; fresh empty `[Unreleased]` subsections left in place

## Test plan

- [ ] `ci-gate` passes (lint, test, build)
- [ ] CHANGELOG `[0.6.0-dev.5]` section matches the 3 included PRs
- [ ] Only `Cargo.toml`, `Cargo.lock`, and `CHANGELOG.md` changed