### PR TITLE
chore(release): v0.6.0-dev.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ All notable changes to jr will be documented here.
 
 ### Changed
 
+## [0.6.0-dev.6] - 2026-06-19
+
+### Added
+
+- **CLAUDE.md dead-citation CI guard (`tests/claude_md_citations.rs`, #544, #545;
+  full VSDD F1–F7):** A new always-run test (`test_all_backtick_citations_in_claude_md_resolve`)
+  fails the build when an in-scope backtick file-path citation in `CLAUDE.md` points to a
+  missing file. Reports the real line number for each broken citation. Coverage scope:
+  `src/`, `tests/`, `docs/`, `.github/`, `scripts/`, and a curated set of root-level files
+  (`CHANGELOG.md`, `Cargo.toml`, `Cargo.lock`, `build.rs`, `.cargo/config.toml`,
+  `.cargo/mutants.toml`). Excluded: `.factory/` directory (artifact branch, not
+  workspace files), glob patterns (`*`, `**`), and human-readable shorthands (e.g.
+  `<file>::<fn>`). CWE-22 path-traversal-safe (rejects any token containing `..`).
+  (#544: base guard; #545: F6 hardening — `SEC-001` dotdot guard, shared constants,
+  mutation-resistance pins, SEC-002 path-canonicalization bypass proof.)
+
 ## [0.6.0-dev.5] - 2026-06-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.6.0-dev.5"
+version = "0.6.0-dev.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.6.0-dev.5"
+version = "0.6.0-dev.6"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary

Cuts dev release `v0.6.0-dev.6`, promoting 2 commits that landed on `develop` since `v0.6.0-dev.5` (tag `71f33c6`).

### Included changes

- **feat #544 — CLAUDE.md dead-citation CI guard (`tests/claude_md_citations.rs`):** Base guard — fails the build when an in-scope backtick file-path citation in CLAUDE.md points to a missing file; reports the real line number; covers `src/`, `tests/`, `docs/`, `.github/`, `scripts/`, and curated root files; excludes `.factory/`, globs, shorthands; CWE-22 traversal-safe. (S-MAINT-DEAD-CITATION-CI, full VSDD F1–F7)
- **feat #545 — DEAD-CITATION-CI F6 hardening (`SEC-001` dotdot guard, shared consts, mutation pins):** Adds a `SEC-001` path-traversal safety proof (`..` in citation → immediate fail before any filesystem call), shared constants for exclusion prefixes, and mutation-resistance pins (`test_dotdot_citation_fails_before_fs_access`, `test_citation_on_factory_path_is_excluded_not_absent`). Includes `SEC-002` path-canonicalization bypass proof (symlinks). Completes the F6 hardening phase.

### Files changed

- `Cargo.toml` — version `0.6.0-dev.5` → `0.6.0-dev.6`
- `Cargo.lock` — `jr` package version line updated
- `CHANGELOG.md` — `[0.6.0-dev.6]` section added; fresh empty `[Unreleased]` subsections left in place

## Test plan

- [ ] `ci-gate` passes (lint, test, build)
- [ ] CHANGELOG `[0.6.0-dev.6]` section matches the 2 included PRs
- [ ] Only `Cargo.toml`, `Cargo.lock`, and `CHANGELOG.md` changed