### PR TITLE
fix(config): invalid profile name via --profile / JR_PROFILE exits 64 not 78 (H-019)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to jr will be documented here.
 
 ### Fixed
 
+- **Invalid profile name via `--profile` or `JR_PROFILE` now exits 64 instead of 78 (H-019):** Supplying an invalid profile name (bad charset, empty, or too long) via the `--profile` flag or `JR_PROFILE` environment variable now exits 64 (EX_USAGE — user input error) instead of 78 (EX_CONFIG — config file error). This matches the exit code produced by the unknown-profile check on the same code path. The config-file boundary (`[profiles."foo:bar"]` in `config.toml`) already exited 64 and is unchanged.
+
 - **`verify-signatures` CI step now exercises correctly in signing-configured forks:** The step was a no-op on forks that set `SIGNING_ENABLED=true` because it did not propagate the expected environment. Fixed so signature verification runs as intended when the opt-in workflow is active. No behavior change in the canonical repo (signing disabled).
 
 ### Changed

--- a/src/config.rs
+++ b/src/config.rs
@@ -296,6 +296,7 @@ impl Config {
         // is also covered) and before resolving `active_profile_name` (so a
         // fresh first-run with empty profiles isn't gated).
         for name in global.profiles.keys() {
+            // map_err supplies a file-locating message; keep even though validate_profile_name now returns UserError.
             validate_profile_name(name).map_err(|_| {
                 JrError::UserError(format!(
                     "invalid profile name {name:?} in config.toml; allowed: \
@@ -1235,7 +1236,7 @@ mod tests {
         let err = result.expect_err("JR_PROFILE with invalid char should reject");
         let je = err.downcast_ref::<JrError>().expect("should be JrError");
         // H-019: JR_PROFILE is user-supplied input → must be UserError (exit 64),
-        // not ConfigError (exit 78). RED GATE: currently returns ConfigError/78.
+        // not ConfigError (exit 78). Previously exited 78 (ConfigError); fixed by H-019.
         assert!(
             matches!(je, JrError::UserError(_)),
             "H-019: JR_PROFILE invalid charset must produce UserError, got {je:?}"
@@ -1265,9 +1266,9 @@ mod tests {
     /// charset character; the input comes from the `--profile` flag, not a
     /// config file.
     ///
-    /// RED GATE: currently exits 78 (ConfigError) because `validate_profile_name`
-    /// returns `JrError::ConfigError` for charset violations and `load_inner`
-    /// propagates it raw via `?`.
+    /// Previously exited 78 (ConfigError) because `validate_profile_name`
+    /// returned `JrError::ConfigError` for charset violations and `load_inner`
+    /// propagated it raw via `?`. Fixed by H-019.
     #[test]
     fn test_load_with_invalid_charset_profile_flag_returns_user_error() {
         let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
@@ -1306,8 +1307,8 @@ mod tests {
     /// `Err` with `JrError::UserError` (exit 64). An empty profile name
     /// supplied via `--profile ""` is a user error.
     ///
-    /// RED GATE: currently exits 78 (ConfigError) because `validate_profile_name`
-    /// returns `JrError::ConfigError` for the empty-name branch.
+    /// Previously exited 78 (ConfigError) because `validate_profile_name`
+    /// returned `JrError::ConfigError` for the empty-name branch. Fixed by H-019.
     #[test]
     fn test_load_with_empty_profile_flag_returns_user_error() {
         let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
@@ -1343,8 +1344,8 @@ mod tests {
     /// return `Err` with `JrError::UserError` (exit 64). A 65-char profile
     /// name supplied via `--profile` is a user error (too long).
     ///
-    /// RED GATE: currently exits 78 (ConfigError) because `validate_profile_name`
-    /// returns `JrError::ConfigError` for the too-long branch.
+    /// Previously exited 78 (ConfigError) because `validate_profile_name`
+    /// returned `JrError::ConfigError` for the too-long branch. Fixed by H-019.
     #[test]
     fn test_load_with_overlength_profile_flag_returns_user_error() {
         let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
@@ -1381,9 +1382,9 @@ mod tests {
     /// `Err` with `JrError::UserError` (exit 64). An empty profile name
     /// from the env var is a user error.
     ///
-    /// RED GATE: currently exits 78 (ConfigError) because `validate_profile_name`
-    /// returns `JrError::ConfigError` for the empty-name branch, propagated
-    /// raw by `load_inner`.
+    /// Previously exited 78 (ConfigError) because `validate_profile_name`
+    /// returned `JrError::ConfigError` for the empty-name branch, propagated
+    /// raw by `load_inner`. Fixed by H-019.
     #[test]
     fn test_load_jr_profile_env_empty_returns_user_error() {
         let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
@@ -1417,6 +1418,48 @@ mod tests {
             64,
             "H-019: exit code must be 64 (EX_USAGE), got {}",
             je.exit_code()
+        );
+    }
+
+    /// H-019 (BC-6.1.004): `Config::load_with(Some("valid-name"))` returns `Ok` when the
+    /// config has a `[profiles.valid-name]` entry. Guards the `load_with(cli_flag)` wiring
+    /// and kills the "charset check → unconditional reject" mutant.
+    #[test]
+    fn test_load_with_valid_profile_flag_returns_ok() {
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = TempDir::new().unwrap();
+        let cfg_dir = dir.path().join("jr");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        std::fs::write(
+            cfg_dir.join("config.toml"),
+            r#"
+                default_profile = "valid-name"
+                [profiles.valid-name]
+                url = "https://example.atlassian.net"
+                auth_method = "api_token"
+            "#,
+        )
+        .unwrap();
+
+        // SAFETY: ENV_MUTEX held.
+        //
+        // JR_CONFIG_DIR is the cross-platform debug seam (BC-6.2.017).
+        // Clear JR_PROFILE so only the cli_flag path is exercised.
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", dir.path());
+            std::env::set_var("JR_CONFIG_DIR", dir.path().join("jr"));
+            std::env::remove_var("JR_PROFILE");
+        }
+        let result = Config::load_with(Some("valid-name"));
+        unsafe {
+            std::env::remove_var("XDG_CONFIG_HOME");
+            std::env::remove_var("JR_CONFIG_DIR");
+        }
+
+        let cfg = result.expect("load_with(valid-name) must return Ok for a known, valid profile");
+        assert_eq!(
+            cfg.active_profile_name, "valid-name",
+            "active_profile_name must match the cli_flag value"
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1225,9 +1225,191 @@ mod tests {
             std::env::remove_var("XDG_CONFIG_HOME");
             std::env::remove_var("JR_CONFIG_DIR");
         }
+        let err = result.expect_err("JR_PROFILE with invalid char should reject");
+        let je = err.downcast_ref::<JrError>().expect("should be JrError");
+        // H-019: JR_PROFILE is user-supplied input → must be UserError (exit 64),
+        // not ConfigError (exit 78). RED GATE: currently returns ConfigError/78.
         assert!(
-            result.is_err(),
-            "JR_PROFILE with invalid char should reject"
+            matches!(je, JrError::UserError(_)),
+            "H-019: JR_PROFILE invalid charset must produce UserError, got {je:?}"
+        );
+        assert_eq!(
+            je.exit_code(),
+            64,
+            "H-019: exit code must be 64 (EX_USAGE), got {}",
+            je.exit_code()
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // H-019: Invalid profile name via --profile flag → UserError (exit 64)
+    //
+    // BC-6.1.004 contract: the input source is the user (--profile flag), so
+    // charset/length violations must produce JrError::UserError (exit 64),
+    // not JrError::ConfigError (exit 78).
+    //
+    // Red Gate: currently validate_profile_name returns ConfigError for
+    // charset and length violations, propagated raw via `?` at load_inner
+    // line ~321, producing exit 78. These tests fail until the fix is applied.
+    // -----------------------------------------------------------------------
+
+    /// H-019 (BC-6.1.004): `Config::load_with(Some("foo:bar"))` must return
+    /// `Err` with `JrError::UserError` (exit 64). The colon is an invalid
+    /// charset character; the input comes from the `--profile` flag, not a
+    /// config file.
+    ///
+    /// RED GATE: currently exits 78 (ConfigError) because `validate_profile_name`
+    /// returns `JrError::ConfigError` for charset violations and `load_inner`
+    /// propagates it raw via `?`.
+    #[test]
+    fn test_load_with_invalid_charset_profile_flag_returns_user_error() {
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = TempDir::new().unwrap();
+        let cfg_dir = dir.path().join("jr");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        // SAFETY: ENV_MUTEX held.
+        //
+        // JR_CONFIG_DIR is the cross-platform debug seam (BC-6.2.017).
+        // Clear JR_PROFILE so only the cli_flag path is exercised.
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", dir.path());
+            std::env::set_var("JR_CONFIG_DIR", dir.path().join("jr"));
+            std::env::remove_var("JR_PROFILE");
+        }
+        let result = Config::load_with(Some("foo:bar"));
+        unsafe {
+            std::env::remove_var("XDG_CONFIG_HOME");
+            std::env::remove_var("JR_CONFIG_DIR");
+        }
+        let err = result.expect_err("--profile foo:bar should reject (colon is invalid charset)");
+        let je = err.downcast_ref::<JrError>().expect("should be JrError");
+        assert!(
+            matches!(je, JrError::UserError(_)),
+            "H-019: --profile flag invalid charset must produce UserError, got {je:?}"
+        );
+        assert_eq!(
+            je.exit_code(),
+            64,
+            "H-019: exit code must be 64 (EX_USAGE), got {}",
+            je.exit_code()
+        );
+    }
+
+    /// H-019 (BC-6.1.004): `Config::load_with(Some(""))` must return
+    /// `Err` with `JrError::UserError` (exit 64). An empty profile name
+    /// supplied via `--profile ""` is a user error.
+    ///
+    /// RED GATE: currently exits 78 (ConfigError) because `validate_profile_name`
+    /// returns `JrError::ConfigError` for the empty-name branch.
+    #[test]
+    fn test_load_with_empty_profile_flag_returns_user_error() {
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = TempDir::new().unwrap();
+        let cfg_dir = dir.path().join("jr");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        // SAFETY: ENV_MUTEX held.
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", dir.path());
+            std::env::set_var("JR_CONFIG_DIR", dir.path().join("jr"));
+            std::env::remove_var("JR_PROFILE");
+        }
+        let result = Config::load_with(Some(""));
+        unsafe {
+            std::env::remove_var("XDG_CONFIG_HOME");
+            std::env::remove_var("JR_CONFIG_DIR");
+        }
+        let err = result.expect_err("--profile \"\" should reject (empty name)");
+        let je = err.downcast_ref::<JrError>().expect("should be JrError");
+        assert!(
+            matches!(je, JrError::UserError(_)),
+            "H-019: --profile flag empty name must produce UserError, got {je:?}"
+        );
+        assert_eq!(
+            je.exit_code(),
+            64,
+            "H-019: exit code must be 64 (EX_USAGE), got {}",
+            je.exit_code()
+        );
+    }
+
+    /// H-019 (BC-6.1.004): `Config::load_with(Some(&"a".repeat(65)))` must
+    /// return `Err` with `JrError::UserError` (exit 64). A 65-char profile
+    /// name supplied via `--profile` is a user error (too long).
+    ///
+    /// RED GATE: currently exits 78 (ConfigError) because `validate_profile_name`
+    /// returns `JrError::ConfigError` for the too-long branch.
+    #[test]
+    fn test_load_with_overlength_profile_flag_returns_user_error() {
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = TempDir::new().unwrap();
+        let cfg_dir = dir.path().join("jr");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        // SAFETY: ENV_MUTEX held.
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", dir.path());
+            std::env::set_var("JR_CONFIG_DIR", dir.path().join("jr"));
+            std::env::remove_var("JR_PROFILE");
+        }
+        let long_name = "a".repeat(65);
+        let result = Config::load_with(Some(long_name.as_str()));
+        unsafe {
+            std::env::remove_var("XDG_CONFIG_HOME");
+            std::env::remove_var("JR_CONFIG_DIR");
+        }
+        let err = result.expect_err("--profile with 65-char name should reject (too long)");
+        let je = err.downcast_ref::<JrError>().expect("should be JrError");
+        assert!(
+            matches!(je, JrError::UserError(_)),
+            "H-019: --profile flag too-long name must produce UserError, got {je:?}"
+        );
+        assert_eq!(
+            je.exit_code(),
+            64,
+            "H-019: exit code must be 64 (EX_USAGE), got {}",
+            je.exit_code()
+        );
+    }
+
+    /// H-019 (BC-6.1.004): `JR_PROFILE=""` (empty string) must return
+    /// `Err` with `JrError::UserError` (exit 64). An empty profile name
+    /// from the env var is a user error.
+    ///
+    /// RED GATE: currently exits 78 (ConfigError) because `validate_profile_name`
+    /// returns `JrError::ConfigError` for the empty-name branch, propagated
+    /// raw by `load_inner`.
+    #[test]
+    fn test_load_jr_profile_env_empty_returns_user_error() {
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = TempDir::new().unwrap();
+        let cfg_dir = dir.path().join("jr");
+        std::fs::create_dir_all(&cfg_dir).unwrap();
+        // SAFETY: ENV_MUTEX held.
+        //
+        // JR_CONFIG_DIR is the cross-platform debug seam (BC-6.2.017).
+        // Set JR_PROFILE="" so the env-var path exercises the empty-name guard.
+        // std::env::var("JR_PROFILE") returns Ok("") → Some("") → resolves to "".
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", dir.path());
+            std::env::set_var("JR_CONFIG_DIR", dir.path().join("jr"));
+            std::env::set_var("JR_PROFILE", "");
+        }
+        let result = Config::load();
+        unsafe {
+            std::env::remove_var("JR_PROFILE");
+            std::env::remove_var("XDG_CONFIG_HOME");
+            std::env::remove_var("JR_CONFIG_DIR");
+        }
+        let err = result.expect_err("JR_PROFILE=\"\" should reject (empty name)");
+        let je = err.downcast_ref::<JrError>().expect("should be JrError");
+        assert!(
+            matches!(je, JrError::UserError(_)),
+            "H-019: JR_PROFILE empty name must produce UserError, got {je:?}"
+        );
+        assert_eq!(
+            je.exit_code(),
+            64,
+            "H-019: exit code must be 64 (EX_USAGE), got {}",
+            je.exit_code()
         );
     }
 
@@ -1307,6 +1489,20 @@ mod tests {
         }
 
         let err = result.expect_err("invalid profile key should reject");
+        // Regression guard (H-019): config-file boundary must emit UserError (exit 64),
+        // not ConfigError (exit 78). This already works via the .map_err wrapper in
+        // load_inner; assert explicitly to prevent future regression.
+        let je = err.downcast_ref::<JrError>().expect("should be JrError");
+        assert!(
+            matches!(je, JrError::UserError(_)),
+            "config-file invalid profile key must produce UserError (exit 64), got {je:?}"
+        );
+        assert_eq!(
+            je.exit_code(),
+            64,
+            "config-file invalid profile key exit code must be 64, got {}",
+            je.exit_code()
+        );
         let msg = format!("{err:#}");
         assert!(msg.contains("invalid profile name"), "got: {msg}");
         assert!(msg.contains("bad:name"), "got: {msg}");

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,9 +119,16 @@ pub fn validate_profile_name(name: &str) -> Result<(), JrError> {
     ];
 
     // BC-6.1.004 (AC-006): length check first so the error is unambiguous when
-    // both conditions fail. Empty names are treated as a length violation.
-    if name.is_empty() || name.len() > 64 {
-        return Err(JrError::ConfigError(
+    // both conditions fail. UserError (exit 64) because the name comes from
+    // user-supplied input (--profile flag, JR_PROFILE env, default_profile
+    // field) — not from a malformed config file.
+    if name.is_empty() {
+        return Err(JrError::UserError(
+            "Profile name must not be empty".to_string(),
+        ));
+    }
+    if name.len() > 64 {
+        return Err(JrError::UserError(
             "Profile name too long (max 64 characters)".to_string(),
         ));
     }
@@ -130,7 +137,7 @@ pub fn validate_profile_name(name: &str) -> Result<(), JrError> {
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
     {
-        return Err(JrError::ConfigError(
+        return Err(JrError::UserError(
             "Profile name contains invalid characters (use a-z, 0-9, -, _)".to_string(),
         ));
     }


### PR DESCRIPTION
## Summary

Fix a wrong exit code: invalid profile names supplied via `--profile` or `JR_PROFILE` now
exit **64 (EX_USAGE)** instead of **78 (EX_CONFIG)**. The root cause was
`validate_profile_name` returning `JrError::ConfigError` for all rejection branches, even
though the input source for both `--profile` and `JR_PROFILE` is always the user, not a
config file.

- `src/config.rs::validate_profile_name` — all three reject branches (empty name, too long,
  invalid charset) now return `JrError::UserError` (exit 64)
- Empty-name guard split from the combined guard so it produces "must not be empty" instead
  of the misleading "too long" message
- Triage document: `.factory/maintenance/2026-06-22/H-019-triage.md`

## Root Cause

`validate_profile_name` was returning `JrError::ConfigError` (exit 78) for every invalid
profile name, regardless of input source. When called from:

- `main.rs` with the `--profile` CLI flag value
- `config.rs::load_inner` with the `JR_PROFILE` env var value

...both paths propagated the error raw via `?`, producing exit 78. This was semantically
wrong: the caller is the user, not a broken config file.

The design intent was already documented in a comment on the adjacent unknown-profile check
("User-supplied input → UserError"), but the validation function itself used ConfigError.

The config-file-key boundary (`[profiles."foo:bar"]` in `config.toml`) already correctly
exited 64 via a `.map_err` wrapper in `load_inner` — that path is unchanged.

## Architecture Changes

```mermaid
graph TD
    A[User: --profile bad:name] --> B[main.rs: validate_profile_name]
    C[User: JR_PROFILE=bad:name] --> D[config::load_inner: validate_profile_name]
    B -->|Before H-019| E[ConfigError exit 78 WRONG]
    D -->|Before H-019| E
    B -->|After H-019| F[UserError exit 64 CORRECT]
    D -->|After H-019| F
    G[config.toml: profiles.bad:name] --> H[load_inner map_err wrapper]
    H --> I[UserError exit 64 already correct, unchanged]
```

## Story Dependencies

```mermaid
graph LR
    H019[H-019 profile exit code] -->|depends on| M547[#547 maintenance sweep 2026-06-22]
    M547 -->|merged to| DEVELOP[develop]
```

No blocking dependencies. This branch is off `develop @ a7ba872`.

## Spec Traceability

```mermaid
flowchart LR
    BC["BC-6.1.004 (AC-006, AC-007)\nProfile name validation\ninput-source → exit code"] --> AC["AC: --profile / JR_PROFILE\nare user-input sources\n→ exit 64 on invalid name"]
    AC --> TEST["5 unit tests in src/config.rs\ntest_load_with_invalid_charset_profile_flag_returns_user_error\ntest_load_with_empty_profile_flag_returns_user_error\ntest_load_with_overlength_profile_flag_returns_user_error\ntest_load_jr_profile_env_invalid_charset_returns_user_error\ntest_load_jr_profile_env_empty_returns_user_error\n+ 1 happy-path mutation pin\ntest_load_with_valid_profile_flag_returns_ok"]
    TEST --> IMPL["src/config.rs::validate_profile_name\nAll three reject branches → UserError\nEmpty guard split for accurate message"]
```

## User-Visible Behavior Change

**BREAKING for scripts that key on exit 78 for invalid profile names via flag/env.**

| Scenario | Before H-019 | After H-019 |
|---|---|---|
| `jr --profile "bad:name" ...` | exit 78 (EX_CONFIG) | exit 64 (EX_USAGE) |
| `JR_PROFILE="bad:name" jr ...` | exit 78 (EX_CONFIG) | exit 64 (EX_USAGE) |
| `JR_PROFILE="" jr ...` | exit 78 (EX_CONFIG) | exit 64 (EX_USAGE) |
| `jr --profile "" ...` | exit 78 (EX_CONFIG) | exit 64 (EX_USAGE) |
| `[profiles."foo:bar"]` in config.toml | exit 64 (EX_USAGE) | exit 64 (unchanged) |

Scripts that caught exit 78 for the flag/env cases should switch to catching exit 64.
This aligns the flag/env paths with the config-file-key path (which was always 64) and
with the unknown-profile check just below it in the same function (also 64).

## Test Evidence

**TDD process followed:**

- Commit `efb6313` — RED: 5 tests asserted `UserError`/exit-64; all failed at `ConfigError`/exit-78
- Commit `ee9e2ac` — GREEN: fix + CHANGELOG; all 5 tests pass
- Commit `69ca77a` — review nits: happy-path mutation pin added, RED-GATE stale comments de-staled

**Local gate results (all GREEN):**

| Check | Result |
|---|---|
| `cargo build` | PASS |
| `cargo test` (unit + integration) | PASS — 952 tests, 0 failures |
| `cargo clippy -- -D warnings` | PASS — 0 warnings |
| `cargo fmt --all -- --check` | PASS |

**Test coverage for H-019:**

| Test | Covers |
|---|---|
| `test_load_with_invalid_charset_profile_flag_returns_user_error` | `--profile "foo:bar"` → UserError exit 64 |
| `test_load_with_empty_profile_flag_returns_user_error` | `--profile ""` → UserError exit 64 |
| `test_load_with_overlength_profile_flag_returns_user_error` | `--profile "aaa..."(65 chars)` → UserError exit 64 |
| `test_load_jr_profile_env_invalid_charset_returns_user_error` | `JR_PROFILE="evil:profile"` → UserError exit 64 |
| `test_load_jr_profile_env_empty_returns_user_error` | `JR_PROFILE=""` → UserError exit 64 |
| `test_load_with_valid_profile_flag_returns_ok` | valid name returns Ok (mutation pin) |

## Demo Evidence

N/A — this is a pure exit-code correctness fix with no UI surface. The behavioral change is
observable only via `echo $?` after a failed `jr --profile "bad:name"` invocation.

## Holdout Evaluation

N/A — evaluated at wave gate.

## Adversarial Review

N/A — evaluated at Phase 5.

## Security Review

Pending dispatch. The change is isolated to `src/config.rs::validate_profile_name` and
touches only the `JrError` variant returned on input rejection. No secrets handling,
no network calls, no file I/O changes.

## Risk Assessment

| Dimension | Assessment |
|---|---|
| Blast radius | Minimal — only affects the error type returned on invalid profile name input |
| Regression risk | Low — existing valid-name paths are unchanged; the config-file-key path is unchanged |
| Script breakage | Low — exit 78 for this case was semantically wrong; any script comparing for 78 was relying on a bug |
| Performance | Zero — exit-code change only |

## AI Pipeline Metadata

| Field | Value |
|---|---|
| Origin | Maintenance sweep 2026-06-22 holdout-freshness sweep (H-019) |
| Triage | Product-owner confirmed REAL-BUG |
| Pipeline mode | Feature mode (maintenance fix) |
| TDD cycles | RED (efb6313) → GREEN (ee9e2ac) → nits (69ca77a) |

## Pre-Merge Checklist

- [x] PR description matches actual diff
- [x] BC-6.1.004 traceability complete (BC → AC → Test → Implementation)
- [x] 6 tests covering H-019 (5 RED→GREEN regression + 1 happy-path mutation pin)
- [x] CHANGELOG [Unreleased] ### Fixed updated
- [x] Local gate: build + test + clippy + fmt all GREEN
- [ ] Security review complete
- [ ] PR review (fresh-eyes) complete
- [ ] CI gate passing (ci-gate job)
- [ ] Merge authorized by product owner
