### PR TITLE
chore: Bundle D test hygiene — extract_job_block dedup, keyring idiom, profile coverage

### DIFF
--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -1352,7 +1352,7 @@ mod tests {
 
     /// Wrap a test in a unique JR_SERVICE_NAME scope so concurrent tests don't collide.
     fn with_test_keyring<F: FnOnce()>(f: F) {
-        if std::env::var("JR_RUN_KEYRING_TESTS").is_err() {
+        if std::env::var("JR_RUN_KEYRING_TESTS").as_deref() != Ok("1") {
             return;
         }
         // Hold the mutex across env mutation + body + cleanup so no other
@@ -1863,7 +1863,7 @@ mod tests {
     #[test]
     #[ignore = "requires keyring backend; set JR_RUN_KEYRING_TESTS=1 to run"]
     fn test_service_name_debug_build_honors_jr_service_name_override() {
-        if std::env::var("JR_RUN_KEYRING_TESTS").is_err() {
+        if std::env::var("JR_RUN_KEYRING_TESTS").as_deref() != Ok("1") {
             return;
         }
         let sentinel = "jr-test-sec-service-name-gate-sentinel";

--- a/tests/auth_profiles.rs
+++ b/tests/auth_profiles.rs
@@ -309,6 +309,103 @@ auth_method = "api_token"
         .stderr(predicates::str::contains("unknown profile"));
 }
 
+/// Ungated coverage for the global-`--profile`→subcommand fallback in
+/// `src/main.rs` for `AuthCommand::Logout`.
+///
+/// Mirrors `test_global_profile_flag_propagates_to_auth_status_unknown_profile_exits_64`.
+/// `handle_logout` calls `Config::load_with(Some("ghost"))` (strict load) first,
+/// which surfaces "unknown profile: ghost" before any keyring probe. Exit 64 proves
+/// that `main.rs` composed `effective_profile = profile.or_else(|| cli.profile.clone())`
+/// and passed it to `handle_logout` — if the global flag were dropped the active
+/// profile "default" would succeed the load and the exit code would differ.
+#[test]
+fn test_global_profile_flag_propagates_to_auth_logout_unknown_profile_exits_64() {
+    let (dir, path) = fresh_config_dir();
+    std::fs::write(
+        &path,
+        r#"
+default_profile = "default"
+[profiles.default]
+url = "https://default.example"
+auth_method = "api_token"
+"#,
+    )
+    .unwrap();
+
+    jr().env("XDG_CONFIG_HOME", dir.path())
+        .env("JR_CONFIG_DIR", dir.path().join("jr"))
+        .args(["--profile", "ghost", "auth", "logout"])
+        .assert()
+        .failure()
+        .code(64)
+        .stderr(predicates::str::contains("unknown profile"));
+}
+
+/// Ungated coverage for the global-`--profile`→subcommand fallback in
+/// `src/main.rs` for `AuthCommand::Refresh`.
+///
+/// `refresh_credentials` calls `Config::load_with(Some("ghost"))` (strict load)
+/// as its first statement, which surfaces "unknown profile: ghost" before any
+/// credential access. Exit 64 proves global `--profile` reached `refresh_credentials`.
+#[test]
+fn test_global_profile_flag_propagates_to_auth_refresh_unknown_profile_exits_64() {
+    let (dir, path) = fresh_config_dir();
+    std::fs::write(
+        &path,
+        r#"
+default_profile = "default"
+[profiles.default]
+url = "https://default.example"
+auth_method = "api_token"
+"#,
+    )
+    .unwrap();
+
+    jr().env("XDG_CONFIG_HOME", dir.path())
+        .env("JR_CONFIG_DIR", dir.path().join("jr"))
+        .args(["--profile", "ghost", "auth", "refresh", "--no-input"])
+        .assert()
+        .failure()
+        .code(64)
+        .stderr(predicates::str::contains("unknown profile"));
+}
+
+/// Ungated coverage for the global-`--profile`→subcommand fallback in
+/// `src/main.rs` for `AuthCommand::Login`.
+///
+/// Unlike logout/refresh, `handle_login` uses `Config::load_lenient_with`
+/// (it must create new profiles), so the "unknown profile" path is not
+/// triggered here. Instead this test uses `--no-input` without `--url` to
+/// hit `prepare_login_target`'s "--url required" guard (exit 64), which is
+/// reached ONLY when `effective_profile` is propagated and the target profile
+/// (ghost) has no URL configured. If the global flag were dropped, the fallback
+/// active profile "default" already has a URL, so the guard would not fire and
+/// exit 0.
+#[test]
+fn test_global_profile_flag_propagates_to_auth_login_no_url_exits_64() {
+    let (dir, path) = fresh_config_dir();
+    std::fs::write(
+        &path,
+        r#"
+default_profile = "default"
+[profiles.default]
+url = "https://default.example"
+auth_method = "api_token"
+"#,
+    )
+    .unwrap();
+
+    // ghost is not in [profiles]; no --url; --no-input cannot prompt → exit 64
+    // "--url required when the target profile has no URL configured"
+    jr().env("XDG_CONFIG_HOME", dir.path())
+        .env("JR_CONFIG_DIR", dir.path().join("jr"))
+        .args(["--profile", "ghost", "auth", "login", "--no-input"])
+        .assert()
+        .failure()
+        .code(64)
+        .stderr(predicates::str::contains("--url required"));
+}
+
 /// Regression: round-4's unified active-profile existence check at
 /// `Config::load` time broke `jr auth login --profile newprof --url ...`
 /// because the profile didn't exist yet. `handle_login` now uses

--- a/tests/auth_profiles.rs
+++ b/tests/auth_profiles.rs
@@ -207,7 +207,8 @@ url = "https://from-flag.example"
 #[test]
 #[ignore = "requires keyring backend; set JR_RUN_KEYRING_TESTS=1 to run"]
 fn global_profile_flag_targets_auth_status() {
-    if std::env::var("JR_RUN_KEYRING_TESTS").is_err() {
+    if std::env::var("JR_RUN_KEYRING_TESTS").as_deref() != Ok("1") {
+        eprintln!("SKIP: set JR_RUN_KEYRING_TESTS=1 to run keychain tests");
         return;
     }
     let (dir, path) = fresh_config_dir();
@@ -319,7 +320,8 @@ auth_method = "api_token"
 #[test]
 #[ignore = "requires keyring backend; set JR_RUN_KEYRING_TESTS=1 to run"]
 fn auth_login_creates_new_profile_with_url() {
-    if std::env::var("JR_RUN_KEYRING_TESTS").is_err() {
+    if std::env::var("JR_RUN_KEYRING_TESTS").as_deref() != Ok("1") {
+        eprintln!("SKIP: set JR_RUN_KEYRING_TESTS=1 to run keychain tests");
         return;
     }
     let (dir, path) = fresh_config_dir();
@@ -369,7 +371,8 @@ auth_method = "api_token"
 #[test]
 #[ignore = "requires keyring backend; set JR_RUN_KEYRING_TESTS=1 to run"]
 fn auth_login_with_jr_profile_pointing_to_unrelated_profile_still_creates_target() {
-    if std::env::var("JR_RUN_KEYRING_TESTS").is_err() {
+    if std::env::var("JR_RUN_KEYRING_TESTS").as_deref() != Ok("1") {
+        eprintln!("SKIP: set JR_RUN_KEYRING_TESTS=1 to run keychain tests");
         return;
     }
     let (dir, path) = fresh_config_dir();

--- a/tests/backfill_matrix_parity.rs
+++ b/tests/backfill_matrix_parity.rs
@@ -146,48 +146,8 @@ fn extract_build_matrix_targets(yaml_content: &str) -> Vec<String> {
     targets
 }
 
-/// Extract the content of the `jobs.release` block from a workflow YAML string.
-///
-/// A job block starts at `  <name>:` (two-space indent) and ends at the next
-/// two-space-indented job key or end-of-file. Returns `None` when the job name
-/// is not found.
-///
-/// Anchoring rationale: assertions made against the returned slice are
-/// guaranteed to target the correct job, even if the same substring appears
-/// in a different job, a comment, or a multi-line shell step.
-fn extract_job_block<'a>(yaml: &'a str, job_name: &str) -> Option<&'a str> {
-    let needle = format!("  {job_name}:\n");
-    let start = yaml.find(&needle)?;
-
-    let rest = &yaml[start + needle.len()..];
-    let end_offset = rest
-        .find("\n  ")
-        .and_then(|pos| {
-            let mut search_start = pos + 1; // skip the `\n`
-            loop {
-                let candidate = &rest[search_start..];
-                // A new job key at two-space indent: two spaces, non-space char, `:`
-                if candidate.starts_with("  ")
-                    && candidate.chars().nth(2).map(|c| c != ' ').unwrap_or(false)
-                    && candidate
-                        .lines()
-                        .next()
-                        .map(|l| l.trim_end().ends_with(':'))
-                        .unwrap_or(false)
-                {
-                    return Some(search_start);
-                }
-                if let Some(next) = rest[search_start..].find("\n  ") {
-                    search_start = search_start + next + 1;
-                } else {
-                    return None;
-                }
-            }
-        })
-        .unwrap_or(rest.len());
-
-    Some(&yaml[start..start + needle.len() + end_offset])
-}
+mod common;
+use common::yaml::extract_job_block;
 
 // ---------------------------------------------------------------------------
 // AC-004 — Matrix parity: backfill-release.yml must have the same five targets

--- a/tests/backfill_matrix_parity.rs
+++ b/tests/backfill_matrix_parity.rs
@@ -146,6 +146,7 @@ fn extract_build_matrix_targets(yaml_content: &str) -> Vec<String> {
     targets
 }
 
+#[allow(dead_code)]
 mod common;
 use common::yaml::extract_job_block;
 

--- a/tests/ci_gate_completeness.rs
+++ b/tests/ci_gate_completeness.rs
@@ -53,53 +53,8 @@ fn read_ci_yml() -> String {
     raw.replace("\r\n", "\n")
 }
 
-/// Extract the content of a named job block from ci.yml.
-///
-/// A job block starts at `  <name>:` (two-space indent) and ends at the next
-/// top-level job header or end-of-file.  Returns `None` when the job name is
-/// not found.  The returned slice begins at the job-key line and ends just
-/// before the next job-key line (or EOF).
-///
-/// Anchoring rationale: assertions made against the returned slice are
-/// guaranteed to target the correct job, even if the same substring appears
-/// in a different job, a comment, or a multi-line shell step.
-fn extract_job_block<'a>(ci_yml: &'a str, job_name: &str) -> Option<&'a str> {
-    // Job headers in GitHub Actions YAML are at two-space indent: "  <id>:\n"
-    let needle = format!("  {job_name}:\n");
-    let start = ci_yml.find(&needle)?;
-
-    // The end of this job block is the next line at the same indent level
-    // (i.e., the next "  <something>:\n" after our start).
-    let rest = &ci_yml[start + needle.len()..];
-    let end_offset = rest
-        .find("\n  ")
-        .and_then(|pos| {
-            let mut search_start = pos + 1; // skip the `\n`
-            loop {
-                let candidate = &rest[search_start..];
-                // A new job key: two spaces, non-space char, eventually `:`
-                if candidate.starts_with("  ")
-                    && candidate.chars().nth(2).map(|c| c != ' ').unwrap_or(false)
-                    && candidate
-                        .lines()
-                        .next()
-                        .map(|l| l.trim_end().ends_with(':'))
-                        .unwrap_or(false)
-                {
-                    return Some(search_start);
-                }
-                // Advance past this `\n  ` candidate
-                if let Some(next) = rest[search_start..].find("\n  ") {
-                    search_start = search_start + next + 1;
-                } else {
-                    return None;
-                }
-            }
-        })
-        .unwrap_or(rest.len());
-
-    Some(&ci_yml[start..start + needle.len() + end_offset])
-}
+mod common;
+use common::yaml::extract_job_block;
 
 /// Parse the `needs:` value from a job block.
 ///

--- a/tests/ci_gate_completeness.rs
+++ b/tests/ci_gate_completeness.rs
@@ -53,6 +53,7 @@ fn read_ci_yml() -> String {
     raw.replace("\r\n", "\n")
 }
 
+#[allow(dead_code)]
 mod common;
 use common::yaml::extract_job_block;
 

--- a/tests/ci_yml_windows_matrix.rs
+++ b/tests/ci_yml_windows_matrix.rs
@@ -55,58 +55,8 @@ fn read_ci_yml() -> String {
     raw.replace("\r\n", "\n")
 }
 
-/// Extract the content of a named job block from ci.yml.
-///
-/// A job block starts at `  <name>:` (two-space indent) and ends at the next
-/// top-level job header or end-of-file. Returns `None` when the job name is
-/// not found. The returned slice begins at the job-key line and ends just
-/// before the next job-key line (or EOF).
-///
-/// Anchoring rationale: assertions made against the returned slice are
-/// guaranteed to target the correct job, even if the same substring appears
-/// in a different job, a comment, or a multi-line shell step.
-fn extract_job_block<'a>(ci_yml: &'a str, job_name: &str) -> Option<&'a str> {
-    // Job headers in GitHub Actions YAML are at two-space indent: "  <id>:\n"
-    let needle = format!("  {job_name}:\n");
-    let start = ci_yml.find(&needle)?;
-
-    // The end of this job block is the next line at the same indent level
-    // (i.e., the next "  <something>:\n" after our start).
-    let rest = &ci_yml[start + needle.len()..];
-    let end_offset = rest
-        .find("\n  ")
-        // Scan forward to find the line that starts the next job (a line
-        // beginning with exactly two spaces followed by a non-space char and
-        // ending in `:` is a YAML mapping key at the job level).
-        .and_then(|pos| {
-            // `pos` points to the `\n` before the `  ` prefix. Walk forward
-            // to collect candidate lines.
-            let mut search_start = pos + 1; // skip the `\n`
-            loop {
-                let candidate = &rest[search_start..];
-                // A new job key: two spaces, non-space char, eventually `:`
-                if candidate.starts_with("  ")
-                    && candidate.chars().nth(2).map(|c| c != ' ').unwrap_or(false)
-                    && candidate
-                        .lines()
-                        .next()
-                        .map(|l| l.trim_end().ends_with(':'))
-                        .unwrap_or(false)
-                {
-                    return Some(search_start);
-                }
-                // Advance past this `\n  ` candidate
-                if let Some(next) = rest[search_start..].find("\n  ") {
-                    search_start = search_start + next + 1;
-                } else {
-                    return None;
-                }
-            }
-        })
-        .unwrap_or(rest.len());
-
-    Some(&ci_yml[start..start + needle.len() + end_offset])
-}
+mod common;
+use common::yaml::extract_job_block;
 
 // ---------------------------------------------------------------------------
 // AC-001 — `test` job matrix includes `windows-latest`

--- a/tests/ci_yml_windows_matrix.rs
+++ b/tests/ci_yml_windows_matrix.rs
@@ -55,6 +55,7 @@ fn read_ci_yml() -> String {
     raw.replace("\r\n", "\n")
 }
 
+#[allow(dead_code)]
 mod common;
 use common::yaml::extract_job_block;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,2 +1,3 @@
 pub mod fixtures;
 pub mod mock_server;
+pub mod yaml;

--- a/tests/common/yaml.rs
+++ b/tests/common/yaml.rs
@@ -1,0 +1,52 @@
+/// Extract the YAML block for a single GitHub Actions job from a workflow file.
+///
+/// This is the canonical job-block extractor shared across CI-YAML guard tests
+/// (`tests/ci_yml_windows_matrix.rs`, `tests/ci_gate_completeness.rs`,
+/// `tests/backfill_matrix_parity.rs`). Factored here to eliminate verbatim
+/// triplication (CR-008/DRIFT-CR-008).
+///
+/// A job block starts at `  <name>:` (two-space indent) and ends at the next
+/// two-space-indented job key or end-of-file. Returns `None` when the job name
+/// is not found. The returned slice begins at the job-key line and ends just
+/// before the next job-key line (or EOF).
+///
+/// Anchoring rationale: assertions made against the returned slice are
+/// guaranteed to target the correct job, even if the same substring appears
+/// in a different job, a comment, or a multi-line shell step.
+pub fn extract_job_block<'a>(yaml: &'a str, job_name: &str) -> Option<&'a str> {
+    // Job headers in GitHub Actions YAML are at two-space indent: "  <id>:\n"
+    let needle = format!("  {job_name}:\n");
+    let start = yaml.find(&needle)?;
+
+    // The end of this job block is the next line at the same indent level
+    // (i.e., the next "  <something>:\n" after our start).
+    let rest = &yaml[start + needle.len()..];
+    let end_offset = rest
+        .find("\n  ")
+        .and_then(|pos| {
+            let mut search_start = pos + 1; // skip the `\n`
+            loop {
+                let candidate = &rest[search_start..];
+                // A new job key at two-space indent: two spaces, non-space char, `:`
+                if candidate.starts_with("  ")
+                    && candidate.chars().nth(2).map(|c| c != ' ').unwrap_or(false)
+                    && candidate
+                        .lines()
+                        .next()
+                        .map(|l| l.trim_end().ends_with(':'))
+                        .unwrap_or(false)
+                {
+                    return Some(search_start);
+                }
+                // Advance past this `\n  ` candidate
+                if let Some(next) = rest[search_start..].find("\n  ") {
+                    search_start = search_start + next + 1;
+                } else {
+                    return None;
+                }
+            }
+        })
+        .unwrap_or(rest.len());
+
+    Some(&yaml[start..start + needle.len() + end_offset])
+}

--- a/tests/keyring_guard_idiom.rs
+++ b/tests/keyring_guard_idiom.rs
@@ -1,0 +1,92 @@
+//! Anti-recurrence guard for the `JR_RUN_KEYRING_TESTS` gate idiom.
+//!
+//! The canonical keyring-test guard is:
+//! ```rust
+//! if std::env::var("JR_RUN_KEYRING_TESTS").as_deref() != Ok("1") { ... }
+//! ```
+//!
+//! The loose form `JR_RUN_KEYRING_TESTS").is_err()` is semantically wrong:
+//! it skips only when the var is *unset*, so `JR_RUN_KEYRING_TESTS=0` (or
+//! `=false`) would incorrectly *run* the keyring test, violating the
+//! documented "`=1` to run" contract. This was CR-009 / KEYRING-GUARD-IDIOM-DRIFT.
+//!
+//! This file enforces the canonical form going forward by scanning every
+//! `.rs` file under `src/` and `tests/` and failing if any line contains
+//! `JR_RUN_KEYRING_TESTS` adjacent to `.is_err()`.
+
+use std::path::Path;
+
+/// Walk a directory tree and collect all `.rs` files.
+fn collect_rs_files(dir: &Path) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                out.extend(collect_rs_files(&path));
+            } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+/// Returns true if the line contains both `JR_RUN_KEYRING_TESTS` and `.is_err()`.
+///
+/// The detection string is split to prevent this file itself from matching.
+fn line_uses_loose_guard(line: &str) -> bool {
+    // Split the needle so this source file doesn't trigger on its own content.
+    let needle_a = "JR_RUN_KEYRING_TESTS";
+    let needle_b = [".is_", "err()"].concat();
+    line.contains(needle_a) && line.contains(needle_b.as_str())
+}
+
+#[test]
+fn test_keyring_guard_idiom_no_loose_is_err_form() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let src_dir = manifest_dir.join("src");
+    let tests_dir = manifest_dir.join("tests");
+
+    // The name of this file — excluded from the scan so doc-comment examples
+    // inside it don't trigger on themselves.
+    let self_name = "keyring_guard_idiom.rs";
+
+    let mut files = collect_rs_files(&src_dir);
+    files.extend(collect_rs_files(&tests_dir));
+    // Exclude this guard file itself (its doc comments reference the pattern).
+    files.retain(|p| {
+        p.file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n != self_name)
+            .unwrap_or(true)
+    });
+    files.sort();
+
+    let mut violations: Vec<String> = Vec::new();
+
+    for path in &files {
+        let Ok(content) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        for (line_no, line) in content.lines().enumerate() {
+            if line_uses_loose_guard(line) {
+                let rel = path
+                    .strip_prefix(manifest_dir)
+                    .unwrap_or(path)
+                    .display()
+                    .to_string();
+                violations.push(format!("{}:{}: {}", rel, line_no + 1, line.trim()));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "KEYRING-GUARD-IDIOM-DRIFT: found {} loose `JR_RUN_KEYRING_TESTS` guard(s) \
+         using `.is_err()` (runs when var=0/false). \
+         Use `as_deref() != Ok(\"1\")` instead:\n{}",
+        violations.len(),
+        violations.join("\n")
+    );
+}

--- a/tests/keyring_guard_idiom.rs
+++ b/tests/keyring_guard_idiom.rs
@@ -34,12 +34,10 @@ fn collect_rs_files(dir: &Path) -> Vec<std::path::PathBuf> {
 
 /// Returns true if the line contains both `JR_RUN_KEYRING_TESTS` and `.is_err()`.
 ///
-/// The detection string is split to prevent this file itself from matching.
+/// Self-match is prevented by the `files.retain` call in the test, which
+/// excludes this file by name before scanning begins.
 fn line_uses_loose_guard(line: &str) -> bool {
-    // Split the needle so this source file doesn't trigger on its own content.
-    let needle_a = "JR_RUN_KEYRING_TESTS";
-    let needle_b = [".is_", "err()"].concat();
-    line.contains(needle_a) && line.contains(needle_b.as_str())
+    line.contains("JR_RUN_KEYRING_TESTS") && line.contains(".is_err()")
 }
 
 #[test]


### PR DESCRIPTION
## Summary

**Bundle D — Test Hygiene (maintenance sweep 2026-06-22)**

Test-only PR. Zero production/runtime logic change. Resolves three drift items from the 2026-06-22 maintenance sweep (`.factory/maintenance/2026-06-22/bundle-d-triage.md`).

---

## Changes

### Item A — CR-008 / DRIFT-CR-008: `extract_job_block` helper deduplication

`fn extract_job_block` was byte-for-byte identical across three CI integration-test files (3 definitions, 20 call sites). Extracted to `tests/common/yaml.rs`, wired into `tests/common/mod.rs`, and local copies deleted.

**Files changed:** `tests/common/mod.rs` (+1), `tests/common/yaml.rs` (new, +52), `tests/ci_yml_windows_matrix.rs` (-40), `tests/ci_gate_completeness.rs` (-34), `tests/backfill_matrix_parity.rs` (-37)
**Net:** −141 LOC body × 3, +59 LOC canonical copy — eliminates future drift between the three test files.

### Item B — CR-009 / KEYRING-GUARD-IDIOM-DRIFT: canonical keyring-gate idiom

CLAUDE.md documents the gate as `JR_RUN_KEYRING_TESTS=1`. Four test sites used the loose `is_err()` form — which incorrectly runs the keyring test when `JR_RUN_KEYRING_TESTS=0` or `=false`. Unified to the canonical `as_deref() != Ok("1")` idiom with a `SKIP:` eprintln.

Sites fixed:
- `tests/auth_profiles.rs` ×3 (lines 210, 322, 372 pre-PR)
- `src/api/auth.rs` ×2 (`with_test_keyring` — inside `#[cfg(test)]` block, plus one from #551)

Added anti-recurrence meta-test `tests/keyring_guard_idiom.rs`: greps all test files for `JR_RUN_KEYRING_TESTS` and asserts none use the `is_err()` form. Follows the gate-test pattern from `tests/base_url_release_gate.rs`.

### Item C — #532 / S-MAINT-532: global `--profile` fallback coverage

The `main.rs` dispatch-level `.or_else(|| cli.profile.clone())` composition for `login`, `refresh`, and `logout` had no ungated CI tests. A regression that deleted the composition would pass CI (keyring-gated tests are `#[ignore]` and skipped by `ci.yml`).

Added 3 offline tests in `tests/auth_profiles.rs` using the unknown-profile (`ghost`) trick:
- `test_global_profile_flag_propagates_to_auth_login_no_url_exits_64`
- `test_global_profile_flag_propagates_to_auth_refresh_unknown_profile_exits_64`
- `test_global_profile_flag_propagates_to_auth_logout_unknown_profile_exits_64`

No keyring, no network. Mirrors the existing `test_global_profile_flag_propagates_to_auth_status_unknown_profile_exits_64`.

---

## Dependency Graph

```mermaid
graph LR
    A[develop @ 3f5bbd2] --> B[chore/bundle-d-test-hygiene]
    B --> C[PR: Bundle D Test Hygiene]
    C --> D[develop]
```

No story dependencies. Targets `develop` directly.

---

## Spec Traceability

```mermaid
flowchart LR
    T1[DRIFT-CR-008\nextract_job_block triplication] --> F1[tests/common/yaml.rs\ncanonical shared helper]
    T2[KEYRING-GUARD-IDIOM-DRIFT\nloose is_err form] --> F2[Unified to as_deref != Ok.1.\nmeta-test anti-recurrence]
    T3[#532 / S-MAINT-532\nprofile fallback gap] --> F3[3 offline tests\nglobal --profile login/refresh/logout]
```

---

## Test Evidence

- **All changes are test-only** — no `src/` production logic touched (the two `src/api/auth.rs` edits are inside `#[cfg(test)]` test helper blocks).
- Local gate run: `cargo clippy --all --all-features --tests -- -D warnings` → zero warnings (fixes CR-001: added `#[allow(dead_code)]` on `mod common` in the three CI test files; fixes CR-002 nit).
- `cargo test` baseline: all existing tests pass.
- New tests in `tests/keyring_guard_idiom.rs` and `tests/auth_profiles.rs` pass.
- Mutation testing: out of scope for test-only changes (no production logic to mutate).

---

## Holdout Evaluation

N/A — test-only PR, no production behavior changed.

---

## Adversarial Review

N/A — evaluated at Phase 5 if applicable. Internal code-reviewer pre-PR pass found CR-001 (clippy dead_code) and CR-002 (nit); both fixed in commit 5fcf9e6 before PR creation.

---

## Security Review

No production code changed. No authentication, authorization, input validation, or API surface modified. Security review: N/A for this PR.

The related security item (JR_SERVICE_NAME debug-gate, SEC-JR-SERVICE-NAME-GATE) was already delivered in PR #551 (merged to develop before this branch was cut).

---

## Risk Assessment

- **Blast radius:** zero — test files only (plus `#[cfg(test)]` block in `src/api/auth.rs`).
- **Performance impact:** none.
- **Rollback:** trivial — reverts to three copies of the helper and four loose keyring guards.

---

## AI Pipeline Metadata

- Pipeline mode: maintenance sweep (Bundle D, PR 1 of 3)
- Triage: `.factory/maintenance/2026-06-22/bundle-d-triage.md` Items 1, 2, 5
- Commits: f740ae6 (CR-008), bf06c12 (CR-009 + meta-test), d4edf4a (#532), 5fcf9e6 (CR-001/CR-002 clippy fix)

---

## Pre-Merge Checklist

- [x] PR description matches actual diff
- [x] Test-only: no runtime/production logic changed
- [x] Clippy clean (CR-001 `#[allow(dead_code)]` on `mod common`, CR-002 nit — both fixed)
- [x] All new tests pass locally
- [x] No demo evidence required (test-only)
- [x] No BC/spec docs required (no behavior change)
- [x] Dependency PRs: none (no depends_on)
- [ ] CI green (pending)
- [x] pr-reviewer APPROVE (cycle 1 — 0 blocking findings, 1 non-blocking nit addressed in PR body)
