### PR TITLE
chore(release): v0.6.0-dev.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to jr will be documented here.
 
 ### Security
 
+### Fixed
+
+### Changed
+
+## [0.6.0-dev.7] - 2026-06-26
+
+### Security
+
 - **SEC-001 (CWE-674):** Pathologically nested markdown/ADF input (≥256 levels) now
   exits 64 with "nesting too deep" instead of stack-overflowing. Guard applies to
   `markdown_to_adf` (forward path) and `adf_to_text` (reverse path).
@@ -32,6 +40,10 @@ All notable changes to jr will be documented here.
   - `insta` 1.47.2 → 1.48.0 (#541)
   - `quinn-proto` 0.11.14 → 0.11.15 (RUSTSEC-2026-0185, non-reachable from jr — http3 feature off)
   - `actions/checkout` 6.0.3 → 7.0.0 (#550)
+
+- Internal (no behavior change): split the oversized `src/cli/issue/create.rs` (2,880 LOC)
+  into three cohesive modules — `create.rs` (394), `edit.rs` (2,067), `jsm_create.rs` (444) —
+  to satisfy the ADR-0012 shard rule (#556, #558). Test parity preserved (1957/93).
 
 ## [0.6.0-dev.6] - 2026-06-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.6.0-dev.6"
+version = "0.6.0-dev.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.6.0-dev.6"
+version = "0.6.0-dev.7"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary

Routine dev pre-release: `0.6.0-dev.6` → `0.6.0-dev.7`.

After merge, the `v0.6.0-dev.7` tag (applied separately by the orchestrator) triggers `release.yml` to build 5 targets and publish a GitHub Release.

---

## Changelog highlights

### Security
- **SEC-001 (CWE-674):** Pathologically nested markdown/ADF input (≥256 levels deep) now exits 64 with "nesting too deep" instead of stack-overflowing. Guard applies to both `markdown_to_adf` (forward path) and `adf_to_text` (reverse path). ([#553](https://github.com/Zious11/jira-cli/pull/553))
- **`JR_SERVICE_NAME` debug-gate (SEC-JR-SERVICE-NAME-GATE, [#551](https://github.com/Zious11/jira-cli/pull/551)):** The keychain-service-name override env var is now honored only in debug builds; release binaries always use the compiled-in `jr-jira-cli` service name. Closes a test-seam leak.

### Fixed
- **H-019:** Invalid profile name via `--profile` or `JR_PROFILE` now exits 64 (EX_USAGE) instead of 78 (EX_CONFIG). ([#548](https://github.com/Zious11/jira-cli/pull/548))
- `verify-signatures` CI step now exercises correctly in signing-configured forks.

### Changed
- Dependency bumps: `codecov/codecov-action` 6→7, `insta` 1.47.2→1.48.0, `quinn-proto` 0.11.14→0.11.15 (RUSTSEC-2026-0185, non-reachable), `actions/checkout` 6→7.
- Internal (no behavior change): split the oversized `src/cli/issue/create.rs` (2,880 LOC) into three cohesive modules — `create.rs` (394 LOC), `edit.rs` (2,067 LOC), `jsm_create.rs` (444 LOC) — to satisfy the ADR-0012 shard rule. ([#556](https://github.com/Zious11/jira-cli/pull/556), [#558](https://github.com/Zious11/jira-cli/pull/558)) Test parity preserved (1957/93).

---

## CHANGELOG roll

`[Unreleased]` rolled to `[0.6.0-dev.7] - 2026-06-26` with a fresh empty `[Unreleased]` skeleton prepended for the next cycle.

---

## Pre-merge checklist

- [x] Version bumped in `Cargo.toml` + `Cargo.lock`
- [x] CHANGELOG rolled (`[Unreleased]` → `[0.6.0-dev.7] - 2026-06-26`)
- [x] Branch: `release/v0.6.0-dev.7` targeting `develop`
- [ ] CI passing
- [ ] Merge (orchestrator-gated — DEC-128: do NOT merge from this PR without orchestrator authorization)
- [ ] Tag `v0.6.0-dev.7` (orchestrator step, post-merge)