### PR TITLE
test(cli): pin --field/--label & C-1 edit guards and --output json error-shape coverage

### DIFF
--- a/tests/issue_edit_field.rs
+++ b/tests/issue_edit_field.rs
@@ -3322,3 +3322,127 @@ async fn test_label_plus_markdown_rejected_with_exit_64_no_http() {
          stderr={stderr}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// G-EDIT-FIELD-LABEL-GUARD (FIX-F5-001, BC-3.4.017 clause 6)
+// `jr issue edit <KEY> --field NAME=VALUE --label foo` → exit 64, offline.
+//
+// The mutual-exclusion block in `edit.rs::handle_edit`
+// § "--label cannot be combined with" fires BEFORE any HTTP call when --label
+// is combined with --field.  Without the block the --field write would silently
+// be dropped because the label→bulk routing fork does not honour --field.
+//
+// Non-tautology: removing the `if !field_pairs.is_empty()` arm from the
+// conflicting-flags block would let this invocation reach `handle_edit_bulk_labels`
+// which ignores field_pairs entirely → data loss with exit 0.
+// ---------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_edit_field_and_label_combined_exits_64_with_guard_message() {
+    let server = MockServer::start().await;
+    // No mocks mounted — the mutual-exclusion guard fires before any HTTP call.
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    let output = jr_cmd_with_xdg(&server.uri(), cache_dir.path(), config_dir.path())
+        .args([
+            "--no-input",
+            "issue",
+            "edit",
+            "FOO-1",
+            "--field",
+            "Severity=Critical",
+            "--label",
+            "add:foo",
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // The FIX-F5-001 mutual-exclusion guard must fire.
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "Expected exit 64 for --field + --label combination (FIX-F5-001); \
+         stderr={stderr} stdout={stdout}"
+    );
+
+    // The guard message must name the conflict.
+    assert!(
+        stderr.contains("--label cannot be combined with"),
+        "Stderr must contain '--label cannot be combined with' (guard message); stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("--field"),
+        "Stderr must name '--field' as the conflicting flag; stderr={stderr}"
+    );
+
+    // stdout must be empty — no partial data.
+    assert!(
+        stdout.trim().is_empty(),
+        "stdout must be empty when guard fires pre-HTTP; stdout={stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// G-EDIT-FIELD-C1-BULK (C-1 guard, BC-3.4.017 — single-key only for --field)
+// `jr issue edit FOO-1 FOO-2 --field NAME=VALUE` (multi-key / bulk) → exit 64.
+//
+// The C-1 guard in `edit.rs::handle_edit`
+// § "Multi-key bulk edit doesn't yet support" fires after the working-key-set
+// is resolved but before any API call to editmeta or PUT.  Without the guard,
+// --field would reach handle_edit_bulk_fields which ignores field_pairs
+// entirely → silent data loss.
+//
+// Non-tautology: removing the `if !field_pairs.is_empty()` arm from the
+// unsupported-flags block would allow the bulk path to run and silently discard
+// the --field write with exit 0.
+// ---------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_edit_field_multi_key_bulk_exits_64_with_c1_message() {
+    let server = MockServer::start().await;
+    // No mocks — C-1 guard fires before any HTTP call.
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    let output = jr_cmd_with_xdg(&server.uri(), cache_dir.path(), config_dir.path())
+        .args([
+            "--no-input",
+            "issue",
+            "edit",
+            "FOO-1",
+            "FOO-2",
+            "--field",
+            "Severity=Critical",
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // The C-1 guard must fire.
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "Expected exit 64 for multi-key + --field (C-1 guard); \
+         stderr={stderr} stdout={stdout}"
+    );
+
+    // C-1 message must identify --field and the single-key constraint.
+    assert!(
+        stderr.contains("--field"),
+        "Stderr must name '--field' in the C-1 rejection message; stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("Multi-key bulk edit doesn't yet support"),
+        "Stderr must contain the C-1 bulk-rejection phrase; stderr={stderr}"
+    );
+
+    // stdout must be empty.
+    assert!(
+        stdout.trim().is_empty(),
+        "stdout must be empty when C-1 guard fires pre-HTTP; stdout={stdout}"
+    );
+}

--- a/tests/json_error_shape.rs
+++ b/tests/json_error_shape.rs
@@ -1,0 +1,248 @@
+//! #526 JSON error-envelope contract extension — BC-7.3.010
+//!
+//! Pins the `--output json` error-envelope contract for three commands that were
+//! previously uncovered:
+//!
+//! - G-ERRSHAPE-CHANGELOG: `jr issue changelog FOO-1 --output json` with a 404 API
+//!   response → `{"error":"…","code":1}` on stderr, empty stdout, exit 1.
+//!
+//! - G-ERRSHAPE-QUEUE-VIEW: `jr queue view --id 99 --output json --project HELP`
+//!   where the service desk lookup returns a non-JSM project → `{"error":"…","code":64}`
+//!   on stderr, empty stdout, exit 64.
+//!
+//! - G-ERRSHAPE-REQUESTTYPE-LIST: `jr requesttype list --output json --project HELP`
+//!   with a 404 project response → `{"error":"…","code":1}` on stderr,
+//!   empty stdout, exit 1.
+//!
+//! ## Error-envelope contract (main.rs)
+//!
+//! When `--output json` is set and the command propagates an error, `src/main.rs::main`
+//! builds `{"error":"<message>","code":<exit_code>}` via a compact `serde_json::json!`
+//! Display call and emits it to **stderr** via `eprintln!`, then exits with `<exit_code>`.
+//! **stdout must be empty** — this is the channel-separation invariant from #526.
+//! Note: `output::render_json` formats SUCCESS stdout JSON; the ERROR envelope is
+//! constructed directly in `src/main.rs::main` and is never routed through `render_json`.
+//!
+//! Non-tautology for each test: if the command's error path wrote directly to stdout
+//! (or wrote plain text to stderr instead of the JSON envelope), these tests would
+//! fail because either (a) stderr would not be valid JSON, or (b) stdout would be
+//! non-empty.
+//!
+//! BC anchor: BC-7.3.010 (JSON render invariant — all `--output json` success paths
+//! route through `output::render_json` or `output::print_output`; errors use the
+//! `src/main.rs::main` envelope, not ad-hoc formatting).
+
+#[allow(dead_code)]
+mod common;
+
+use assert_cmd::Command;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Build a `jr` command with XDG isolation and mock-server wiring.
+///
+/// `--no-input` is already baked in; callers must NOT include it in `.args()` (else double-flag).
+fn jr_cmd(server_uri: &str, cache_dir: &std::path::Path, config_dir: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("jr").unwrap();
+    cmd.env("JR_BASE_URL", server_uri)
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir)
+        .env("JR_CACHE_DIR", cache_dir.join("jr"))
+        .env("XDG_CONFIG_HOME", config_dir)
+        .env("JR_CONFIG_DIR", config_dir.join("jr"))
+        .arg("--no-input");
+    cmd
+}
+
+/// Assert the error-envelope contract: stderr is `{"error":"…","code":<expected_code>}`,
+/// stdout is empty, and the process exits with `expected_code`.
+fn assert_json_error_envelope(output: &std::process::Output, expected_code: i32, label: &str) {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Exit code.
+    assert_eq!(
+        output.status.code(),
+        Some(expected_code),
+        "{label}: expected exit {expected_code}; stderr={stderr} stdout={stdout}"
+    );
+
+    // stdout must be empty — channel-separation invariant (#526).
+    assert!(
+        stdout.trim().is_empty(),
+        "{label}: stdout must be empty on error (channel-separation #526); stdout={stdout}"
+    );
+
+    // stderr must be valid JSON.
+    let parsed: serde_json::Value = serde_json::from_str(stderr.trim()).unwrap_or_else(|e| {
+        panic!("{label}: stderr must be valid JSON when --output json set: {e}\nstderr: {stderr}")
+    });
+
+    // `error` field must be a non-empty string.
+    assert!(
+        parsed["error"].as_str().is_some_and(|s| !s.is_empty()),
+        "{label}: JSON envelope must have non-empty 'error' field; got: {parsed}"
+    );
+
+    // `code` field must match the exit code.
+    assert_eq!(
+        parsed["code"].as_i64(),
+        Some(expected_code as i64),
+        "{label}: JSON envelope 'code' must be {expected_code}; got: {parsed}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// G-ERRSHAPE-CHANGELOG — BC-7.3.010
+//
+// `jr issue changelog FOO-1 --output json` when the API returns 404
+// must emit `{"error":"…","code":1}` to stderr, empty stdout, exit 1.
+//
+// The 404 is returned by the changelog endpoint itself.  The client converts
+// a 4xx into a JrError (propagated via `?`), and main.rs wraps it in the
+// JSON envelope.
+//
+// Non-tautology: if `handle` in `cli/issue/changelog.rs` wrote an error
+// directly to stdout via `println!` instead of propagating the error, stdout
+// would be non-empty and the test would fail.
+// ---------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_issue_changelog_output_json_api_error_emits_json_envelope() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    // Mount the changelog endpoint returning 404 (issue not found / no access).
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/changelog"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "errorMessages": ["Issue does not exist or you do not have permission to see it."],
+            "errors": {}
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["--output", "json", "issue", "changelog", "FOO-1"])
+        .output()
+        .unwrap();
+
+    // A 404 from the API propagates as a generic error (exit 1 per JrError::ApiError).
+    assert_json_error_envelope(&output, 1, "G-ERRSHAPE-CHANGELOG");
+}
+
+// ---------------------------------------------------------------------------
+// G-ERRSHAPE-QUEUE-VIEW — BC-7.3.010
+//
+// `jr queue view --id 99 --output json --project HELP` when the project-meta
+// lookup returns a non-JSM (software) project type → `require_service_desk`
+// fires a JrError::UserError (exit 64).
+//
+// The guard is in `api/jsm/servicedesks.rs::require_service_desk` and fires
+// before any queue API call.
+//
+// Non-tautology: if `cli/queue.rs::handle` wrote the error directly to stdout
+// as plain text, stdout would be non-empty and the JSON-parse assertion would
+// fail.
+// ---------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_queue_view_output_json_non_jsm_project_emits_json_envelope() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    // Project HELP is a software project (not service_desk) → require_service_desk
+    // will return a JrError::UserError.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/project/HELP"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "10001",
+            "key": "HELP",
+            "name": "Help Project",
+            "projectTypeKey": "software",
+            "simplified": false
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args([
+            "--output",
+            "json",
+            "--project",
+            "HELP",
+            "queue",
+            "view",
+            "--id",
+            "99",
+        ])
+        .output()
+        .unwrap();
+
+    // require_service_desk emits a JrError::UserError (exit 64).
+    assert_json_error_envelope(&output, 64, "G-ERRSHAPE-QUEUE-VIEW");
+
+    // Pin that the RIGHT guard fired: the require_service_desk message
+    // (src/api/jsm/servicedesks.rs::require_service_desk) contains the
+    // exact phrase "Jira Service Management project".  Any other exit-64
+    // UserError would not contain this substring.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let parsed: serde_json::Value = serde_json::from_str(stderr.trim()).unwrap();
+    assert!(
+        parsed["error"]
+            .as_str()
+            .is_some_and(|s| s.contains("Jira Service Management project")),
+        "G-ERRSHAPE-QUEUE-VIEW: error field must contain 'Jira Service Management project' \
+         (require_service_desk guard message); got: {parsed}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// G-ERRSHAPE-REQUESTTYPE-LIST — BC-7.3.010
+//
+// `jr requesttype list --output json --project HELP` when the project-meta
+// lookup returns a 404 → error propagates → `{"error":"…","code":1}` on
+// stderr, empty stdout, exit 1.
+//
+// The 404 is from `GET /rest/api/3/project/HELP`; `require_service_desk` in
+// `api/jsm/servicedesks.rs` calls this endpoint and propagates the error via `?`.
+//
+// Non-tautology: if `cli/requesttype.rs::handle` wrote the error directly to
+// stdout (bypassing the main.rs envelope), stdout would be non-empty, the
+// JSON-parse on stdout would fail or the envelope assertion would not hold.
+// ---------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_requesttype_list_output_json_project_404_emits_json_envelope() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    // Project does not exist → 404.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/project/HELP"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "errorMessages": ["No project could be found with key 'HELP'."],
+            "errors": {}
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args([
+            "--output",
+            "json",
+            "--project",
+            "HELP",
+            "requesttype",
+            "list",
+        ])
+        .output()
+        .unwrap();
+
+    // A 404 from the API propagates as exit 1.
+    assert_json_error_envelope(&output, 1, "G-ERRSHAPE-REQUESTTYPE-LIST");
+}


### PR DESCRIPTION
## Summary

Regression-hardening test coverage for two shipped-but-unpinned CLI guards. Test-only — zero production code change.

- **FIX-F5-001 / BC-3.4.017:** `--field` + `--label` mutual-exclusion block (exit 64 before any HTTP call)
- **C-1 guard / BC-3.4.017:** `--field` on multi-key bulk edit rejected at exit 64
- **BC-7.3.010 / #526:** `--output json` error-envelope contract pinned for 3 previously-uncovered commands

## The 5 New Tests

### `tests/issue_edit_field.rs` — 2 tests appended

1. **`test_edit_field_and_label_combined_exits_64_with_guard_message`** (FIX-F5-001, BC-3.4.017)
   - `jr issue edit FOO-1 --field Severity=Critical --label add:foo` → exit 64
   - Asserts stderr contains `"--label cannot be combined with"` + `"--field"`, stdout empty
   - No HTTP mocks — guard fires pre-HTTP
   - Guards against silent data loss if ME block removed (label routing fork ignores `field_pairs`)

2. **`test_edit_field_multi_key_bulk_exits_64_with_c1_message`** (C-1 guard, BC-3.4.017)
   - `jr issue edit FOO-1 FOO-2 --field Severity=Critical` → exit 64
   - Asserts stderr contains `"--field"` + `"Multi-key bulk edit doesn't yet support"`, stdout empty
   - No HTTP mocks — C-1 fires pre-editmeta/PUT

### `tests/json_error_shape.rs` — new file, 3 tests (BC-7.3.010)

3. **`test_issue_changelog_output_json_api_error_emits_json_envelope`**
   - `jr issue changelog FOO-1 --output json` + mock 404 → stderr `{"error":"…","code":1}`, stdout empty, exit 1

4. **`test_queue_view_output_json_non_jsm_project_emits_json_envelope`**
   - `jr queue view --id 99 --output json --project HELP` + mock software project → stderr `{"error":"…","code":64}`, stdout empty, exit 64
   - Also pins the `require_service_desk` guard message contains `"Jira Service Management project"`

5. **`test_requesttype_list_output_json_project_404_emits_json_envelope`**
   - `jr requesttype list --output json --project HELP` + mock 404 → stderr `{"error":"…","code":1}`, stdout empty, exit 1

## Guard Status

All 5 tests PASS against the current codebase — **guards were already implemented**. These are regression pins, not new-feature tests. Origin: E2E edge-case audit (E2E-EDGE-CASE-GAPS-2026-06-27).

## Review (Pre-PR)

| Finding | Severity | Resolution |
|---------|----------|-----------|
| Doc comment cited wrong exit code for `queue view` non-JSM guard | MED | Fixed pre-PR |
| 4 style/doc findings | LOW | Fixed pre-PR |

Adversary gate: **CLEAN** — no outstanding findings at PR creation.

## BC Anchors

- `BC-3.4.017` — `--field` single-key-only constraint and flag-overlap guards
- `BC-7.3.010` — `--output json` error-envelope contract (error on stderr, empty stdout)
- `FIX-F5-001` — `--field` + `--label` mutual-exclusion block

## Checklist

- [x] Test-only — no production code changed
- [x] All 5 tests pass locally
- [x] clippy / fmt green
- [x] No real Jira data
- [x] Guards confirmed already-implemented (regression pins)