### PR TITLE
docs(readme): document mise install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,41 @@ To install a specific version:
 curl -fsSL https://raw.githubusercontent.com/Zious11/jira-cli/main/install.sh | sh -s -- v0.5.0
 ```
 
+### Install with mise
+
+If you manage tool versions with [mise](https://mise.jdx.dev/), you can pin
+`jr` alongside the rest of your project's tools:
+
+```bash
+mise use github:<owner>/jira-cli@latest
+```
+
+Replace `<owner>` with the GitHub owner of the repository (or fork) you
+want to install releases from — for the canonical upstream that's this
+repository's owner; for a downstream distribution that publishes its own
+signed builds, use that fork's owner.
+
+To track prerelease builds cut from `develop` (`v*-dev.*`, `v*-beta.*`,
+`v*-rc.*`), opt in per-tool in your `mise.toml`:
+
+```toml
+[tools]
+"github:<owner>/jira-cli" = { version = "latest", prerelease = true }
+```
+
+mise's `github:` backend auto-selects the release asset matching your OS
+and architecture, extracts the `jr` binary onto your `PATH`, and (once
+per-release attestations are published) natively verifies GitHub Artifact
+Attestations and SLSA provenance in Rust without invoking `gh` or
+`slsa-verifier`.
+
+If mise-installed `jr` refuses to launch on macOS with a Gatekeeper
+warning, clear the quarantine attribute:
+
+```bash
+xattr -d com.apple.quarantine "$(mise which jr)"
+```
+
 ### From source
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -41,33 +41,47 @@ If you manage tool versions with [mise](https://mise.jdx.dev/), you can pin
 `jr` alongside the rest of your project's tools:
 
 ```bash
-mise use github:<owner>/jira-cli@latest
+mise use github:Zious11/jira-cli@latest
 ```
 
-Replace `<owner>` with the GitHub owner of the repository (or fork) you
-want to install releases from — for the canonical upstream that's this
-repository's owner; for a downstream distribution that publishes its own
-signed builds, use that fork's owner.
+Replace `Zious11` with a fork's owner if you install from a downstream
+distribution that publishes its own signed releases.
 
-To track prerelease builds cut from `develop` (`v*-dev.*`, `v*-beta.*`,
-`v*-rc.*`), opt in per-tool in your `mise.toml`:
+mise's `github:` backend auto-selects the release asset matching your OS
+and architecture and extracts the `jr` binary (assuming
+[`mise activate`](https://mise.jdx.dev/getting-started.html) is set up in
+your shell profile, this puts `jr` on your `PATH`). Once releases ship
+GitHub Artifact Attestations (planned — see
+[#574](https://github.com/Zious11/jira-cli/pull/574)), mise verifies them
+natively without invoking `gh` or `slsa-verifier`.
+
+To track prerelease builds cut from `develop` (currently `v*-dev.*`), opt
+in per-tool in your `mise.toml`:
 
 ```toml
 [tools]
-"github:<owner>/jira-cli" = { version = "latest", prerelease = true }
+"github:Zious11/jira-cli" = { version = "latest", prerelease = true }
 ```
 
-mise's `github:` backend auto-selects the release asset matching your OS
-and architecture, extracts the `jr` binary onto your `PATH`, and (once
-per-release attestations are published) natively verifies GitHub Artifact
-Attestations and SLSA provenance in Rust without invoking `gh` or
-`slsa-verifier`.
+Windows users need `prerelease = true` for now: the current stable
+(`v0.5.0`) shipped without a Windows asset, so a plain `@latest` resolves
+to a release with no matching download until a Windows binary lands on a
+stable tag (planned for `v0.6.0`).
 
 If mise-installed `jr` refuses to launch on macOS with a Gatekeeper
-warning, clear the quarantine attribute:
+warning, clear the quarantine attribute. When mise is active in your
+shell, `mise which jr` resolves the shim:
 
 ```bash
 xattr -d com.apple.quarantine "$(mise which jr)"
+```
+
+If mise is not yet active in this shell, `mise which jr` prints nothing —
+resolve the install directory directly instead, which does not require
+activation:
+
+```bash
+xattr -d com.apple.quarantine "$(mise where 'github:Zious11/jira-cli')/jr"
 ```
 
 ### From source


### PR DESCRIPTION
## Summary

Adds a short "Install with mise" section to the Install part of the README,
documenting `mise use github:<owner>/jira-cli@latest` as an alternative to
the curl-piped one-liner. Owner-agnostic — the same snippet works for this
repository and any fork that publishes its own signed releases.

## Why

- `mise use github:<owner>/jira-cli` works today with zero additional
  publisher work: mise's `github:` backend auto-picks the correct tarball
  from the release asset set and extracts the `jr` binary onto `PATH`.
  Smoke-tested end-to-end on macOS arm64 against `v0.5.0`
  (`jr-v0.5.0-aarch64-apple-darwin.tar.gz` → `jr 0.5.0`).
- Adds a lock-file-tracked, per-project pinning path alongside the
  one-liner installer. Users on the mise/asdf/pyenv side of the ecosystem
  get a familiar install without needing a Homebrew tap.
- Documents the `prerelease = true` opt-in for tracking `-dev.*`/`-beta.*`/
  `-rc.*` releases cut from `develop`, matching the existing gitflow
  channels.
- Preserves the macOS post-install ergonomics: adds one troubleshooting
  line for `xattr -d com.apple.quarantine` (needed only when a
  quarantine-aware host process propagates the attribute — mise itself
  does not set it, mirroring Homebrew bottles).

## What this is not

- Not a mise-registry shorthand submission (that's a separate upstream PR
  to `jdx/mise` and is out of scope here).
- Not an aqua-registry submission.
- Not a change to any workflow, asset, or build.
- README-only. No `Cargo.toml`, `src/`, or CI touched.

## Fork-transparency

The snippet uses `<owner>` as a placeholder with an explanatory sentence,
so the block is correct whether a reader is looking at this repository
or at a downstream fork's checkout. No hardcoded owner in the mise text
(unchanged elsewhere: the existing curl one-liner, badges, and
"Coming soon" tap URLs still reference the canonical owner as they did
before).

## Test plan

- `mise install` under a `mise.toml` pinning `github:Zious11/jira-cli =
  "0.5.0"` — resolves the darwin arm64 tarball, extracts `jr`, `jr
  --version` reports `jr 0.5.0`.
- Same block with `prerelease = true` resolves against the latest
  `v*-dev.*` tag (currently `v0.6.0-dev.7`).
