### PR TITLE
chore: bump version to 0.6.0-dev.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.6.0-dev.7"
+version = "0.6.0-dev.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.6.0-dev.7"
+version = "0.6.0-dev.8"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary

- Bumps `Cargo.toml` (and `Cargo.lock`) from `0.6.0-dev.7` → `0.6.0-dev.8`.
- Post-F7 release of the **ADF CODE-MARK EXCLUSIVITY** bundle: enforces `code` mark exclusivity in `push_code` — strips typographic marks at emission (BC-7.2.015, closes #571, PRs #593 / #594).

## Notes

- All CI checks (`cargo check`, `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test`) passed locally before push.
- Tag `v0.6.0-dev.8` will be pushed on `develop` **after this PR merges** to trigger the pre-release build workflow.
- No functional code changes in this PR — version strings only.