### PR TITLE
chore: bump version to 0.6.0-dev.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.6.0-dev.8"
+version = "0.6.0-dev.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.6.0-dev.8"
+version = "0.6.0-dev.9"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary

- Bumps `jr` crate version `0.6.0-dev.8` → `0.6.0-dev.9` in `Cargo.toml` and `Cargo.lock`
- Ships **SOH-BUGS-1** bundle (external reports by sackofhacks):
  - #589 — JSM dry-run `createmeta` parse crash (fixed via PR #597)
  - #590 — case-insensitive `jr api -X` flag (fixed via PR #601)
  - #582 — `--field` id-absent `allowedValues` handling (fixed via PR #602)
- Bundle: **CONVERGED AND CLOSED** (DEC-167)
- Holdout: **1.00** — Step-4.5 STRICT converged

## Release procedure

Identical to v0.6.0-dev.8 precedent (PR #596):
1. Human squash-merges this PR to `develop`
2. Annotated tag `v0.6.0-dev.9` pushed on `develop`
3. `release.yml` workflow triggers and builds the pre-release binaries

## Local gates (all passed)

- `cargo build` — ok
- `cargo clippy --all-targets -- -D warnings` — ok (0 warnings)
- `cargo fmt --all -- --check` — ok
- `cargo test` — all suites ok, 0 failed

DEC-128: do NOT merge — human squash-merge required.