### PR TITLE
docs(spec): fix --yes gate direction + coverage attribution; full comment-crud.md sweep vs PRD (#577)

### DIFF
--- a/docs/specs/comment-crud.md
+++ b/docs/specs/comment-crud.md
@@ -1,7 +1,7 @@
 # Comment CRUD — `jr issue comment` subcommand group
 
-**Story:** S-577-1 (subcommand refactor) + S-577-3/4/5/6 (delete/edit/view implementations)
-**Status:** S-577-1 merged (add subcommand); S-577-3/4/5/6 pending.
+**Story:** S-577-1 (subcommand refactor) + S-577-2 (API methods) + S-577-3/4/5/6 (delete/edit/view CLI implementations)
+**Status:** S-577-1 + S-577-2 merged (subcommand group + API methods); S-577-3/4/5/6 pending.
 
 ## Background
 
@@ -50,7 +50,7 @@ Edit a comment body and/or visibility.
 - `--markdown` — convert body to ADF.
 - `--internal` — set JSM internal visibility. Mutually exclusive with `--public`.
 - `--public` — set JSM public visibility. Mutually exclusive with `--internal`.
-- `--yes` — skip confirmation when changing visibility from public to internal.
+- `--yes` — skip the confirmation prompt when making a comment public (`--public`); no effect on other paths (EC-3.5.008-1/-4).
 - `--output json` — `{"changed_fields": {...}, "id": str, "key": str, "updated": true}`.
 
 ### `jr issue comment view KEY --id ID` *(stub, S-577-6)*
@@ -113,10 +113,9 @@ Three behavioral contracts govern this:
   key-set is `{"body","properties"}`, where `properties` is
   `[{"key":"sd.public.comment","value":{"internal":false}}]`.
 
-Acceptance criterion AC-009(i) in S-577-1 enumerates these verdicts in the story's
-test-coverage table. The MERGE/PRESERVED path is covered by the body-only test variant;
-the properties-key variants are covered by the `--internal` and `--public` test
-variants respectively.
+These wire-shape verdicts are pinned by the API-method tests in `tests/comment_crud_api.rs`
+(S-577-2): body-only → key-set `{"body"}`; `--internal`/`--public` → key-set
+`{"body","properties"}`. CLI-level edit coverage lands with S-577-4/5.
 
 ## Behavioral contracts
 


### PR DESCRIPTION
## Summary

Wave-A integration pass-2 findings against \`docs/specs/comment-crud.md\` (updated by #613):

**F-1 MEDIUM — \`--yes\` gate direction inverted.**
The \`--yes\` flag bullet described it as "skip confirmation when changing visibility from public to internal." That is wrong: \`--yes\` gates the \`--public\` path (making a comment visible to customers), not \`--internal\`. EC-3.5.008-1/-4 gate \`--public\`; \`--internal\` requires no confirmation. Corrected to: "skip the confirmation prompt when making a comment public (\`--public\`); no effect on other paths (EC-3.5.008-1/-4)."

**F-2 LOW — coverage attribution to a non-existent test table.**
The wire-shape section cited "AC-009(i) in S-577-1 enumerates these verdicts in the story's test-coverage table." S-577-1 has no such table (it is the subcommand-refactor story; the API methods live in S-577-2). Re-anchored to \`tests/comment_crud_api.rs\` (S-577-2), which is the actual file pinning the body-only and properties-key wire shapes.

**Whole-file sweep (2 stale header lines).**
Story and Status header lines omitted S-577-2 (which is merged). Updated to reflect the real landed state: S-577-1 + S-577-2 merged; S-577-3/4/5/6 pending.

Line-by-line PRD §3.5 conformance verified for the remainder of the file — no further divergences found.

## Self-check (docs-only proportionality review)

- Single file: \`docs/specs/comment-crud.md\` (+6/-7).
- F-1 fix aligns with PRD §3.5 confirmation-gate semantics (public → confirm; internal → no confirm).
- F-2 fix correctly points to \`tests/comment_crud_api.rs\` which exists on develop post-S-577-2 merge.
- Header lines now accurately reflect merged story state.
- No closing keywords. No code or test changes.
- Citation guard: 61/61 (no new \`src/\` citations added).

## Test plan

- [x] \`cargo test\` — no code changes; test suite unaffected
- [x] \`cargo clippy -- -D warnings\` — no code changes
- [x] \`cargo fmt --all -- --check\` — no code changes
- [x] Spec Guards (citation checks, BC counts) — citation guard 61/61; no BC count change