### PR TITLE
feat(comment): comment view handler (#577 part 6)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -35,16 +35,15 @@ examine_globs = [
 ]
 
 # Exclude todo!() stubs in interactions.rs that are unkillable by design.
-# These two functions (handle_comment_edit, handle_comment_view) are implemented
-# in future stories (S-577-4/6) and must not be mutated until then — a todo!()
-# body produces only one possible mutation (replace return with Ok(())) which
-# always panics at runtime, never caught.
-# IMPORTANT: remove this exclude_re entry when S-577-4/6 implement these stubs
-# (whichever lands last removes the whole entry).
+# handle_comment_edit is implemented in a future story (S-577-4/5) and must not
+# be mutated until then — a todo!() body produces only one possible mutation
+# (replace return with Ok(())) which always panics at runtime, never caught.
+# IMPORTANT: remove this exclude_re entry when S-577-4/5 implement the edit stub
+# (handle_comment_view was removed here when S-577-6 implemented it).
 # Note: #[mutants::skip] attribute (policy §Whitelist Convention) requires the
 # `mutants` crate (not in Cargo.toml); comment-based skip does not work in
 # cargo-mutants 27.0.0; exclude_re is the supported crate-free alternative.
-exclude_re = ["handle_comment_(edit|view)"]
+exclude_re = ["handle_comment_(edit)"]
 
 # The absolute per-mutant test ceiling is set via `--timeout 240` on the CLI
 # invocation (CI and local). There is no .cargo/mutants.toml key for it in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ All notable changes to jr will be documented here.
   `<type>:<value>`, or `None`). `--output json` passes the raw API response
   through losslessly (`serde_json::Value` passthrough — no typed round-trip that
   would silently drop extra fields). Invalid `--id` charset exits 64; 404/403
-  exits 64 with Jira's error body surfaced; deep ADF nesting exits 64.
+  exits 64 with Jira's error body surfaced. (Over-deep comment bodies are
+  rejected at the JSON parse layer, exit 1.)
 
 - **CI: BC-body Trace/Source citation guard (Guard 1) (DEC-148):** adds
   `scripts/check-bc-citation-symbols.sh` (BC-CITE-001; validates `src/` file and symbol

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ All notable changes to jr will be documented here.
   `workflow.rs` to a new `src/cli/issue/interactions.rs` shard per ADR-0012 /
   PF-017.
 
+- **`jr issue comment view KEY --id ID` — read a single comment (S-577-6, #577):**
+  `jr issue comment view FOO-1 --id 10001` fetches the comment with
+  `GET /rest/api/3/issue/{key}/comment/{id}?expand=properties` and renders six
+  labeled fields (ID, Author, Created, Updated, JSM internal, Restricted) plus
+  an unlabeled body block rendered via ADF-to-text. The `JSM internal:` field
+  shows `Yes`/`No`/`N/A` from the `sd.public.comment` entity property. The
+  `Restricted:` field uses a 4-rung ladder (role/group value, `id=<identifier>`,
+  `<type>:<value>`, or `None`). `--output json` passes the raw API response
+  through losslessly (`serde_json::Value` passthrough — no typed round-trip that
+  would silently drop extra fields). Invalid `--id` charset exits 64; 404/403
+  exits 64 with Jira's error body surfaced; deep ADF nesting exits 64.
+
 - **CI: BC-body Trace/Source citation guard (Guard 1) (DEC-148):** adds
   `scripts/check-bc-citation-symbols.sh` (BC-CITE-001; validates `src/` file and symbol
   citations in `**Trace**:`/`**Source**:` fields of all `bc-*.md` bodies; definition-anchored

--- a/src/cli/issue/interactions.rs
+++ b/src/cli/issue/interactions.rs
@@ -279,6 +279,7 @@ pub(super) async fn handle_comment_view(
 #[cfg(test)]
 mod tests {
     use super::validate_comment_id;
+    use crate::adf;
 
     // EC-3.5.002-1 charset validation — exercises every accepted token class
     // and all three arms of the `.all()` closure so mutation testing can kill
@@ -330,5 +331,54 @@ mod tests {
     #[test]
     fn test_validate_comment_id_rejects_dot() {
         assert!(validate_comment_id("id.with.dots").is_err());
+    }
+
+    // ── AC-007 tier (i) — EC-3.5.010-2(a) propagation (GREEN-throughout) ──────
+    //
+    // Verifies that `adf_to_text` returns `Err` for a >256-deep ADF node and that
+    // the error kind maps to the UserError/exit-64 class.
+    //
+    // Strategy: programmatically BUILD (not parse) a serde_json::Value with nesting
+    // depth > 256. Construction via serde_json::json! loops has no recursion limit;
+    // only serde_json::from_slice (parsing) is bounded at 128. After building, we
+    // call adf::adf_to_text(&deep_node) directly — no HTTP boundary involved.
+    //
+    // Cross-reference: tests/adf_recursion_depth.rs uses the identical programmatic
+    // BUILD approach for the forward (markdown_to_adf) path
+    // (e.g. test_markdown_to_adf_depth_256_blockquote_is_err).
+    //
+    // This test is GREEN-throughout (not a Red Gate participant): it calls
+    // adf_to_text directly, which is fully implemented. The handle_comment_view
+    // stub being todo!() does NOT affect this test.
+    #[test]
+    fn test_bc_3_5_010_ec2a_adf_error_propagates_exit64() {
+        // Build a 257-deep ADF node entirely in memory via Value construction
+        // (no serde_json string parsing — avoids the 128-level parse limit).
+        // Depth 257 > MAX_ADF_DEPTH (256), so adf_to_text must return Err.
+        let mut node = serde_json::json!({"type": "text", "text": "leaf"});
+        for _ in 0..257 {
+            node = serde_json::json!({
+                "type": "paragraph",
+                "content": [node]
+            });
+        }
+
+        let result = adf::adf_to_text(&node);
+
+        assert!(
+            result.is_err(),
+            "EC-3.5.010-2(a): adf_to_text must return Err for a 257-deep ADF node \
+             (depth guard MAX_ADF_DEPTH=256); got Ok"
+        );
+
+        // Confirm the error maps to the UserError/exit-64 class.
+        let err = result.unwrap_err();
+        assert_eq!(
+            err.exit_code(),
+            64,
+            "EC-3.5.010-2(a): adf_to_text depth-guard error must map to exit 64 \
+             (JrError::UserError); got exit_code: {}; err: {err}",
+            err.exit_code()
+        );
     }
 }

--- a/src/cli/issue/interactions.rs
+++ b/src/cli/issue/interactions.rs
@@ -582,4 +582,32 @@ mod tests {
              (loop exhausted without sd.public.comment match)"
         );
     }
+
+    // ── Mutation-kill: format_restricted_field rung (d) fallback ───────────
+    //
+    // Kills mutant #3 (CI run 29299750396):
+    //   interactions.rs — replace guard `!t.is_empty()` with `true`
+    //   in the rung (c-id) arm `(t, _, false) if !t.is_empty()`.
+    //
+    // With guard → true, a visibility with type="" (empty) and a non-empty
+    // identifier would match rung (c-id) and produce ":some-id" instead of
+    // "None". This test asserts that rung (d) fires for empty type, forcing
+    // the guard to actually check `!t.is_empty()` to survive the mutant.
+    #[test]
+    fn test_bc_3_5_010_format_restricted_empty_type_with_identifier_returns_none() {
+        // type = "" (empty) — must fall through to rung (d) → "None"
+        // If the `!t.is_empty()` guard were replaced with `true`, this would
+        // match rung (c-id) and produce ":some-id" instead.
+        let visibility = serde_json::json!({
+            "type": "",
+            "value": "",
+            "identifier": "some-id"
+        });
+        let result = format_restricted_field(Some(&visibility));
+        assert_eq!(
+            result, "None",
+            "BC-3.5.010 rung (d): empty type + non-empty identifier must fall \
+             through to rung (d) → 'None', not ':some-id'"
+        );
+    }
 }

--- a/src/cli/issue/interactions.rs
+++ b/src/cli/issue/interactions.rs
@@ -419,6 +419,8 @@ pub(super) async fn handle_comment_view(
 
 #[cfg(test)]
 mod tests {
+    use super::format_jsm_internal_field;
+    use super::format_restricted_field;
     use super::validate_comment_id;
     use crate::adf;
 
@@ -520,6 +522,64 @@ mod tests {
             "EC-3.5.010-2(a): adf_to_text depth-guard error must map to exit 64 \
              (JrError::UserError); got exit_code: {}; err: {err}",
             err.exit_code()
+        );
+    }
+
+    // ── BC-3.5.010 pure-helper unit tests ──────────────────────────────────
+    //
+    // Direct calls to format_restricted_field / format_jsm_internal_field with
+    // serde_json::json! fixtures.  No subprocess or mock server required.
+
+    // (a) format_restricted_field rung (c-id):
+    //     non-role/group type, empty value, non-empty identifier → "<type>:<identifier>"
+    //     AC-005 worked example: type=Team, value="", identifier=AlphaTeam → "Team:AlphaTeam"
+    #[test]
+    fn test_bc_3_5_010_format_restricted_rung_c_id_type_plus_identifier() {
+        let visibility = serde_json::json!({
+            "type": "Team",
+            "value": "",
+            "identifier": "AlphaTeam"
+        });
+        let result = format_restricted_field(Some(&visibility));
+        assert_eq!(
+            result, "Team:AlphaTeam",
+            "BC-3.5.010 rung (c-id): non-role/group type + empty value + non-empty \
+             identifier must render as '<type>:<identifier>'"
+        );
+    }
+
+    // (b) format_jsm_internal_field — stringly-typed internal → "N/A"
+    //     BC-3.5.010 §field-5: sd.public.comment key present, but value.internal is
+    //     the JSON string "true" (JSDCLOUD-9766), not a boolean.
+    //     as_bool() returns None for string values → inner None arm → "N/A".
+    #[test]
+    fn test_bc_3_5_010_jsm_internal_stringly_typed_returns_na() {
+        let props = serde_json::json!([{
+            "key": "sd.public.comment",
+            "value": { "internal": "true" }
+        }]);
+        let result = format_jsm_internal_field(Some(&props));
+        assert_eq!(
+            result, "N/A",
+            "BC-3.5.010 §field-5: stringly-typed internal must return N/A \
+             (as_bool() is None for string values)"
+        );
+    }
+
+    // (c) format_jsm_internal_field — unknown-key-only properties → "N/A"
+    //     EC-006: properties array present but contains no sd.public.comment entry.
+    //     Loop exhausts without matching → falls through to the post-loop "N/A".
+    #[test]
+    fn test_bc_3_5_010_jsm_internal_unknown_key_only_returns_na() {
+        let props = serde_json::json!([{
+            "key": "some.other.property",
+            "value": { "internal": true }
+        }]);
+        let result = format_jsm_internal_field(Some(&props));
+        assert_eq!(
+            result, "N/A",
+            "BC-3.5.010 EC-006: unknown-key-only properties must return N/A \
+             (loop exhausted without sd.public.comment match)"
         );
     }
 }

--- a/src/cli/issue/interactions.rs
+++ b/src/cli/issue/interactions.rs
@@ -377,12 +377,16 @@ pub(super) async fn handle_comment_view(
         OutputFormat::Table => {
             // 7-element human render: 6 labeled plain key-value lines + unlabeled body block.
             // Timestamps (fields 3/4) rendered as raw ISO 8601 strings — do NOT reformat.
-            let id_val = response["id"].as_str().unwrap_or("(unknown)");
+            // BC-3.5.010 fallback tokens (normative per spec):
+            //   field 1 id  → "N/A" when absent/null
+            //   field 2 author.displayName → "Unknown" when author null or displayName absent
+            //   fields 3/4 created/updated → "N/A" when absent/null
+            let id_val = response["id"].as_str().unwrap_or("N/A");
             let author = response["author"]["displayName"]
                 .as_str()
-                .unwrap_or("(unknown)");
-            let created = response["created"].as_str().unwrap_or("(unknown)");
-            let updated = response["updated"].as_str().unwrap_or("(unknown)");
+                .unwrap_or("Unknown");
+            let created = response["created"].as_str().unwrap_or("N/A");
+            let updated = response["updated"].as_str().unwrap_or("N/A");
             let jsm_internal = format_jsm_internal_field(response.get("properties"));
             let restricted = format_restricted_field(response.get("visibility"));
 

--- a/src/cli/issue/interactions.rs
+++ b/src/cli/issue/interactions.rs
@@ -237,6 +237,65 @@ pub(super) async fn handle_comment_delete(
     }
 }
 
+// ── Comment View Format Helpers ──────────────────────────────────────────
+
+/// Format the `Restricted:` field (field 6) using the 4-rung ladder.
+///
+/// Rung ordering (non-negotiable per BC-3.5.010):
+/// (a) role/group with non-empty value → `<value>`
+/// (b) role/group with empty value, non-empty identifier → `id=<identifier>`
+/// (c) non-role/group type — value-OR-identifier preference:
+///     non-empty value → `<type>:<value>`
+///     empty value + non-empty identifier → `<type>:<identifier>`
+/// (d) fallback → `None`
+///
+/// `visibility` is `response.get("visibility")` — `Some(v)` when the key is
+/// present (even if the JSON value is null), `None` when the key is absent entirely.
+fn format_restricted_field(visibility: Option<&serde_json::Value>) -> String {
+    match visibility {
+        None => "None".to_string(),
+        Some(v) => {
+            let vtype = v["type"].as_str().unwrap_or("");
+            let value = v["value"].as_str().unwrap_or("");
+            let identifier = v["identifier"].as_str().unwrap_or("");
+            match (vtype, value.is_empty(), identifier.is_empty()) {
+                // Rung (a): role/group with non-empty value
+                ("role" | "group", false, _) => value.to_string(),
+                // Rung (b): role/group with empty value, non-empty identifier
+                ("role" | "group", true, false) => format!("id={identifier}"),
+                // Rung (c): non-role/group type — value-OR-identifier preference
+                (t, _, _) if !t.is_empty() && !value.is_empty() => {
+                    format!("{t}:{value}")
+                }
+                (t, _, false) if !t.is_empty() => format!("{t}:{identifier}"),
+                // Rung (d): fallback
+                _ => "None".to_string(),
+            }
+        }
+    }
+}
+
+/// Format the `JSM internal:` field (field 5) from the comment's `properties` array.
+///
+/// Scans for `{"key":"sd.public.comment","value":{"internal":bool}}` in the
+/// properties array. Returns `"Yes"` / `"No"` / `"N/A"` (BC-3.5.010 Field-5 ladder).
+fn format_jsm_internal_field(properties: Option<&serde_json::Value>) -> &'static str {
+    let props = match properties.and_then(|v| v.as_array()) {
+        Some(arr) => arr,
+        None => return "N/A",
+    };
+    for prop in props {
+        if prop["key"].as_str() == Some("sd.public.comment") {
+            return match prop["value"]["internal"].as_bool() {
+                Some(true) => "Yes",
+                Some(false) => "No",
+                None => "N/A",
+            };
+        }
+    }
+    "N/A"
+}
+
 // ── Comment Edit ─────────────────────────────────────────────────────────
 
 /// Edit a comment body (optionally set visibility).
@@ -263,15 +322,93 @@ pub(super) async fn handle_comment_edit(
 
 /// View a single comment by ID.
 ///
-/// Stub. Implementation delivered in S-577-6.
+/// Fetches `GET /rest/api/3/issue/{key}/comment/{id}?expand=properties` and renders
+/// six labeled fields + an unlabeled body block (BC-3.5.010).
+///
+/// Pipeline:
+/// 1. `validate_comment_id` (EC-3.5.002-1) — exit 64 on bad charset
+/// 2. `client.get_comment(key, id)` — returns raw `serde_json::Value`
+/// 3. 404/403 → exit 64 + two-line body surface (BC-3.5.004 pattern)
+/// 4. `--output json` → `render_json` passthrough (EC-3.5.010-1, #526 invariant)
+/// 5. Human render: 6 labeled fields + unlabeled body block via `adf_to_text`
+///    (EC-3.5.010-2a: depth error → exit 64)
+///
 /// No `no_input` parameter — read-only handler, no interactive prompt.
 pub(super) async fn handle_comment_view(
-    _key: String,
-    _id: String,
-    _output_format: &OutputFormat,
-    _client: &JiraClient,
+    key: String,
+    id: String,
+    output_format: &OutputFormat,
+    client: &JiraClient,
 ) -> Result<()> {
-    todo!("comment view — implemented in S-577-6")
+    // Step 1: validate --id charset (EC-3.5.002-1)
+    validate_comment_id(&id)?;
+
+    // Step 2: fetch the comment (returns raw serde_json::Value — no typed round-trip)
+    let response: serde_json::Value = match client.get_comment(&key, &id).await {
+        Ok(v) => v,
+        Err(e) => {
+            // 404/403 → exit 64 + two-line body surface (BC-3.5.004 pattern).
+            let user_err_msg = {
+                match e.downcast_ref::<JrError>() {
+                    Some(JrError::ApiError { status, message })
+                        if *status == 404 || *status == 403 =>
+                    {
+                        Some(format!(
+                            "comment not found or permission denied: {key}#{id}\n{message}",
+                        ))
+                    }
+                    _ => None,
+                }
+            };
+            if let Some(msg) = user_err_msg {
+                return Err(JrError::UserError(msg).into());
+            }
+            return Err(e);
+        }
+    };
+
+    // Step 3: route to output format
+    match output_format {
+        OutputFormat::Json => {
+            // EC-3.5.010-1: raw serde_json::Value passthrough — no typed round-trip
+            // (#526 JSON render invariant: all JSON routes through render_json)
+            println!("{}", output::render_json(&response)?);
+        }
+        OutputFormat::Table => {
+            // 7-element human render: 6 labeled plain key-value lines + unlabeled body block.
+            // Timestamps (fields 3/4) rendered as raw ISO 8601 strings — do NOT reformat.
+            let id_val = response["id"].as_str().unwrap_or("(unknown)");
+            let author = response["author"]["displayName"]
+                .as_str()
+                .unwrap_or("(unknown)");
+            let created = response["created"].as_str().unwrap_or("(unknown)");
+            let updated = response["updated"].as_str().unwrap_or("(unknown)");
+            let jsm_internal = format_jsm_internal_field(response.get("properties"));
+            let restricted = format_restricted_field(response.get("visibility"));
+
+            // Fields 1–6 as plain key-value lines; blank-line separator before body block.
+            print!(
+                "ID: {id_val}\n\
+                 Author: {author}\n\
+                 Created: {created}\n\
+                 Updated: {updated}\n\
+                 JSM internal: {jsm_internal}\n\
+                 Restricted: {restricted}\n\
+                 \n"
+            );
+
+            // Body block (unlabeled, field 7): ADF → text via adf_to_text.
+            // EC-3.5.010-2(a): JrError::UserError from depth guard propagates as exit 64.
+            // When body key is absent, response["body"] == Value::Null → adf_to_text
+            // returns Ok("") → nothing printed after the blank-line separator.
+            let body_text = adf::adf_to_text(&response["body"])?;
+            if !body_text.is_empty() {
+                println!("{body_text}");
+            }
+        }
+    }
+
+    Ok(())
 }
 
 // ── Unit tests ────────────────────────────────────────────────────────────

--- a/tests/comment_view.rs
+++ b/tests/comment_view.rs
@@ -924,3 +924,51 @@ async fn test_bc_3_5_010_degraded_fixture_fallback_tokens() {
          got stdout: {stdout}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Mutation-kill — non-404/403 API error propagates as exit 1
+// BC-3.5.010 — kills two guard mutations in handle_comment_view:
+//   mutant #1: replace `*status == 404 || *status == 403` with true
+//              → ANY ApiError would get exit 64 + preamble; 500 would match
+//   mutant #2: replace `== 403` with `!= 403`
+//              → 500 matches `500 != 403` = true → exit 64
+// With the correct guard, 500 is neither 404 nor 403, so the error propagates
+// as-is through `Err(e)`, which JrError maps to exit 1 (ApiError exit code).
+// ---------------------------------------------------------------------------
+
+/// Verify that a 500 Internal Server Error from the GET endpoint exits 1
+/// (not 64) and does NOT emit the "comment not found or permission denied"
+/// preamble.
+#[tokio::test]
+async fn test_bc_3_5_010_view_500_exits_1_not_64() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/comment/10001"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
+            "errorMessages": ["Internal server error"]
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "comment", "view", "FOO-1", "--id", "10001"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "BC-3.5.010 500-guard: 500 error must exit 1 (not 64); \
+         got {:?}\nstderr: {stderr}",
+        output.status.code()
+    );
+    assert!(
+        !stderr.contains("comment not found or permission denied"),
+        "BC-3.5.010 500-guard: 500 error must NOT emit the 404/403 preamble; got: {stderr}"
+    );
+}

--- a/tests/comment_view.rs
+++ b/tests/comment_view.rs
@@ -853,3 +853,74 @@ async fn test_bc_3_5_010_body_absent_empty_block_stdout_ends_restricted_none() {
          got stdout: {stdout:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// BC-3.5.010 — fallback tokens for absent/null header fields
+// ---------------------------------------------------------------------------
+
+/// Verify graceful-degradation tokens for all four required-but-possibly-absent
+/// header fields (BC-3.5.010 spec pins:
+///   field 1 ID  → "N/A" when `id` key absent
+///   field 2 Author → "Unknown" when `author` is null or `displayName` absent
+///   field 3 Created → "N/A" when `created` key absent
+///   field 4 Updated → "N/A" when `updated` key absent
+///
+/// Fixture: `author: null` (anonymized/deleted user — real Jira case);
+/// `id`, `created`, `updated` keys omitted.
+///
+/// Must be RED against code using `unwrap_or("(unknown)")` for all four fields.
+#[tokio::test]
+async fn test_bc_3_5_010_degraded_fixture_fallback_tokens() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/comment/10001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            // id, created, updated keys deliberately absent
+            "author": null   // null author — GDPR-anonymized or deleted user
+            // no body, no visibility, no properties
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "comment", "view", "FOO-1", "--id", "10001"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "BC-3.5.010 degraded: must exit 0; got {:?}\nstderr: {stderr}\nstdout: {stdout}",
+        output.status.code()
+    );
+    // BC-3.5.010 pin: field 1 absent id → "N/A"
+    assert!(
+        stdout.contains("ID: N/A"),
+        "BC-3.5.010 degraded: stdout must contain 'ID: N/A' when id key absent; \
+         got stdout: {stdout}"
+    );
+    // BC-3.5.010 pin: field 2 null author → "Unknown"
+    assert!(
+        stdout.contains("Author: Unknown"),
+        "BC-3.5.010 degraded: stdout must contain 'Author: Unknown' when author is null; \
+         got stdout: {stdout}"
+    );
+    // BC-3.5.010 pin: field 3 absent created → "N/A"
+    assert!(
+        stdout.contains("Created: N/A"),
+        "BC-3.5.010 degraded: stdout must contain 'Created: N/A' when created key absent; \
+         got stdout: {stdout}"
+    );
+    // BC-3.5.010 pin: field 4 absent updated → "N/A"
+    assert!(
+        stdout.contains("Updated: N/A"),
+        "BC-3.5.010 degraded: stdout must contain 'Updated: N/A' when updated key absent; \
+         got stdout: {stdout}"
+    );
+}

--- a/tests/comment_view.rs
+++ b/tests/comment_view.rs
@@ -1,0 +1,855 @@
+//! CLI-level integration tests for `jr issue comment view`.
+//!
+//! Red Gate: all 14 tests FAIL because `handle_comment_view` is `todo!()`.
+//! Every subprocess exits 101 (Rust panic / todo!() code) instead of the
+//! expected exit codes — exit 0 (success), exit 64 (user error), exit 1
+//! (serde parse-error path).
+//!
+//! AC-007 tier (i) lib-unit lives in src/cli/issue/interactions.rs #[cfg(test)],
+//! not here. It calls `adf_to_text` directly and is GREEN-throughout
+//! (not a Red Gate participant).
+//!
+//! BC anchors: BC-3.5.010
+//! VPs: VP-577-007, VP-577-016, VP-577-021 (7 variants), VP-577-022(c)
+//! Story: S-577-6, GitHub issue #577
+
+use assert_cmd::Command;
+use serde_json::Value;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ---------------------------------------------------------------------------
+// Harness helper
+// ---------------------------------------------------------------------------
+
+/// Build a `jr` command pointing at the mock server with XDG isolation.
+/// Does NOT add `--no-input` or any other defaults — callers supply all flags.
+fn jr_cmd(server_uri: &str, cache_dir: &std::path::Path, config_dir: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("jr").unwrap();
+    cmd.env("JR_BASE_URL", server_uri)
+        .env("JR_AUTH_HEADER", "Basic dGVzdDp0ZXN0")
+        .env("XDG_CACHE_HOME", cache_dir)
+        .env("JR_CACHE_DIR", cache_dir.join("jr"))
+        .env("XDG_CONFIG_HOME", config_dir)
+        .env("JR_CONFIG_DIR", config_dir.join("jr"));
+    cmd
+}
+
+/// Minimal ADF body paragraph containing "hello world".
+fn adf_hello_world() -> Value {
+    serde_json::json!({
+        "version": 1,
+        "type": "doc",
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "hello world"
+                    }
+                ]
+            }
+        ]
+    })
+}
+
+// ---------------------------------------------------------------------------
+// AC-001 / VP-577-021 variant 1
+// BC-3.5.010 — 6 labeled fields + unlabeled body block render completeness
+// ---------------------------------------------------------------------------
+
+/// Verify that `jr issue comment view FOO-1 --id 10001` against a full comment
+/// fixture exits 0 and stdout contains all 6 labeled field headers in byte order:
+/// "ID:", "Author:", "Created:", "Updated:", "JSM internal: Yes", "Restricted: None".
+/// No "Body:" label is asserted — the body block is unlabeled per BC-3.5.010.
+///
+/// Fixture: no `visibility` field → rung (d) → "Restricted: None".
+/// `properties[0].value.internal == true` → "JSM internal: Yes".
+///
+/// Red Gate: fails because `handle_comment_view` is `todo!()` → exit 101.
+#[tokio::test]
+async fn test_bc_3_5_010_view_human_render_all_seven_fields() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    let body = adf_hello_world();
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/comment/10001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "10001",
+            "self": "https://example.atlassian.net/rest/api/3/issue/FOO-1/comment/10001",
+            "author": {
+                "displayName": "Jane Smith",
+                "emailAddress": "jane@example.com",
+                "accountId": "abc123"
+            },
+            "created": "2026-07-01T09:00:00.000+0000",
+            "updated": "2026-07-01T10:30:00.000+0000",
+            "body": body,
+            "properties": [
+                {
+                    "key": "sd.public.comment",
+                    "value": { "internal": true }
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "comment", "view", "FOO-1", "--id", "10001"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "BC-3.5.010 all-fields: must exit 0; got {:?}\nstderr: {stderr}\nstdout: {stdout}",
+        output.status.code()
+    );
+    for label in [
+        "ID:",
+        "Author:",
+        "Created:",
+        "Updated:",
+        "JSM internal: Yes",
+        "Restricted: None",
+    ] {
+        assert!(
+            stdout.contains(label),
+            "BC-3.5.010 all-fields: stdout must contain '{label}'; got stdout: {stdout}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AC-002 / VP-577-021 variant 1
+// BC-3.5.010 — Field-5 JSM internal: Yes when sd.public.comment.internal=true
+// ---------------------------------------------------------------------------
+
+/// Verify that a comment with `properties[0].key == "sd.public.comment"` and
+/// `value.internal == true` → stdout contains "JSM internal: Yes".
+///
+/// Red Gate: fails because `handle_comment_view` is `todo!()` → exit 101.
+#[tokio::test]
+async fn test_bc_3_5_010_jsm_internal_yes_when_internal_true() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    let body = adf_hello_world();
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/comment/10001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "10001",
+            "author": { "displayName": "Jane Smith" },
+            "created": "2026-07-01T09:00:00.000+0000",
+            "updated": "2026-07-01T10:30:00.000+0000",
+            "body": body,
+            "properties": [
+                {
+                    "key": "sd.public.comment",
+                    "value": { "internal": true }
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "comment", "view", "FOO-1", "--id", "10001"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "BC-3.5.010 jsm-yes: must exit 0; got {:?}\nstderr: {stderr}\nstdout: {stdout}",
+        output.status.code()
+    );
+    assert!(
+        stdout.contains("JSM internal: Yes"),
+        "BC-3.5.010 jsm-yes: stdout must contain 'JSM internal: Yes'; got stdout: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC-003 / VP-577-021 variant 7
+// BC-3.5.010 — Field-5 JSM internal: No when sd.public.comment.internal=false
+// ---------------------------------------------------------------------------
+
+/// Verify that a comment with `properties[0].value.internal == false` →
+/// stdout contains "JSM internal: No".
+///
+/// Red Gate: fails because `handle_comment_view` is `todo!()` → exit 101.
+#[tokio::test]
+async fn test_bc_3_5_010_jsm_internal_no_when_internal_false() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    let body = adf_hello_world();
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/comment/10001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "10001",
+            "author": { "displayName": "Jane Smith" },
+            "created": "2026-07-01T09:00:00.000+0000",
+            "updated": "2026-07-01T10:30:00.000+0000",
+            "body": body,
+            "properties": [
+                {
+                    "key": "sd.public.comment",
+                    "value": { "internal": false }
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "comment", "view", "FOO-1", "--id", "10001"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "BC-3.5.010 jsm-no: must exit 0; got {:?}\nstderr: {stderr}\nstdout: {stdout}",
+        output.status.code()
+    );
+    assert!(
+        stdout.contains("JSM internal: No"),
+        "BC-3.5.010 jsm-no: stdout must contain 'JSM internal: No'; got stdout: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC-004 / VP-577-021 variant 3
+// BC-3.5.010 — Field-5 JSM internal: N/A when no properties field
+// ---------------------------------------------------------------------------
+
+/// Verify that a comment with no `properties` field (or empty array) →
+/// stdout contains "JSM internal: N/A".
+///
+/// Red Gate: fails because `handle_comment_view` is `todo!()` → exit 101.
+#[tokio::test]
+async fn test_bc_3_5_010_jsm_internal_na_when_no_properties() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    let body = adf_hello_world();
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/comment/10001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "10001",
+            "author": { "displayName": "Jane Smith" },
+            "created": "2026-07-01T09:00:00.000+0000",
+            "updated": "2026-07-01T10:30:00.000+0000",
+            "body": body
+            // no "properties" field
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "comment", "view", "FOO-1", "--id", "10001"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "BC-3.5.010 jsm-na: must exit 0; got {:?}\nstderr: {stderr}\nstdout: {stdout}",
+        output.status.code()
+    );
+    assert!(
+        stdout.contains("JSM internal: N/A"),
+        "BC-3.5.010 jsm-na: stdout must contain 'JSM internal: N/A'; got stdout: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC-005 / VP-577-021 variants 4, 5, 6
+// BC-3.5.010 — Field-6 Restricted 4-rung ladder
+// ---------------------------------------------------------------------------
+
+/// Rung (a): visibility.type == "role" or "group" with non-empty value →
+/// "Restricted: <value>" (not "id=" prefix, not "<type>:" prefix).
+///
+/// Fixture: type="role", value="Software Engineers" → "Restricted: Software Engineers".
+///
+/// Red Gate: fails because `handle_comment_view` is `todo!()` → exit 101.
+#[tokio::test]
+async fn test_bc_3_5_010_restricted_ladder_rung_a() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    let body = adf_hello_world();
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/comment/10001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "10001",
+            "author": { "displayName": "Jane Smith" },
+            "created": "2026-07-01T09:00:00.000+0000",
+            "updated": "2026-07-01T10:30:00.000+0000",
+            "body": body,
+            "visibility": {
+                "type": "role",
+                "value": "Software Engineers",
+                "identifier": "sr-engineers"
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "comment", "view", "FOO-1", "--id", "10001"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "BC-3.5.010 rung-a: must exit 0; got {:?}\nstderr: {stderr}\nstdout: {stdout}",
+        output.status.code()
+    );
+    assert!(
+        stdout.contains("Restricted: Software Engineers"),
+        "BC-3.5.010 rung-a: stdout must contain 'Restricted: Software Engineers'; \
+         got stdout: {stdout}"
+    );
+}
+
+/// Rung (b): visibility.type == "role" or "group" with empty/null value, non-empty
+/// identifier → "Restricted: id=<identifier>".
+///
+/// Fixture: type="group", value="", identifier="sr-engineers" →
+/// "Restricted: id=sr-engineers".
+///
+/// Red Gate: fails because `handle_comment_view` is `todo!()` → exit 101.
+#[tokio::test]
+async fn test_bc_3_5_010_restricted_ladder_rung_b() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    let body = adf_hello_world();
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/comment/10001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "10001",
+            "author": { "displayName": "Jane Smith" },
+            "created": "2026-07-01T09:00:00.000+0000",
+            "updated": "2026-07-01T10:30:00.000+0000",
+            "body": body,
+            "visibility": {
+                "type": "group",
+                "value": "",
+                "identifier": "sr-engineers"
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "comment", "view", "FOO-1", "--id", "10001"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "BC-3.5.010 rung-b: must exit 0; got {:?}\nstderr: {stderr}\nstdout: {stdout}",
+        output.status.code()
+    );
+    assert!(
+        stdout.contains("Restricted: id=sr-engineers"),
+        "BC-3.5.010 rung-b: stdout must contain 'Restricted: id=sr-engineers'; \
+         got stdout: {stdout}"
+    );
+}
+
+/// Rung (c): visibility.type is non-role/non-group with non-empty value →
+/// "Restricted: <type>:<value>".
+///
+/// Fixture: type="Team", value="AlphaTeam" → "Restricted: Team:AlphaTeam".
+///
+/// Red Gate: fails because `handle_comment_view` is `todo!()` → exit 101.
+#[tokio::test]
+async fn test_bc_3_5_010_restricted_ladder_rung_c() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    let body = adf_hello_world();
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/comment/10001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "10001",
+            "author": { "displayName": "Jane Smith" },
+            "created": "2026-07-01T09:00:00.000+0000",
+            "updated": "2026-07-01T10:30:00.000+0000",
+            "body": body,
+            "visibility": {
+                "type": "Team",
+                "value": "AlphaTeam",
+                "identifier": "some-uuid"
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "comment", "view", "FOO-1", "--id", "10001"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "BC-3.5.010 rung-c: must exit 0; got {:?}\nstderr: {stderr}\nstdout: {stdout}",
+        output.status.code()
+    );
+    assert!(
+        stdout.contains("Restricted: Team:AlphaTeam"),
+        "BC-3.5.010 rung-c: stdout must contain 'Restricted: Team:AlphaTeam'; \
+         got stdout: {stdout}"
+    );
+}
+
+/// Rung (d): no `visibility` field → "Restricted: None".
+///
+/// Fixture: visibility field absent from response JSON.
+///
+/// Red Gate: fails because `handle_comment_view` is `todo!()` → exit 101.
+#[tokio::test]
+async fn test_bc_3_5_010_restricted_ladder_rung_d() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    let body = adf_hello_world();
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/comment/10001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "10001",
+            "author": { "displayName": "Jane Smith" },
+            "created": "2026-07-01T09:00:00.000+0000",
+            "updated": "2026-07-01T10:30:00.000+0000",
+            "body": body
+            // no "visibility" field → rung d → "Restricted: None"
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "comment", "view", "FOO-1", "--id", "10001"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "BC-3.5.010 rung-d: must exit 0; got {:?}\nstderr: {stderr}\nstdout: {stdout}",
+        output.status.code()
+    );
+    assert!(
+        stdout.contains("Restricted: None"),
+        "BC-3.5.010 rung-d: stdout must contain 'Restricted: None'; got stdout: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC-006 / VP-577-021 variant 1
+// BC-3.5.010 — Field-7 body rendered via adf_to_text with blank-line separator
+// ---------------------------------------------------------------------------
+
+/// Verify that a comment with an ADF body containing "hello world" renders body
+/// text after a blank-line separator following the header block, with no
+/// "Body:" label emitted.
+///
+/// Assertion: stdout contains a blank line ("\n\n") followed by "hello world".
+///
+/// Red Gate: fails because `handle_comment_view` is `todo!()` → exit 101.
+#[tokio::test]
+async fn test_bc_3_5_010_body_rendered_with_blank_line_separator() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    let body = adf_hello_world();
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/comment/10001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "10001",
+            "author": { "displayName": "Jane Smith" },
+            "created": "2026-07-01T09:00:00.000+0000",
+            "updated": "2026-07-01T10:30:00.000+0000",
+            "body": body
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "comment", "view", "FOO-1", "--id", "10001"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "BC-3.5.010 body-sep: must exit 0; got {:?}\nstderr: {stderr}\nstdout: {stdout}",
+        output.status.code()
+    );
+    // The blank-line separator ("\n\n") separates headers from body block.
+    assert!(
+        stdout.contains("\n\nhello world"),
+        "BC-3.5.010 body-sep: stdout must contain blank-line separator before body text; \
+         expected '\\n\\nhello world'; got stdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Body:"),
+        "BC-3.5.010 body-sep: stdout must NOT contain a 'Body:' label; got stdout: {stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC-007 tier (ii) — subprocess
+// EC-3.5.010-2(a) — JSON-parse-error boundary behavior
+// ---------------------------------------------------------------------------
+
+/// Verify that a wiremock response body with ≥129 levels of JSON nesting causes
+/// `serde_json::from_slice` to fail (serde default recursion limit = 128), which
+/// propagates as `JrError::Json` → exit 1 at the CLI boundary.
+///
+/// This test pins the BOUNDARY BEHAVIOR: the `adf_to_text` depth-guard exit-64
+/// path is unreachable via the HTTP boundary because serde_json rejects the body
+/// before `adf_to_text` is called. See story AC-007 for the full analysis.
+/// The unit-level propagation test (tier-i) lives in
+/// `src/cli/issue/interactions.rs #[cfg(test)]`.
+///
+/// Red Gate: fails because `handle_comment_view` is `todo!()` → exit 101 ≠ 1.
+#[tokio::test]
+async fn test_bc_3_5_010_ec2a_deep_json_parse_error_exits_1() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    // Build a 129-deep nested JSON string that serde_json cannot parse
+    // (serde_json recursion limit = 128). Constructed as a String to bypass the
+    // serde_json::Value recursion limit (construction via json! macro is also
+    // bounded, so we build the string directly).
+    let mut json_str = "42".to_string(); // leaf value
+    for _ in 0..129 {
+        json_str = format!("{{\"a\":{json_str}}}");
+    }
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/comment/10001"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(json_str)
+                .insert_header("Content-Type", "application/json"),
+        )
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "comment", "view", "FOO-1", "--id", "10001"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // The serde_json recursion limit fires first → JrError::Json → exit 1.
+    // (NOT exit 64, which would require adf_to_text to be called.)
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "EC-3.5.010-2 boundary: 129-deep JSON body must cause JrError::Json → exit 1 \
+         (NOT exit 64); got {:?}\nstderr: {stderr}",
+        output.status.code()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC-008
+// BC-3.5.010 Response-404 — 404 → exit 64 + two-part body surface
+// ---------------------------------------------------------------------------
+
+/// Verify that `jr issue comment view FOO-1 --id 10001` against a wiremock
+/// returning 404 exits 64, and stderr contains BOTH:
+/// (a) preamble "comment not found or permission denied"
+/// (b) Jira body text "Comment not found."
+///
+/// Red Gate: fails because `handle_comment_view` is `todo!()` → exit 101.
+#[tokio::test]
+async fn test_bc_3_5_010_404_exits_64_with_body_surface() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/comment/10001"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "errorMessages": ["Comment not found."]
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "comment", "view", "FOO-1", "--id", "10001"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "BC-3.5.010 404: must exit 64; got {:?}\nstderr: {stderr}",
+        output.status.code()
+    );
+    assert!(
+        stderr.contains("comment not found or permission denied"),
+        "BC-3.5.010 404: stderr must contain preamble \
+         'comment not found or permission denied'; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Comment not found."),
+        "BC-3.5.010 404: stderr must contain Jira body text 'Comment not found.'; \
+         got: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC-009 / VP-577-016, VP-577-007
+// BC-3.5.010 EC-3.5.010-1 — JSON output: serde_json::Value passthrough
+// ---------------------------------------------------------------------------
+
+/// Two assertions in one test (VP-577-016 + VP-577-007):
+///
+/// (a) VP-577-016 — "self" field survives passthrough: `--output json` returns
+///     a JSON response that includes the `"self"` URL field (a standard Jira API
+///     field absent from any typed `Comment` struct). The `"self"` key must survive
+///     in stdout, confirming lossless serde_json::Value passthrough.
+///
+/// (b) VP-577-007 — `?expand=properties` is in the request URL AND
+///     `properties[0].value.internal` == true in the JSON output.
+///
+/// Red Gate: fails because `handle_comment_view` is `todo!()` → exit 101.
+#[tokio::test]
+async fn test_bc_3_5_010_ec1_json_output_passthrough() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    let body = adf_hello_world();
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/comment/10001"))
+        .and(query_param("expand", "properties"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "10001",
+            "self": "https://example.atlassian.net/rest/api/3/issue/FOO-1/comment/10001",
+            "author": { "displayName": "Jane Smith" },
+            "created": "2026-07-01T09:00:00.000+0000",
+            "updated": "2026-07-01T10:30:00.000+0000",
+            "body": body,
+            "properties": [
+                {
+                    "key": "sd.public.comment",
+                    "value": { "internal": true }
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args([
+            "issue", "comment", "view", "FOO-1", "--id", "10001", "--output", "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "BC-3.5.010 json-passthrough: must exit 0; got {:?}\nstderr: {stderr}\nstdout: {stdout}",
+        output.status.code()
+    );
+
+    let parsed: Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!(
+            "BC-3.5.010 json-passthrough: stdout must be valid JSON; \
+             parse error: {e}\nstdout: {stdout}"
+        )
+    });
+
+    // VP-577-016: "self" key must survive (lossless Value passthrough)
+    assert!(
+        parsed.get("self").is_some(),
+        "VP-577-016: 'self' field must survive passthrough in JSON output; \
+         got JSON: {parsed}"
+    );
+
+    // VP-577-007: properties[0].value.internal must be true
+    let internal = &parsed["properties"][0]["value"]["internal"];
+    assert_eq!(
+        *internal,
+        Value::Bool(true),
+        "VP-577-007: properties[0].value.internal must be true in JSON output; \
+         got: {internal}"
+    );
+
+    // VP-577-007: URL must contain expand=properties (checked via received requests)
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(
+        requests.len(),
+        1,
+        "VP-577-007: expected exactly 1 GET request; got {}",
+        requests.len()
+    );
+    let url_str = requests[0].url.as_str();
+    assert!(
+        url_str.contains("expand=properties"),
+        "VP-577-007: request URL must contain 'expand=properties'; got: {url_str}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC-010 / VP-577-022 variant (c)
+// EC-3.5.002-1 — invalid --id charset → exit 64, no GET
+// ---------------------------------------------------------------------------
+
+/// Verify that `jr issue comment view FOO-1 --id "../x"` exits 64 with stderr
+/// containing "invalid comment id". The GET mock has `.expect(0)` — the
+/// validation must fire before any HTTP call.
+///
+/// Shared validation rule: EC-3.5.002-1 (`validate_comment_id`), shared with
+/// delete (VP-577-022a) and edit (VP-577-022b).
+///
+/// Red Gate: fails because `handle_comment_view` is `todo!()` → exit 101.
+#[tokio::test]
+async fn test_bc_3_5_002_ec1_view_invalid_id_regex_exits_64() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "comment", "view", "FOO-1", "--id", "../x"])
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(64),
+        "EC-3.5.002-1 view: must exit 64 on invalid --id charset; \
+         got {:?}\nstderr: {stderr}",
+        output.status.code()
+    );
+    assert!(
+        stderr.contains("invalid comment id"),
+        "EC-3.5.002-1 view: stderr must contain 'invalid comment id'; got: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC-011 / VP-577-021 variant 2
+// BC-3.5.010 — body-absent fallback: empty body block + byte-level stdout pin
+// ---------------------------------------------------------------------------
+
+/// Verify that a comment fixture without a `body` field → exit 0; header fields
+/// 1–6 render with graceful-degradation fallbacks; body block is empty (blank
+/// line after Restricted field, no additional content).
+///
+/// Byte-level pin (VP-577-021 variant 2): stdout ends with "Restricted: None\n\n"
+/// — the structural blank-line separator always renders, leaving nothing after it
+/// when body is absent.
+///
+/// Red Gate: fails because `handle_comment_view` is `todo!()` → exit 101.
+#[tokio::test]
+async fn test_bc_3_5_010_body_absent_empty_block_stdout_ends_restricted_none() {
+    let server = MockServer::start().await;
+    let cache_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/issue/FOO-1/comment/10001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "10001",
+            "author": { "displayName": "Jane Smith" },
+            "created": "2026-07-01T09:00:00.000+0000",
+            "updated": "2026-07-01T10:30:00.000+0000"
+            // no "body" field, no "visibility", no "properties"
+        })))
+        .mount(&server)
+        .await;
+
+    let output = jr_cmd(&server.uri(), cache_dir.path(), config_dir.path())
+        .args(["issue", "comment", "view", "FOO-1", "--id", "10001"])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "BC-3.5.010 body-absent: must exit 0; got {:?}\nstderr: {stderr}\nstdout: {stdout}",
+        output.status.code()
+    );
+
+    // Byte-level pin: stdout ends with "Restricted: None\n\n"
+    // The blank-line separator always renders, leaving nothing after it when body
+    // is absent.
+    assert!(
+        stdout.ends_with("Restricted: None\n\n"),
+        "VP-577-021 variant 2: stdout must end with 'Restricted: None\\n\\n'; \
+         got stdout: {stdout:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements \`jr issue comment view KEY --id ID [--output json]\` (S-577-6, bundle SOH-COMMENT-CRUD-1). Removes the \`handle_comment_view\` todo!() stub from \`src/cli/issue/interactions.rs\` and delivers the full read-only handler.

**Core behaviour:**
- \`validate_comment_id\` — charset guard: rejects IDs outside \`[0-9A-Za-z_-]\\` (exit 64) before any network call. Shared helper from S-577-3.
- \`GET /rest/api/3/issue/{key}/comment/{id}?expand=properties\` — raw \`serde_json::Value\` passthrough; NOT a typed struct (lossless; Jira returns fields absent from typed structs).
- 404/403 → exit 64 + two-line stderr body surface (BC-3.5.004 pattern, matching delete handler).
- \`--output json\` → \`render_json\` passthrough (EC-3.5.010-1, JSON render invariant #526).
- Human render: 6 labeled fields + unlabeled body block:
  - Fields 1–4: ID, Author, Created, Updated (raw ISO 8601 timestamps, no reformatting).
  - Field 5 (JSM internal): \`format_jsm_internal_field\` — scans \`properties\` for \`sd.public.comment.internal\`; returns Yes/No/N/A.
  - Field 6 (Restricted): \`format_restricted_field\` — 4-rung ladder (role/group value → group empty identifier → other-type value → fallback None).
  - Body block (unlabeled): \`adf_to_text\` after blank-line separator; depth error → exit 64 (EC-3.5.010-2a).
- \`adf_to_text\` error path pinned via unit-level programmatic ADF construction (AC-007 tier-i) — serde's 128-level recursion limit fires before \`adf_to_text\` on the wiremock path; tier-ii subprocess test pins that boundary behavior (exit 1).

**mutants.toml update:** \`exclude_re\` narrowed — \`view\` removed from the \`handle_comment_(edit|view)\` alternation; remaining entry is \`handle_comment_(edit)\` (S-577-4 still excluded pending its story).

## Acceptance criterion → test mapping (11 ACs, 15 tests)

All 11 ACs covered by 15 tests: 14 subprocess in \`tests/comment_view.rs\` + 1 tier-i lib-unit in \`src/cli/issue/interactions.rs\` \`#[cfg(test)]\`:

| AC | BC Anchor | Test function(s) | Tier | Result |
|----|-----------|-----------------|------|--------|
| AC-001 (6 fields + body) | BC-3.5.010 | \`test_bc_3_5_010_view_human_render_all_seven_fields\` | subprocess | PASS |
| AC-002 (JSM Yes) | BC-3.5.010 Field-5 | \`test_bc_3_5_010_jsm_internal_yes_when_internal_true\` | subprocess | PASS |
| AC-003 (JSM No) | BC-3.5.010 Field-5 | \`test_bc_3_5_010_jsm_internal_no_when_internal_false\` | subprocess | PASS |
| AC-004 (JSM N/A) | BC-3.5.010 Field-5 | \`test_bc_3_5_010_jsm_internal_na_when_no_properties\` | subprocess | PASS |
| AC-005 (Restricted 4-rung) | BC-3.5.010 Field-6 | \`test_bc_3_5_010_restricted_ladder_rung_a/b/c/d\` (4 tests) | subprocess | PASS |
| AC-006 (body + blank-line sep) | BC-3.5.010 Field-7 | \`test_bc_3_5_010_body_rendered_with_blank_line_separator\` | subprocess | PASS |
| AC-007 (adf_to_text depth) | EC-3.5.010-2a | \`test_bc_3_5_010_ec2a_adf_error_propagates_exit64\` (tier i) | lib-unit | PASS |
| AC-007 (serde 128 boundary) | EC-3.5.010-2a | \`test_bc_3_5_010_ec2a_deep_json_parse_error_exits_1\` (tier ii) | subprocess | PASS |
| AC-008 (404) | BC-3.5.010 / BC-3.5.004 | \`test_bc_3_5_010_404_exits_64_with_body_surface\` | subprocess | PASS |
| AC-009 (JSON passthrough + expand) | EC-3.5.010-1, VP-577-016, VP-577-007 | \`test_bc_3_5_010_ec1_json_output_passthrough\` | subprocess | PASS |
| AC-010 (invalid --id) | EC-3.5.002-1, VP-577-022c | \`test_bc_3_5_002_ec1_view_invalid_id_regex_exits_64\` | subprocess | PASS |
| AC-011 (body absent) | VP-577-021 variant 2 | \`test_bc_3_5_010_body_absent_empty_block_stdout_ends_restricted_none\` | subprocess | PASS |

Extra degradation test: \`test_bc_3_5_010_degraded_fixture_fallback_tokens\` (absent id/created/updated → "N/A"; null author → "Unknown") — kills mutants on fallback arms. Total: 15/15 green.

## Convergence evidence (Step 4.5, BC-5.39.001)

- **6 adversarial passes:** 1M (fallback-tokens) / 1M (helper-arm coverage) / 1L (CHANGELOG exit-claim) / CLEAN / CLEAN / CLEAN (windows p4/p5/p6)
- **Fix commits:** 0f48818 (correct fallback tokens) / 245d57d (add helper-arm unit tests) / 9a82e84 (CHANGELOG correction)
- **Wave:** C (parallel with S-577-4). Bundle's final story is S-577-5 (wave D), which owns \`closes #577\`.
- **Per-AC demos:** \`.factory/demos/S-577-6/\` (11/11 ACs; INDEX.md — factory artifact, gitignored per DEC-166 convention)

## Test plan

- [x] \`cargo test\` — all tests pass (lib + all integration suites, 0 failures)
- [x] \`cargo clippy -- -D warnings\` — zero warnings
- [x] \`cargo clippy --tests -- -D warnings\` — zero warnings
- [x] \`cargo fmt --all -- --check\` — clean
- [x] 14 Red Gate subprocess tests (9132fe7) → all green post-implementation
- [x] 1 tier-i lib-unit (unit-level \`adf_to_text\` depth guard path) — GREEN throughout (not a Red Gate participant)
- [x] E2E CLI surface guard (\`tests/e2e_cli_surface_guard.rs\`) — green (no new CLI surface added; view dispatch was wired in S-577-1)
- [x] \`exclude_re\` narrowed: \`view\` removed from \`handle_comment_(edit|view)\`; remaining entry covers S-577-4's stub only