### PR TITLE
docs(spec): correct stale stub labels for shipped comment subcommands (#577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,8 @@ All notable changes to jr will be documented here.
   `jr issue comment add KEY "message"`. Invoking the flat form now exits 2 with a
   migration hint: `error: use \`jr issue comment add\` instead`.
   The `add` subcommand accepts the same flags (`--stdin`, `--file`, `--markdown`,
-  `--internal`). New subcommands `delete`, `edit`, and `view` were added; `edit`
-  (S-577-4) and `view` (S-577-6) are fully implemented in this release; `delete`
-  remains a stub (S-577-3).
+  `--internal`). New subcommands `delete` (S-577-3), `edit` (S-577-4), and `view`
+  (S-577-6) are all fully implemented in this release.
 
 ### Added
 
@@ -30,7 +29,8 @@ All notable changes to jr will be documented here.
 - **`jr issue comment add/delete/edit/view` subcommand group (S-577-1):**
   `jr issue comment` is now a subcommand group. `add` is fully implemented
   (replaces the old flat form). `edit` (body-only, S-577-4) and `view` (S-577-6)
-  are also fully implemented in this release. `delete` remains a stub (S-577-3).
+  are also fully implemented in this release. `delete` (S-577-3) is likewise fully
+  implemented (y/N confirmation gate, `--yes` bypass, 404/403 exit 64).
   Interaction handlers extracted from `workflow.rs` to a new
   `src/cli/issue/interactions.rs` shard per ADR-0012 / PF-017.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to jr will be documented here.
   `jr issue comment add KEY "message"`. Invoking the flat form now exits 2 with a
   migration hint: `error: use \`jr issue comment add\` instead`.
   The `add` subcommand accepts the same flags (`--stdin`, `--file`, `--markdown`,
-  `--internal`). New subcommands `delete` (S-577-3), `edit` (S-577-4), and `view`
+  `--internal`). New subcommands `delete` (S-577-3), `edit` (body-only, S-577-4), and `view`
   (S-577-6) are all fully implemented in this release.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ All notable changes to jr will be documented here.
   `jr issue comment add KEY "message"`. Invoking the flat form now exits 2 with a
   migration hint: `error: use \`jr issue comment add\` instead`.
   The `add` subcommand accepts the same flags (`--stdin`, `--file`, `--markdown`,
-  `--internal`). New subcommands `delete`, `edit`, and `view` are stubs
-  (implemented in S-577-3/4/5/6).
+  `--internal`). New subcommands `delete`, `edit`, and `view` were added; `edit`
+  (S-577-4) and `view` (S-577-6) are fully implemented in this release; `delete`
+  remains a stub (S-577-3).
 
 ### Added
 
@@ -28,10 +29,10 @@ All notable changes to jr will be documented here.
 
 - **`jr issue comment add/delete/edit/view` subcommand group (S-577-1):**
   `jr issue comment` is now a subcommand group. `add` is fully implemented
-  (replaces the old flat form). `delete`, `edit`, and `view` are stubs to be
-  completed in follow-on stories. Interaction handlers extracted from
-  `workflow.rs` to a new `src/cli/issue/interactions.rs` shard per ADR-0012 /
-  PF-017.
+  (replaces the old flat form). `edit` (body-only, S-577-4) and `view` (S-577-6)
+  are also fully implemented in this release. `delete` remains a stub (S-577-3).
+  Interaction handlers extracted from `workflow.rs` to a new
+  `src/cli/issue/interactions.rs` shard per ADR-0012 / PF-017.
 
 - **`jr issue comment view KEY --id ID` — read a single comment (S-577-6, #577):**
   `jr issue comment view FOO-1 --id 10001` fetches the comment with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ src/
 │   │   ├── edit.rs          # issue edit: single + bulk field/label/type paths, dry-run, type-error enrichment; extracted from create.rs (Seam B, ADR-0012)
 │   │   ├── jsm_create.rs    # JSM `handle_jsm_create` path + RT-id resolution (extracted from create.rs, ADR-0012/ADR-0014)
 │   │   ├── workflow.rs      # move + transitions + assign + open
-│   │   ├── interactions.rs  # comment CRUD handlers: add, delete (stub), edit (stub), view (stub) (S-577-1+)
+│   │   ├── interactions.rs  # comment CRUD handlers: add, delete, edit (body-only), view (S-577-1..6); visibility flags deferred to S-577-5
 │   │   ├── links.rs         # link + unlink + link-types
 │   │   ├── helpers.rs       # team/points resolution, user resolution, prompts
 │   │   ├── assets.rs        # linked assets (issue→asset lookup)

--- a/docs/specs/comment-crud.md
+++ b/docs/specs/comment-crud.md
@@ -1,7 +1,7 @@
 # Comment CRUD — `jr issue comment` subcommand group
 
 **Story:** S-577-1 (subcommand refactor) + S-577-2 (API methods) + S-577-3/4/5/6 (delete/edit/view CLI implementations)
-**Status:** S-577-1 + S-577-2 merged (subcommand group + API methods); S-577-3/4/5/6 pending.
+**Status:** S-577-1 + S-577-2 + S-577-4 + S-577-6 merged; S-577-3 (delete) and S-577-5 (visibility flags) pending.
 
 ## Background
 
@@ -39,7 +39,7 @@ Delete a comment by numeric ID. Requires `--yes` or interactive confirmation.
 - `--yes` — skip confirmation prompt (non-interactive usage).
 - `--output json` — `{"deleted": true, "id": str, "key": str}`.
 
-### `jr issue comment edit KEY [TEXT] --id ID [--file PATH] [--stdin] [--markdown] [--internal|--public] [--yes]` *(stub, S-577-4/5)*
+### `jr issue comment edit KEY [TEXT] --id ID [--file PATH] [--stdin] [--markdown] [--internal|--public] [--yes]` *(body edit shipped, S-577-4; --internal/--public/--yes deferred to S-577-5)*
 
 Edit a comment body and/or visibility.
 
@@ -53,7 +53,7 @@ Edit a comment body and/or visibility.
 - `--yes` — skip the confirmation prompt when making a comment public (`--public`); no effect on other paths (EC-3.5.008-1/-4).
 - `--output json` — `{"changed_fields": {...}, "id": str, "key": str, "updated": true}`.
 
-### `jr issue comment view KEY --id ID` *(stub, S-577-6)*
+### `jr issue comment view KEY --id ID`
 
 View a single comment by ID.
 
@@ -132,6 +132,6 @@ See `docs/specs/json-output-shapes.md` for the canonical shapes.
 ## Implementation files
 
 - `src/cli/mod.rs` — `IssueCommand::Comment { command: CommentSubcommand }`, `CommentSubcommand` enum.
-- `src/cli/issue/interactions.rs` — `handle_comment_add` (implemented); stubs for delete/edit/view.
+- `src/cli/issue/interactions.rs` — `handle_comment_add`, `handle_comment_edit` (body-only, S-577-4), `handle_comment_view` (S-577-6) implemented; `handle_comment_delete` stub (S-577-3).
 - `src/cli/issue/mod.rs` — dispatch to interactions handlers.
 - `src/main.rs` — `try_parse` intercept for flat-form migration hint.

--- a/docs/specs/comment-crud.md
+++ b/docs/specs/comment-crud.md
@@ -1,7 +1,7 @@
 # Comment CRUD — `jr issue comment` subcommand group
 
 **Story:** S-577-1 (subcommand refactor) + S-577-2 (API methods) + S-577-3/4/5/6 (delete/edit/view CLI implementations)
-**Status:** S-577-1 + S-577-2 + S-577-4 + S-577-6 merged; S-577-3 (delete) and S-577-5 (visibility flags) pending.
+**Status:** S-577-1 + S-577-2 + S-577-3 + S-577-4 + S-577-6 merged; S-577-5 (visibility flags) pending.
 
 ## Background
 
@@ -31,7 +31,7 @@ Add a comment. Replaces the old flat form.
 
 Exit codes: 0 success, 1 API error, 1 empty body (legacy `anyhow::bail!`, not `JrError::UserError`; the future edit subcommand exits 64 for empty body per BC-3.5.009 EC-3.5.009-5 — add's behavior is preserved as-is per EC-3.5.012-2).
 
-### `jr issue comment delete KEY --id ID [--yes]` *(stub, S-577-3)*
+### `jr issue comment delete KEY --id ID [--yes]`
 
 Delete a comment by numeric ID. Requires `--yes` or interactive confirmation.
 
@@ -132,6 +132,6 @@ See `docs/specs/json-output-shapes.md` for the canonical shapes.
 ## Implementation files
 
 - `src/cli/mod.rs` — `IssueCommand::Comment { command: CommentSubcommand }`, `CommentSubcommand` enum.
-- `src/cli/issue/interactions.rs` — `handle_comment_add`, `handle_comment_edit` (body-only, S-577-4), `handle_comment_view` (S-577-6) implemented; `handle_comment_delete` stub (S-577-3).
+- `src/cli/issue/interactions.rs` — all four handlers implemented: `handle_comment_add`, `handle_comment_delete` (S-577-3), `handle_comment_edit` (body-only, S-577-4), `handle_comment_view` (S-577-6).
 - `src/cli/issue/mod.rs` — dispatch to interactions handlers.
 - `src/main.rs` — `try_parse` intercept for flat-form migration hint.

--- a/docs/specs/json-output-shapes.md
+++ b/docs/specs/json-output-shapes.md
@@ -17,7 +17,7 @@ Write operations use VERB-ALIGNED success-field names by intentional design. The
 | `issue assign --unassign` | `{"key": str, "assignee": null, "changed": bool}` | `changed` is false when already unassigned. |
 | `issue remote-link` | `{"key": str, "id": int, "url": str, "title": str, "self": str}` | Verified at `src/cli/issue/json_output.rs` (`remote_link_response`). |
 | `issue comment add` | Jira Comment object (passthrough from `POST /rest/api/3/issue/{key}/comment`) | `{"id": str, "created": str, …}`. Passthrough; shape is Jira Cloud authoritative. Table output: `Added comment to KEY (id: N)`. Implemented in `src/cli/issue/interactions.rs::handle_comment_add`. |
-| `issue comment delete` | `{"deleted": bool, "id": str, "key": str}` | Stub (S-577-3). Shape pinned by S-577-1 AC-009(h). |
+| `issue comment delete` | Success: `{"deleted": true, "id": str, "key": str}`; interactive cancel: `{"cancelled": true, "deleted": false}` (no `id`/`key`) | Shipped (S-577-3). Cancel path emits when user answers N interactively; `--yes` bypasses the prompt. 404/403 → exit 64. |
 | `issue comment edit` | `{"changed_fields": {"body": str}, "id": str, "key": str, "updated": true}` | Body-only shipped (S-577-4). `changed_fields.body` carries the raw pre-trim user input string (BC-3.5.005 raw echo pin). Visibility fields (`--internal`/`--public`) deferred to S-577-5. |
 | `issue comment view` | Jira Comment object (passthrough from `GET /rest/api/3/issue/{key}/comment/{id}?expand=properties`) | Shipped (S-577-6). Raw `serde_json::Value` passthrough — no typed round-trip. Route: `output::render_json` (#526 invariant). |
 | `sprint add` | `{"sprint_id": int, "issues": [str], "added": true}` | Verified at `src/cli/sprint.rs` (`sprint_add_response`). |

--- a/docs/specs/json-output-shapes.md
+++ b/docs/specs/json-output-shapes.md
@@ -18,8 +18,8 @@ Write operations use VERB-ALIGNED success-field names by intentional design. The
 | `issue remote-link` | `{"key": str, "id": int, "url": str, "title": str, "self": str}` | Verified at `src/cli/issue/json_output.rs` (`remote_link_response`). |
 | `issue comment add` | Jira Comment object (passthrough from `POST /rest/api/3/issue/{key}/comment`) | `{"id": str, "created": str, …}`. Passthrough; shape is Jira Cloud authoritative. Table output: `Added comment to KEY (id: N)`. Implemented in `src/cli/issue/interactions.rs::handle_comment_add`. |
 | `issue comment delete` | `{"deleted": bool, "id": str, "key": str}` | Stub (S-577-3). Shape pinned by S-577-1 AC-009(h). |
-| `issue comment edit` | `{"changed_fields": {...}, "id": str, "key": str, "updated": bool}` | Stub (S-577-4/5). Shape pinned by S-577-1 AC-009(h). `changed_fields` mirrors `issue edit` shape. |
-| `issue comment view` | Jira Comment object (passthrough from `GET /rest/api/3/issue/{key}/comment/{id}`) | Stub (S-577-6). Shape to be finalized on implementation. |
+| `issue comment edit` | `{"changed_fields": {"body": str}, "id": str, "key": str, "updated": true}` | Body-only shipped (S-577-4). `changed_fields.body` carries the raw pre-trim user input string (BC-3.5.005 raw echo pin). Visibility fields (`--internal`/`--public`) deferred to S-577-5. |
+| `issue comment view` | Jira Comment object (passthrough from `GET /rest/api/3/issue/{key}/comment/{id}?expand=properties`) | Shipped (S-577-6). Raw `serde_json::Value` passthrough — no typed round-trip. Route: `output::render_json` (#526 invariant). |
 | `sprint add` | `{"sprint_id": int, "issues": [str], "added": true}` | Verified at `src/cli/sprint.rs` (`sprint_add_response`). |
 | `sprint remove` | `{"issues": [str], "removed": true}` | Verified at `src/cli/sprint.rs` (`sprint_remove_response`). |
 | `auth login` | `{"profile": str, "action": "login", "ok": true}` | NEW in S-2.07 v2.0.0 |


### PR DESCRIPTION
## Summary

Wave-C integration convergence pass-1 finding: reference docs and CHANGELOG incorrectly labeled the `delete`, `edit`, and `view` comment subcommands as stubs after all three shipped in wave B (S-577-3 / PR #615, S-577-4 / PR #617, S-577-6 / PR #616).

**Sweep 1 (4e4464d):** corrects stale stub labels for `edit` and `view` — 6 sites in `docs/specs/comment-crud.md`, `docs/specs/json-output-shapes.md`, and `CHANGELOG.md`, plus 2 audit catches in the JSON shapes table (delete cancel envelope, edit `changed_fields.body` raw-echo pin documented).

**Sweep 2 (7bef83f):** corrects stale stub labels for `delete` — 5 sites + Status header line in the same three files.

**Net state:** zero stub mentions across all three files; shipped JSON envelopes documented (delete success/cancel, edit `changed_fields` shape, view raw passthrough); only S-577-5 visibility semantics remain marked deferred (correct — not yet shipped).

No code changes. Docs only.

## Changes

- `CHANGELOG.md` — two entries updated to reflect all four comment subcommands as shipped
- `docs/specs/comment-crud.md` — status header, delete/edit/view section headings, and implementation files table corrected
- `docs/specs/json-output-shapes.md` — delete/edit/view rows updated with accurate shapes and shipped status

## Related

- Closes no issues (convergence pass — labeled stubs corrected, no feature work)
- References #577 (comment CRUD epic)
- Builds on PR #615 (delete), PR #617 (edit), PR #616 (view)

## Test plan

- [ ] Citation guard: 61/61 (docs-only, no `src/` paths changed)
- [ ] Spot-verify delete cancel envelope against `tests/comment_delete.rs`
- [ ] Confirm `docs/specs/comment-crud.md` status header reads S-577-5 pending only
- [ ] Confirm zero `*(stub` occurrences across the three changed files