### PR TITLE
chore(comments): correct stale stub claims in src comments (#577)

### DIFF
--- a/src/cli/issue/interactions.rs
+++ b/src/cli/issue/interactions.rs
@@ -601,8 +601,8 @@ mod tests {
     // (e.g. test_markdown_to_adf_depth_256_blockquote_is_err).
     //
     // This test is GREEN-throughout (not a Red Gate participant): it calls
-    // adf_to_text directly, which is fully implemented. The handle_comment_view
-    // stub being todo!() does NOT affect this test.
+    // adf_to_text directly, which is fully implemented. This test is independent
+    // of handle_comment_view (which has its own subprocess coverage in tests/comment_view.rs).
     #[test]
     fn test_bc_3_5_010_ec2a_adf_error_propagates_exit64() {
         // Build a 257-deep ADF node entirely in memory via Value construction

--- a/src/cli/issue/mod.rs
+++ b/src/cli/issue/mod.rs
@@ -83,8 +83,8 @@ pub async fn handle(
                 interactions::handle_comment_delete(key, id, yes, output_format, client, no_input)
                     .await
             }
-            // Pass the whole Edit variant so handle_comment_edit (stub, S-577-4/5)
-            // can destructure individual fields when implemented.
+            // Pass the whole Edit variant so handle_comment_edit can destructure
+            // individual fields (body-only shipped S-577-4; visibility flags consumed in S-577-5).
             sub @ CommentSubcommand::Edit { .. } => {
                 interactions::handle_comment_edit(sub, output_format, client, no_input).await
             }


### PR DESCRIPTION
## Summary

Wave-C integration pass-2 found the final 2 sites of the stale-stub-claim family in source comments — both handlers shipped this wave and their accompanying comments were not updated.

**Finding 1 — `src/cli/issue/mod.rs:83-84`:** Dispatch comment on the `CommentSubcommand::Edit` arm read `handle_comment_edit (stub, S-577-4/5)`. The handler shipped in S-577-4 (PR #617, body-only). Updated to: `handle_comment_edit can destructure individual fields (body-only shipped S-577-4; visibility flags consumed in S-577-5)`.

**Finding 2 — `src/cli/issue/interactions.rs:605`:** Test comment on `test_bc_3_5_010_ec2a_adf_error_propagates_exit64` stated `The handle_comment_view stub being todo!() does NOT affect this test`. The handler shipped in S-577-6 (PR #616). Updated to: `This test is independent of handle_comment_view (which has its own subprocess coverage in tests/comment_view.rs)`.

Comment-only changes. Zero behavior change. Lib test suite (1006 tests), clippy --all-targets, fmt, and citation guard 61/61 confirmed green before commit. Src-wide grep now zero stale stub claims.

**Note:** Red Gate provenance docstrings in `tests/` (e.g. "This test is a Red Gate participant") are deliberately untouched — those are architectural annotations, not stale stub claims, and removing them would destroy spec traceability. Accepted precedent from wave-B/C reviews.

## Changes

- `src/cli/issue/mod.rs` — dispatch comment on `Edit` arm corrected (2 lines)
- `src/cli/issue/interactions.rs` — test comment on ADF error-propagation test corrected (2 lines)

## Related

- References #577 (comment CRUD epic)
- Follows docs sweep in PR #618
- Closes no issues