### PR TITLE
docs(readme): add comment delete/edit/view rows to command table (#577)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ jr issue comment add JSM-42 "customer is on the paid plan — prioritizing" --in
 | `jr issue resolutions` | List instance-scoped resolution values (cached 7 days; `--refresh` to bust). Discover what to pass to `--resolution` on `jr issue move`. |
 | `jr issue assign KEY` | Assign to self (or `--to USER`, `--unassign`) |
 | `jr issue comment add KEY "msg"` | Add a comment (`--stdin`, `--file`, `--markdown`, `--internal` for JSM agent-only notes) |
+| `jr issue comment delete KEY --id ID` | Delete a comment by ID (`--yes` to skip y/N confirmation) |
+| `jr issue comment edit KEY --id ID "msg"` | Edit a comment body (`--stdin`, `--file`, `--markdown`; `--internal`/`--public` visibility; `--yes` to skip confirmation) |
+| `jr issue comment view KEY --id ID` | View a single comment by ID (shows JSM visibility and restriction fields) |
 | `jr issue comments KEY` | List comments (`--limit N`; JSM issues show a Visibility column: External / Internal) |
 | `jr issue open KEY` | Open in browser (`--url-only` for scripts) |
 | `jr issue link KEY1 KEY2` | Link two issues (`--type blocks`, defaults to Relates) |


### PR DESCRIPTION
## Summary

F5 scoped-adversarial pass-2 finding: the README command table (primary discovery surface, exhaustive by convention) omitted the three comment subcommands shipped this release. The `add` row was already present; `delete`, `edit`, and `view` were missing.

Adds 3 rows in family order immediately after the existing `comment add` row:

- `jr issue comment delete KEY --id ID` — delete by ID (`--yes` to skip y/N confirmation)
- `jr issue comment edit KEY --id ID "msg"` — edit body (`--stdin`, `--file`, `--markdown`; `--internal`/`--public` visibility; `--yes` to skip confirmation)
- `jr issue comment view KEY --id ID` — view single comment (shows JSM visibility and restriction fields)

Flag claims verified against the live binary. Whole-file comment-family audit found nothing else missing. Citation guard 61/61.

## Changes

- `README.md` — 3 rows added to the command table (1 file, +3 lines)

## Related

- References #577 (comment CRUD epic)
- Follows PR #618 (docs sweep), #619 (src-comment sweep), #621 (S-577-5 deferral sweep)