### PR TITLE
chore: bump version to 0.6.0-dev.10 (#577 bundle release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to jr will be documented here.
 
 ## [Unreleased]
 
+## [0.6.0-dev.10] - 2026-07-15
+
 ### Breaking Changes
 
 - **`jr issue comment` is now a subcommand group (S-577-1, issue #577):**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.6.0-dev.9"
+version = "0.6.0-dev.10"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.6.0-dev.9"
+version = "0.6.0-dev.10"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Summary

Release bump for v0.6.0-dev.10 — the `#577` comment CRUD bundle. F7 convergence pass APPROVED (DEC-176); release authorized.

**Bundle contents (11 PRs):**

| PR | Story | What shipped |
|----|-------|-------------|
| #610 | S-577-1 | `jr issue comment` subcommand group; `add` implemented; flat-form migration hint |
| #611 | S-577-2 | Comment API methods (`GET`/`POST`/`PUT`/`DELETE` + list pagination) |
| #615 | S-577-3 | `comment delete` — y/N confirmation gate, `--yes` bypass, 404/403 exit 64 |
| #617 | S-577-4 | `comment edit` — body-only PUT, body sources (`--stdin`/`--file`/`--markdown`), raw-echo pin (BC-3.5.005) |
| #616 | S-577-6 | `comment view` — single-comment GET, JSM internal/restriction rendering |
| #620 | S-577-5 | `comment edit` visibility flags (`--internal`/`--public`/`--yes` confirmation gate, VP-577-026/029) |
| #618 | docs sweep 1–3 | Stale stub labels + CLAUDE.md tree comment corrected |
| #619 | src sweep 4 | Stale stub claims in source comments corrected |
| #621 | docs sweep 5 | S-577-5 deferral notes resolved; `json-output-shapes.md` machine contract completed |
| #622 | docs sweep 6 | README command table: `delete`/`edit`/`view` rows added |
| *(this PR)* | release | Version bump + CHANGELOG cut |

**Convergence evidence:** F5 scoped-adversarial pass (DEC-174) → F6 targeted-hardening pass (DEC-175) → F7 convergence pass (DEC-176 APPROVED). All doc/src stale-claim sweeps completed; zero residual stub mentions; citation guard 61/61.

## Changes

- `Cargo.toml` — version `0.6.0-dev.9` → `0.6.0-dev.10`
- `Cargo.lock` — lock entry updated to match
- `CHANGELOG.md` — `[Unreleased]` cut: `## [0.6.0-dev.10] - 2026-07-15` inserted above existing content