### PR TITLE
ci: guard scorecard behind SCORECARD_ENABLED repo var

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -20,6 +20,10 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
+    # Default off — enable by setting repo variable SCORECARD_ENABLED=true
+    # (same opt-in pattern as SIGNING_ENABLED). Keeps forks from running
+    # scorecard unintentionally.
+    if: vars.SCORECARD_ENABLED == 'true'
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.


### PR DESCRIPTION
Makes Scorecard analysis opt-in: the job runs only when the repo variable `SCORECARD_ENABLED` is set to `true` — the same opt-in pattern already used for `SIGNING_ENABLED`. No var, no run. Forks and clones stay quiet by default; enable per repo by adding the variable.