### PR TITLE
fix(issue): classify disk-write errors per BC-2.7.012 v1.3.102 — hybrid ErrorKind taxonomy + tmp-path leak fix (FIX-F5-010, F5 round for #576)

### DIFF
--- a/src/cli/issue/attachments.rs
+++ b/src/cli/issue/attachments.rs
@@ -587,6 +587,50 @@ fn batch_path_is_within_dir(
 // S-576-2: private async helpers
 // ---------------------------------------------------------------------------
 
+/// Classify a disk-write `io::Error` into a user-friendly discriminated message.
+///
+/// **BC-2.7.012 v1.3.102** — used by all three I/O sites in `stream_to_file`
+/// (`File::create`, `write_all`, `rename`) so that single-mode (propagate → exit 1)
+/// and batch-mode (per-file fail-soft warning) paths both benefit from one chokepoint.
+///
+/// # Branch mapping
+/// - `StorageFull | QuotaExceeded` →
+///   `"Disk full: not enough space to write <dest>: <os_err>. Free up disk space and try again."`
+/// - `PermissionDenied | ReadOnlyFilesystem` →
+///   `"Permission denied: cannot write to <dir>: <os_err>. Check directory permissions and try again."`
+/// - `_` (non-exhaustive fallback, **required** because `ErrorKind` is `#[non_exhaustive]`) →
+///   `"Failed to write <dest>: <os_err>."`
+///
+/// # Arguments
+/// - `kind`         — `e.kind()` from the raw `std::io::Error` (call BEFORE any anyhow conversion).
+/// - `dest_display` — final destination path, filename portion display-sanitized (CWE-116).
+/// - `dir_display`  — `final_path.parent()` rendered verbatim (operator-controlled).
+/// - `os_err`       — `e.to_string()` from the raw `std::io::Error` (ends in `(os error N)`).
+fn classify_write_error(
+    kind: std::io::ErrorKind,
+    dest_display: &str,
+    dir_display: &str,
+    os_err: &str,
+) -> String {
+    match kind {
+        std::io::ErrorKind::StorageFull | std::io::ErrorKind::QuotaExceeded => {
+            format!(
+                "Disk full: not enough space to write {dest_display}: {os_err}. \
+                 Free up disk space and try again."
+            )
+        }
+        std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::ReadOnlyFilesystem => {
+            format!(
+                "Permission denied: cannot write to {dir_display}: {os_err}. \
+                 Check directory permissions and try again."
+            )
+        }
+        _ => {
+            format!("Failed to write {dest_display}: {os_err}.")
+        }
+    }
+}
+
 /// Stream `response` body to `final_path` using an atomic temp-file + rename pattern.
 ///
 /// Temp file: `tmp_<16 random hex digits>` in the SAME directory as `final_path`
@@ -596,6 +640,11 @@ fn batch_path_is_within_dir(
 ///
 /// On ANY error after temp-file creation, the temp file is deleted before returning
 /// the error (cleanup guarantee for BC-2.7.007 EC-2.7.007-4).
+///
+/// **Write-error classification (BC-2.7.012 v1.3.102):** all three I/O sites
+/// (`File::create`, `write_all`, `rename`) route through `classify_write_error` to
+/// emit discriminated messages (`Disk full: …`, `Permission denied: …`, generic
+/// fallback) that name the **final destination** (never the internal `tmp_<hex>` path).
 async fn stream_to_file(
     response: reqwest::Response,
     final_path: &std::path::Path,
@@ -607,18 +656,49 @@ async fn stream_to_file(
     let token: u64 = rand::random();
     let tmp_path = parent.join(format!("tmp_{token:016x}"));
 
+    // BC-2.7.012 v1.3.102: pre-compute display strings shared across all three I/O
+    // error sites below. CWE-116 / BC-2.7.011: display-sanitize the server-supplied
+    // filename portion; the operator-controlled parent directory is rendered verbatim.
+    let final_fname = final_path
+        .file_name()
+        .map(|n| display_sanitize_filename(&n.to_string_lossy()))
+        .unwrap_or_else(|| display_sanitize_filename(&final_path.to_string_lossy()));
+    let final_dir_display = final_path
+        .parent()
+        .filter(|d| !d.as_os_str().is_empty())
+        .map(|d| d.display().to_string())
+        .unwrap_or_else(|| ".".to_string());
+    let final_dest_display = match final_path.parent() {
+        Some(d) if !d.as_os_str().is_empty() => {
+            format!("{}{}{final_fname}", d.display(), std::path::MAIN_SEPARATOR)
+        }
+        _ => final_fname,
+    };
+
     let result: anyhow::Result<u64> = async {
         let mut file = tokio::fs::File::create(&tmp_path).await.map_err(|e| {
-            anyhow::anyhow!("failed to create temp file {}: {e}", tmp_path.display())
+            let msg = classify_write_error(
+                e.kind(),
+                &final_dest_display,
+                &final_dir_display,
+                &e.to_string(),
+            );
+            anyhow::anyhow!("{msg}")
         })?;
         let mut bytes_written: u64 = 0;
 
         let mut stream = response.bytes_stream();
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.map_err(|e| anyhow::anyhow!("stream error: {e}"))?;
-            file.write_all(&chunk)
-                .await
-                .map_err(|e| anyhow::anyhow!("write error to {}: {e}", tmp_path.display()))?;
+            file.write_all(&chunk).await.map_err(|e| {
+                let msg = classify_write_error(
+                    e.kind(),
+                    &final_dest_display,
+                    &final_dir_display,
+                    &e.to_string(),
+                );
+                anyhow::anyhow!("{msg}")
+            })?;
             bytes_written += chunk.len() as u64;
         }
 
@@ -628,19 +708,13 @@ async fn stream_to_file(
         tokio::fs::rename(&tmp_path, final_path)
             .await
             .map_err(|e| {
-                // BC-2.7.011 / CWE-116: display-sanitize the server-supplied filename
-                // portion; parent directory is operator-controlled and rendered verbatim.
-                let fname = final_path
-                    .file_name()
-                    .map(|n| display_sanitize_filename(&n.to_string_lossy()))
-                    .unwrap_or_else(|| display_sanitize_filename(&final_path.to_string_lossy()));
-                let display = match final_path.parent() {
-                    Some(d) if !d.as_os_str().is_empty() => {
-                        format!("{}{}{fname}", d.display(), std::path::MAIN_SEPARATOR)
-                    }
-                    _ => fname,
-                };
-                anyhow::anyhow!("failed to rename temp to {display}: {e}")
+                let msg = classify_write_error(
+                    e.kind(),
+                    &final_dest_display,
+                    &final_dir_display,
+                    &e.to_string(),
+                );
+                anyhow::anyhow!("{msg}")
             })?;
 
         Ok(bytes_written)
@@ -3273,12 +3347,7 @@ mod tests {
     fn test_bc_2_7_012_classify_generic_fallback() {
         use std::io::ErrorKind;
         let os_err = std::io::Error::from(ErrorKind::Other).to_string();
-        let msg = classify_write_error(
-            ErrorKind::Other,
-            "/output/report.pdf",
-            "/output",
-            &os_err,
-        );
+        let msg = classify_write_error(ErrorKind::Other, "/output/report.pdf", "/output", &os_err);
         assert!(
             msg.starts_with("Failed to write /output/report.pdf:"),
             "Generic fallback must produce 'Failed to write <dest>:' prefix; got: {msg}"

--- a/src/cli/issue/attachments.rs
+++ b/src/cli/issue/attachments.rs
@@ -641,8 +641,8 @@ fn classify_write_error(
 /// On ANY error after temp-file creation, the temp file is deleted before returning
 /// the error (cleanup guarantee for BC-2.7.007 EC-2.7.007-4).
 ///
-/// **Write-error classification (BC-2.7.012 v1.3.102):** all three I/O sites
-/// (`File::create`, `write_all`, `rename`) route through `classify_write_error` to
+/// **Write-error classification (BC-2.7.012 v1.3.102):** all four I/O sites
+/// (`File::create`, `write_all`, `flush`, `rename`) route through `classify_write_error` to
 /// emit discriminated messages (`Disk full: …`, `Permission denied: …`, generic
 /// fallback) that name the **final destination** (never the internal `tmp_<hex>` path).
 async fn stream_to_file(
@@ -702,7 +702,15 @@ async fn stream_to_file(
             bytes_written += chunk.len() as u64;
         }
 
-        file.flush().await?;
+        file.flush().await.map_err(|e| {
+            let msg = classify_write_error(
+                e.kind(),
+                &final_dest_display,
+                &final_dir_display,
+                &e.to_string(),
+            );
+            anyhow::anyhow!("{msg}")
+        })?;
         drop(file);
 
         tokio::fs::rename(&tmp_path, final_path)

--- a/src/cli/issue/attachments.rs
+++ b/src/cli/issue/attachments.rs
@@ -631,6 +631,42 @@ fn classify_write_error(
     }
 }
 
+/// Compute the two display strings used in all write-error messages for `final_path`.
+///
+/// Returns `(dir_display, dest_display)` where:
+/// - `dir_display`  — parent directory, rendered verbatim (operator-controlled); falls
+///   back to `"."` when the path has no non-empty parent component.
+/// - `dest_display` — full destination string for error messages: `"<dir>/<file>"` when
+///   a non-empty parent exists, otherwise just the sanitized filename (no leading
+///   path-separator prefix).
+///
+/// The filename portion is run through `display_sanitize_filename` (CWE-116 / BC-2.7.011).
+/// The parent portion is rendered verbatim (operator-controlled; no sanitization applied).
+///
+/// # Mutant-killing contract (FIX-F5-010)
+/// - Non-empty parent path: `dir_display` == the parent (NOT `"."`).
+/// - Bare filename (no parent / empty parent):
+///   - `dir_display` == `"."` (NOT `""`).
+///   - `dest_display` == the filename — no leading path-separator character.
+fn write_error_display_strings(final_path: &std::path::Path) -> (String, String) {
+    let final_fname = final_path
+        .file_name()
+        .map(|n| display_sanitize_filename(&n.to_string_lossy()))
+        .unwrap_or_else(|| display_sanitize_filename(&final_path.to_string_lossy()));
+    let final_dir_display = final_path
+        .parent()
+        .filter(|d| !d.as_os_str().is_empty())
+        .map(|d| d.display().to_string())
+        .unwrap_or_else(|| ".".to_string());
+    let final_dest_display = match final_path.parent() {
+        Some(d) if !d.as_os_str().is_empty() => {
+            format!("{}{}{final_fname}", d.display(), std::path::MAIN_SEPARATOR)
+        }
+        _ => final_fname,
+    };
+    (final_dir_display, final_dest_display)
+}
+
 /// Stream `response` body to `final_path` using an atomic temp-file + rename pattern.
 ///
 /// Temp file: `tmp_<16 random hex digits>` in the SAME directory as `final_path`
@@ -659,21 +695,7 @@ async fn stream_to_file(
     // BC-2.7.012 v1.3.102: pre-compute display strings shared across all four I/O
     // error sites below. CWE-116 / BC-2.7.011: display-sanitize the server-supplied
     // filename portion; the operator-controlled parent directory is rendered verbatim.
-    let final_fname = final_path
-        .file_name()
-        .map(|n| display_sanitize_filename(&n.to_string_lossy()))
-        .unwrap_or_else(|| display_sanitize_filename(&final_path.to_string_lossy()));
-    let final_dir_display = final_path
-        .parent()
-        .filter(|d| !d.as_os_str().is_empty())
-        .map(|d| d.display().to_string())
-        .unwrap_or_else(|| ".".to_string());
-    let final_dest_display = match final_path.parent() {
-        Some(d) if !d.as_os_str().is_empty() => {
-            format!("{}{}{final_fname}", d.display(), std::path::MAIN_SEPARATOR)
-        }
-        _ => final_fname,
-    };
+    let (final_dir_display, final_dest_display) = write_error_display_strings(final_path);
 
     let result: anyhow::Result<u64> = async {
         let mut file = tokio::fs::File::create(&tmp_path).await.map_err(|e| {
@@ -3388,6 +3410,68 @@ mod tests {
         assert!(
             !msg.contains("Check directory permissions"),
             "Generic fallback must NOT include 'Check directory permissions'; got: {msg}"
+        );
+    }
+
+    // FIX-F5-010: write_error_display_strings mutant-killing tests.
+    //
+    // Mutant 1 ("delete ! in stream_to_file", line 668): changes
+    //   `.filter(|d| !d.as_os_str().is_empty())`
+    //   to `.filter(|d| d.as_os_str().is_empty())`.
+    //   - Normal path ("out/dir/file.txt"): non-empty parent is REJECTED by the mutated
+    //     filter (is_empty() → false → filter drops it), so unwrap_or falls to "." — wrong.
+    //   - Bare filename ("file.txt"): empty parent is ACCEPTED by the mutated filter
+    //     (is_empty() → true → filter keeps it), so .map returns "" — wrong.
+    //
+    // Mutant 2 ("replace match guard !d.as_os_str().is_empty() with true", line 672):
+    //   changes `Some(d) if !d.as_os_str().is_empty()` to `Some(d) if true`.
+    //   - Bare filename: Some("") now matches first arm, dest becomes "/" + fname — wrong.
+    //   - Normal path: arm already matched correctly (non-empty parent), no observable change.
+    //
+    // The two tests together kill both mutants by pinning exact output for both cases.
+
+    #[test]
+    fn test_write_error_display_strings_normal_path_kills_mutant1() {
+        // Non-empty parent "out/dir": the filter and guard both pass in correct code.
+        // Mutant 1 (! deleted): filter rejects "out/dir" (not empty) → dir falls to "."
+        // → assertion `dir == "out/dir"` fails, killing the mutant.
+        let path = std::path::Path::new("out/dir/file.txt");
+        let (dir, dest) = write_error_display_strings(path);
+        assert_eq!(
+            dir, "out/dir",
+            "non-empty parent must be used verbatim as dir; mutant 1 would yield '.'"
+        );
+        assert!(
+            dest.starts_with("out/dir"),
+            "dest must start with the parent directory; got: {dest}"
+        );
+        assert!(
+            dest.contains("file.txt"),
+            "dest must contain the filename portion; got: {dest}"
+        );
+    }
+
+    #[test]
+    fn test_write_error_display_strings_bare_filename_kills_both_mutants() {
+        // Bare filename "file.txt": Path::parent() → Some("") (empty component).
+        // Correct: dir=".", dest="file.txt".
+        //
+        // Mutant 1 (! deleted): empty parent is ACCEPTED by mutated filter
+        //   (d.as_os_str().is_empty() → true) → .map returns "" → dir="" ≠ "." → caught.
+        //
+        // Mutant 2 (guard replaced with true): Some("") matches first arm →
+        //   dest = format!("{}{}file.txt", "", MAIN_SEPARATOR) = "/file.txt" on Unix,
+        //   "\file.txt" on Windows — either way dest ≠ "file.txt" → caught.
+        let path = std::path::Path::new("file.txt");
+        let (dir, dest) = write_error_display_strings(path);
+        assert_eq!(
+            dir, ".",
+            "bare filename must fall back to '.'; mutant 1 (! deleted) would yield ''"
+        );
+        assert_eq!(
+            dest, "file.txt",
+            "bare filename dest must be just the filename with no leading separator; \
+             mutant 2 (guard=true) would prepend the path separator"
         );
     }
 }

--- a/src/cli/issue/attachments.rs
+++ b/src/cli/issue/attachments.rs
@@ -589,7 +589,7 @@ fn batch_path_is_within_dir(
 
 /// Classify a disk-write `io::Error` into a user-friendly discriminated message.
 ///
-/// **BC-2.7.012 v1.3.102** — used by all three I/O sites in `stream_to_file`
+/// **BC-2.7.012 v1.3.102** — used by all four I/O sites in `stream_to_file`
 /// (`File::create`, `write_all`, `rename`) so that single-mode (propagate → exit 1)
 /// and batch-mode (per-file fail-soft warning) paths both benefit from one chokepoint.
 ///
@@ -597,7 +597,7 @@ fn batch_path_is_within_dir(
 /// - `StorageFull | QuotaExceeded` →
 ///   `"Disk full: not enough space to write <dest>: <os_err>. Free up disk space and try again."`
 /// - `PermissionDenied | ReadOnlyFilesystem` →
-///   `"Permission denied: cannot write to <dir>: <os_err>. Check directory permissions and try again."`
+///   `"Permission denied: cannot write to <dir> (writing <dest>): <os_err>. Check directory permissions and try again."`
 /// - `_` (non-exhaustive fallback, **required** because `ErrorKind` is `#[non_exhaustive]`) →
 ///   `"Failed to write <dest>: <os_err>."`
 ///
@@ -621,7 +621,7 @@ fn classify_write_error(
         }
         std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::ReadOnlyFilesystem => {
             format!(
-                "Permission denied: cannot write to {dir_display}: {os_err}. \
+                "Permission denied: cannot write to {dir_display} (writing {dest_display}): {os_err}. \
                  Check directory permissions and try again."
             )
         }
@@ -656,7 +656,7 @@ async fn stream_to_file(
     let token: u64 = rand::random();
     let tmp_path = parent.join(format!("tmp_{token:016x}"));
 
-    // BC-2.7.012 v1.3.102: pre-compute display strings shared across all three I/O
+    // BC-2.7.012 v1.3.102: pre-compute display strings shared across all four I/O
     // error sites below. CWE-116 / BC-2.7.011: display-sanitize the server-supplied
     // filename portion; the operator-controlled parent directory is rendered verbatim.
     let final_fname = final_path
@@ -3247,7 +3247,7 @@ mod tests {
     // Branch mapping (non-exhaustive `_ =>` arm REQUIRED — ErrorKind is
     // `#[non_exhaustive]` and must NOT be exhaustively matched):
     //   StorageFull | QuotaExceeded  →  "Disk full: not enough space to write <dest>: <os_err>. Free up disk space and try again."
-    //   PermissionDenied | ReadOnlyFilesystem  →  "Permission denied: cannot write to <dir>: <os_err>. Check directory permissions and try again."
+    //   PermissionDenied | ReadOnlyFilesystem  →  "Permission denied: cannot write to <dir> (writing <dest>): <os_err>. Check directory permissions and try again."
     //   _ (fallback)  →  "Failed to write <dest>: <os_err>."
     // ===========================================================================
 
@@ -3311,10 +3311,11 @@ mod tests {
             "/output",
             &os_err,
         );
+        // BC-2.7.012 v1.3.103: parenthetical `(writing <dest>)` added after <dir>.
         assert!(
-            msg.starts_with("Permission denied: cannot write to /output:"),
+            msg.starts_with("Permission denied: cannot write to /output (writing"),
             "PermissionDenied must produce \
-             'Permission denied: cannot write to <dir>:' prefix; got: {msg}"
+             'Permission denied: cannot write to <dir> (writing' prefix; got: {msg}"
         );
         assert!(
             msg.contains("Check directory permissions and try again."),
@@ -3323,6 +3324,11 @@ mod tests {
         assert!(
             msg.contains(&os_err),
             "PermissionDenied must include the OS error string '{os_err}'; got: {msg}"
+        );
+        // BC-2.7.012 v1.3.103 / P9-001: dest_display must appear in message.
+        assert!(
+            msg.contains("/output/report.pdf"),
+            "PermissionDenied must include dest_display '/output/report.pdf'; got: {msg}"
         );
     }
 
@@ -3336,10 +3342,11 @@ mod tests {
             "/output",
             &os_err,
         );
+        // BC-2.7.012 v1.3.103: parenthetical `(writing <dest>)` added after <dir>.
         assert!(
-            msg.starts_with("Permission denied: cannot write to /output:"),
+            msg.starts_with("Permission denied: cannot write to /output (writing"),
             "ReadOnlyFilesystem must produce \
-             'Permission denied: cannot write to <dir>:' prefix; got: {msg}"
+             'Permission denied: cannot write to <dir> (writing' prefix; got: {msg}"
         );
         assert!(
             msg.contains("Check directory permissions and try again."),
@@ -3348,6 +3355,11 @@ mod tests {
         assert!(
             msg.contains(&os_err),
             "ReadOnlyFilesystem must include the OS error string '{os_err}'; got: {msg}"
+        );
+        // BC-2.7.012 v1.3.103 / P9-001: dest_display must appear in message.
+        assert!(
+            msg.contains("/output/report.pdf"),
+            "ReadOnlyFilesystem must include dest_display '/output/report.pdf'; got: {msg}"
         );
     }
 

--- a/src/cli/issue/attachments.rs
+++ b/src/cli/issue/attachments.rs
@@ -3143,4 +3143,162 @@ mod tests {
             non_canonical_base.display()
         );
     }
+
+    // ===========================================================================
+    // BC-2.7.012 v1.3.102 — classify_write_error pure classifier unit tests
+    // FIX-F5-010 RED GATE
+    //
+    // These tests call `classify_write_error`, which does NOT yet exist in this
+    // file. They will FAIL TO COMPILE until the implementer adds the function.
+    //
+    // Compile failure IS the RED state — the strongest revert-pin. After the
+    // implementation, all tests in this block must pass without modification.
+    //
+    // Implementer contract (from BC-2.7.012, research doc f5-r5-001):
+    //   fn classify_write_error(
+    //       kind: std::io::ErrorKind,
+    //       dest_display: &str,   // final destination path (display-safe)
+    //       dir_display: &str,    // final_path.parent() verbatim
+    //       os_err: &str,         // std::io::Error::Display of the raw error
+    //   ) -> String
+    //
+    // Branch mapping (non-exhaustive `_ =>` arm REQUIRED — ErrorKind is
+    // `#[non_exhaustive]` and must NOT be exhaustively matched):
+    //   StorageFull | QuotaExceeded  →  "Disk full: not enough space to write <dest>: <os_err>. Free up disk space and try again."
+    //   PermissionDenied | ReadOnlyFilesystem  →  "Permission denied: cannot write to <dir>: <os_err>. Check directory permissions and try again."
+    //   _ (fallback)  →  "Failed to write <dest>: <os_err>."
+    // ===========================================================================
+
+    #[test]
+    fn test_bc_2_7_012_classify_storage_full_disk_full_prefix() {
+        use std::io::ErrorKind;
+        let os_err = std::io::Error::from(ErrorKind::StorageFull).to_string();
+        let msg = classify_write_error(
+            ErrorKind::StorageFull,
+            "/output/report.pdf",
+            "/output",
+            &os_err,
+        );
+        assert!(
+            msg.starts_with("Disk full: not enough space to write /output/report.pdf:"),
+            "StorageFull must produce \
+             'Disk full: not enough space to write <dest>:' prefix; got: {msg}"
+        );
+        assert!(
+            msg.contains("Free up disk space and try again."),
+            "StorageFull must include remediation hint; got: {msg}"
+        );
+        assert!(
+            msg.contains(&os_err),
+            "StorageFull must include the OS error string '{os_err}'; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_bc_2_7_012_classify_quota_exceeded_disk_full_prefix() {
+        use std::io::ErrorKind;
+        let os_err = std::io::Error::from(ErrorKind::QuotaExceeded).to_string();
+        let msg = classify_write_error(
+            ErrorKind::QuotaExceeded,
+            "/output/report.pdf",
+            "/output",
+            &os_err,
+        );
+        assert!(
+            msg.starts_with("Disk full: not enough space to write /output/report.pdf:"),
+            "QuotaExceeded must produce \
+             'Disk full: not enough space to write <dest>:' prefix; got: {msg}"
+        );
+        assert!(
+            msg.contains("Free up disk space and try again."),
+            "QuotaExceeded must include remediation hint; got: {msg}"
+        );
+        assert!(
+            msg.contains(&os_err),
+            "QuotaExceeded must include the OS error string '{os_err}'; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_bc_2_7_012_classify_permission_denied_perm_prefix() {
+        use std::io::ErrorKind;
+        let os_err = std::io::Error::from(ErrorKind::PermissionDenied).to_string();
+        let msg = classify_write_error(
+            ErrorKind::PermissionDenied,
+            "/output/report.pdf",
+            "/output",
+            &os_err,
+        );
+        assert!(
+            msg.starts_with("Permission denied: cannot write to /output:"),
+            "PermissionDenied must produce \
+             'Permission denied: cannot write to <dir>:' prefix; got: {msg}"
+        );
+        assert!(
+            msg.contains("Check directory permissions and try again."),
+            "PermissionDenied must include remediation hint; got: {msg}"
+        );
+        assert!(
+            msg.contains(&os_err),
+            "PermissionDenied must include the OS error string '{os_err}'; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_bc_2_7_012_classify_read_only_filesystem_perm_prefix() {
+        use std::io::ErrorKind;
+        let os_err = std::io::Error::from(ErrorKind::ReadOnlyFilesystem).to_string();
+        let msg = classify_write_error(
+            ErrorKind::ReadOnlyFilesystem,
+            "/output/report.pdf",
+            "/output",
+            &os_err,
+        );
+        assert!(
+            msg.starts_with("Permission denied: cannot write to /output:"),
+            "ReadOnlyFilesystem must produce \
+             'Permission denied: cannot write to <dir>:' prefix; got: {msg}"
+        );
+        assert!(
+            msg.contains("Check directory permissions and try again."),
+            "ReadOnlyFilesystem must include remediation hint; got: {msg}"
+        );
+        assert!(
+            msg.contains(&os_err),
+            "ReadOnlyFilesystem must include the OS error string '{os_err}'; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_bc_2_7_012_classify_generic_fallback() {
+        use std::io::ErrorKind;
+        let os_err = std::io::Error::from(ErrorKind::Other).to_string();
+        let msg = classify_write_error(
+            ErrorKind::Other,
+            "/output/report.pdf",
+            "/output",
+            &os_err,
+        );
+        assert!(
+            msg.starts_with("Failed to write /output/report.pdf:"),
+            "Generic fallback must produce 'Failed to write <dest>:' prefix; got: {msg}"
+        );
+        assert!(
+            msg.contains(&os_err),
+            "Generic fallback must include the OS error string '{os_err}'; got: {msg}"
+        );
+        assert!(
+            msg.ends_with('.'),
+            "Generic fallback message must end with '.'; got: {msg}"
+        );
+        // Generic fallback must NOT include the discriminated remediation hints.
+        assert!(
+            !msg.contains("Free up disk space"),
+            "Generic fallback must NOT include 'Free up disk space'; got: {msg}"
+        );
+        assert!(
+            !msg.contains("Check directory permissions"),
+            "Generic fallback must NOT include 'Check directory permissions'; got: {msg}"
+        );
+    }
 }

--- a/tests/attachment_download.rs
+++ b/tests/attachment_download.rs
@@ -3715,11 +3715,7 @@ async fn test_bc_2_7_012_eacces_permission_denied_error_message() {
 
     // Create a directory that will be made non-writable.
     let restricted = TempDir::new().unwrap();
-    std::fs::set_permissions(
-        restricted.path(),
-        std::fs::Permissions::from_mode(0o555),
-    )
-    .unwrap();
+    std::fs::set_permissions(restricted.path(), std::fs::Permissions::from_mode(0o555)).unwrap();
 
     // Root-skip guard: probe whether the restriction actually binds.
     // Running as root (uid 0) bypasses permission bits → test would not exercise
@@ -3727,10 +3723,7 @@ async fn test_bc_2_7_012_eacces_permission_denied_error_message() {
     let probe = restricted.path().join(".probe_f5010");
     if std::fs::write(&probe, b"").is_ok() {
         let _ = std::fs::remove_file(&probe);
-        let _ = std::fs::set_permissions(
-            restricted.path(),
-            std::fs::Permissions::from_mode(0o755),
-        );
+        let _ = std::fs::set_permissions(restricted.path(), std::fs::Permissions::from_mode(0o755));
         eprintln!(
             "test_bc_2_7_012_eacces_permission_denied_error_message: SKIPPED \
              (write into 0o555 dir succeeded — running as root)"
@@ -3779,10 +3772,7 @@ async fn test_bc_2_7_012_eacces_permission_denied_error_message() {
         .unwrap();
 
     // Restore permissions so TempDir::Drop can remove the directory.
-    let _ = std::fs::set_permissions(
-        restricted.path(),
-        std::fs::Permissions::from_mode(0o755),
-    );
+    let _ = std::fs::set_permissions(restricted.path(), std::fs::Permissions::from_mode(0o755));
 
     let stderr = String::from_utf8_lossy(&output.stderr);
 

--- a/tests/attachment_download.rs
+++ b/tests/attachment_download.rs
@@ -1314,10 +1314,13 @@ async fn test_bc_2_7_012_error_taxonomy() {
         s.contains("Could not reach"),
         "network error stderr must contain 'Could not reach' — got: {s}"
     );
-    // Note: ENOSPC and EACCES are documented in BC-2.7.012 but are not deterministically
-    // triggerable in CI. Their canonical strings are:
-    //   ENOSPC → exit 1 + "Disk full: not enough space to write <path>"
-    //   EACCES → exit 1 + "Permission denied: cannot write to <dir>"
+    // ENOSPC: not deterministically triggerable in CI (requires filling a real disk).
+    // Its canonical string is tested at the pure-classifier level inside
+    // src/cli/issue/attachments.rs::tests (test_bc_2_7_012_classify_storage_full_*
+    // and test_bc_2_7_012_classify_quota_exceeded_*).
+    //
+    // EACCES: covered by the dedicated integration test below —
+    // test_bc_2_7_012_eacces_permission_denied_error_message (FIX-F5-010).
 }
 
 // ---------------------------------------------------------------------------
@@ -3686,5 +3689,145 @@ async fn test_f5_r3_001_download_id_404_canonical_only_no_jira_body() {
         !stderr.contains(SENTINEL),
         "F5-R3-001 RED: download --id 404 must NOT surface the Jira error body \
          (BC-2.7.012 canonical-only); sentinel found in stderr: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FIX-F5-010 — BC-2.7.012 v1.3.102: EACCES permission-denied disk-write error
+// ---------------------------------------------------------------------------
+
+/// BC-2.7.012 / FIX-F5-010: downloading to a non-writable directory → exit 1
+/// with `Permission denied: cannot write to <dir>: <os_error>. Check directory
+/// permissions and try again.` AND no `tmp_` leak in stderr.
+///
+/// Unix-only (`chmod 0o555` semantics). Skipped cleanly when running as root
+/// (uid 0) because root bypasses directory permission bits — detected by
+/// probing whether a write into the restricted dir actually fails.
+///
+/// RED state: current `stream_to_file` emits
+/// `Error: failed to create temp file /dir/tmp_<hex>: Permission denied (os error 13)`
+/// which fails assertions (b) "Permission denied: cannot write to", (d) remediation
+/// hint, and (e) tmp_-leak pin.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_bc_2_7_012_eacces_permission_denied_error_message() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Create a directory that will be made non-writable.
+    let restricted = TempDir::new().unwrap();
+    std::fs::set_permissions(
+        restricted.path(),
+        std::fs::Permissions::from_mode(0o555),
+    )
+    .unwrap();
+
+    // Root-skip guard: probe whether the restriction actually binds.
+    // Running as root (uid 0) bypasses permission bits → test would not exercise
+    // the EACCES path → skip rather than emit a false GREEN.
+    let probe = restricted.path().join(".probe_f5010");
+    if std::fs::write(&probe, b"").is_ok() {
+        let _ = std::fs::remove_file(&probe);
+        let _ = std::fs::set_permissions(
+            restricted.path(),
+            std::fs::Permissions::from_mode(0o755),
+        );
+        eprintln!(
+            "test_bc_2_7_012_eacces_permission_denied_error_message: SKIPPED \
+             (write into 0o555 dir succeeded — running as root)"
+        );
+        return;
+    }
+
+    let cache = TempDir::new().unwrap();
+    let config = TempDir::new().unwrap();
+    let server = MockServer::start().await;
+
+    // Step-1: attachment metadata GET.
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/attachment/77777"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "77777",
+            "filename": "eacces_test.bin",
+            "size": 4,
+            "mimeType": "application/octet-stream",
+            "content": format!("{}/rest/api/3/attachment/content/77777", server.uri()),
+        })))
+        .mount(&server)
+        .await;
+
+    // Step-2: attachment content GET (small body; stream_to_file hits EACCES on
+    // File::create before writing any bytes).
+    Mock::given(method("GET"))
+        .and(path("/rest/api/3/attachment/content/77777"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(b"data"))
+        .mount(&server)
+        .await;
+
+    let out_path = restricted.path().join("eacces_test.bin");
+    let output = jr_cmd_with_xdg(&server.uri(), cache.path(), config.path())
+        .args([
+            "issue",
+            "attachment",
+            "download",
+            "EACCES-1",
+            "--id",
+            "77777",
+            "--out",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    // Restore permissions so TempDir::Drop can remove the directory.
+    let _ = std::fs::set_permissions(
+        restricted.path(),
+        std::fs::Permissions::from_mode(0o755),
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // (a) Must exit 1 (write failure, not panic / exit 101).
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "BC-2.7.012 EACCES: must exit 1; got {:?}\nstderr: {stderr}",
+        output.status.code()
+    );
+
+    // (b) Must contain the "Permission denied: cannot write to" prefix.
+    //
+    // RED: current code emits "Error: failed to create temp file /dir/tmp_<hex>: …"
+    assert!(
+        stderr.contains("Permission denied: cannot write to "),
+        "BC-2.7.012 EACCES: stderr must contain \
+         'Permission denied: cannot write to '; got: {stderr}"
+    );
+
+    // (c) Must name the FINAL destination parent directory (not the tmp_ path).
+    //
+    // RED: current code names the tmp_<hex> file in the path, not the directory alone.
+    let dir_str = restricted.path().to_str().unwrap();
+    assert!(
+        stderr.contains(dir_str),
+        "BC-2.7.012 EACCES: stderr must contain the restricted dir path '{dir_str}'; \
+         got: {stderr}"
+    );
+
+    // (d) Must include the remediation hint (BC-2.7.012 table).
+    //
+    // RED: current code has no remediation hint.
+    assert!(
+        stderr.contains("Check directory permissions and try again."),
+        "BC-2.7.012 EACCES: stderr must contain remediation hint \
+         'Check directory permissions and try again.'; got: {stderr}"
+    );
+
+    // (e) Must NOT leak the internal tmp_<hex> path (tmp-path-leak pin).
+    //
+    // RED: current code leaks "tmp_<16 hex chars>" in the error message.
+    assert!(
+        !stderr.contains("tmp_"),
+        "BC-2.7.012 EACCES: stderr must NOT contain 'tmp_' (internal temp path \
+         must not be surfaced to the user); got: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary

Implements the disk-write error taxonomy pinned by BC-2.7.012 (previously specified but never implemented — F5-R5-001 HIGH finding). Fixes a tmp-path leak at all four I/O sites: callers now see the intended destination path, not an internal `tmp_<hex>` handle. Research backing: `.factory/research/f5-r5-001-disk-error-taxonomy-2026-07-24.md` (HIGH confidence, peer-CLI hybrid pattern per GNU/clig.dev standards).

## Finding

| Finding | Severity | Description | Fix |
|---------|----------|-------------|-----|
| F5-R5-001 | HIGH | BC-2.7.012 v1.3.102 pinned three disk-error message strings that were never implemented — `stream_to_file` emitted raw `std::io` error text leaking the internal `tmp_<hex>` path. Research confirmed hybrid `ErrorKind`-based taxonomy (StorageFull/QuotaExceeded → disk-full message; PermissionDenied/ReadOnlyFilesystem → permission message; `_` fallback) is correct for the GNU/clig.dev standard. Both spec and code amended together (spec v1.3.102, factory commit b5ec1fa6). | `classify_write_error(kind, dest_display, dir_display, os_err) → String` pure classifier + wiring at all four I/O sites in `stream_to_file` (File::create, write_all, flush, rename); final-dest path displayed via `display_sanitize_filename` |

## Error Message Taxonomy (BC-2.7.012 v1.3.103)

| `ErrorKind` | Emitted message |
|-------------|-----------------|
| `StorageFull` \| `QuotaExceeded` | `Disk full: not enough space to write <dest>: <os_err>. Free up disk space and try again.` |
| `PermissionDenied` \| `ReadOnlyFilesystem` | `Permission denied: cannot write to <dir> (writing <dest>): <os_err>. Check directory permissions and try again.` |
| `_` (fallback) | `Failed to write <dest>: <os_err>.` |

`<dest>` is the final destination path (via `display_sanitize_filename` on the server-supplied filename portion — CWE-116). `<dir>` is the containing directory. `tmp_<hex>` never appears in user-visible output.

**Windows platform note (BC-2.7.012 v1.3.103):** On Windows, `rename(tmp, existing_directory)` returns `ErrorKind::PermissionDenied` (ERROR_ACCESS_DENIED) rather than EISDIR. The v1.3.102 PermissionDenied branch emitted only `<dir>`, which meant the destination filename was absent from the error on Windows. v1.3.103 adds `(writing <dest>)` parenthetical after `<dir>`, reconciling BC-2.7.007 P9-001 (`test_bc_2_7_007_rename_failure_error_display_sanitizes_filename` asserts sanitized filename present) with the directory-first intent of the PermissionDenied branch.

## Commit Map

| Commit | Content |
|--------|---------|
| `8a6867b3` | RED: 5 compile-RED unit tests (`classify_write_error` does not yet exist) + 1 assertion-RED EACCES integration test |
| `38d7898d` | `classify_write_error` classifier + `stream_to_file` wiring at all 3 I/O sites; `stream_to_file` rustdoc updated to cite BC-2.7.012 v1.3.102 |
| `6f2f6385` | flush advisory: route `file.flush().await` error through `classify_write_error`; `stream_to_file` rustdoc updated to "all four I/O sites" |
| `30f718d5` | BC-2.7.012 v1.3.103: PermissionDenied branch adds `(writing <dest>)` parenthetical; two unit tests updated; "three→four" comment NIT fixed |

## Test Evidence

**Unit tests** (`src/cli/issue/attachments.rs`, compile-RED in `8a6867b3`, green after `38d7898d`, updated in `30f718d5`):
- `test_bc_2_7_012_classify_storage_full_disk_full_prefix`
- `test_bc_2_7_012_classify_quota_exceeded_disk_full_prefix`
- `test_bc_2_7_012_classify_permission_denied_perm_prefix`
- `test_bc_2_7_012_classify_read_only_filesystem_perm_prefix`
- `test_bc_2_7_012_classify_generic_fallback`

**Integration test** (`tests/attachment_download.rs`, `#[cfg(unix)]`):
- `test_bc_2_7_012_eacces_permission_denied_error_message` — writes to a `chmod 0o555` directory; asserts (a) exit 1, (b) canonical "Permission denied: cannot write to" prefix present, (c) parent dir path in stderr, (d) remediation hint "Check directory permissions and try again.", (e) `tmp_` absent from stderr

**Cross-platform regression test** (`tests/attachment_download.rs`):
- `test_bc_2_7_007_rename_failure_error_display_sanitizes_filename` — rename to pre-existing directory; asserts display-sanitized filename present in error (P9-001); previously failed on Windows CI (PermissionDenied branch omitted filename)

Full suite: `cargo test` — 0 failures; `cargo clippy --all-targets -- -D warnings` — clean; `cargo fmt --all -- --check` — clean.

## Spec Traceability

| Spec | Version | Change |
|------|---------|--------|
| BC-2.7.012 disk-write error taxonomy | v1.3.103 | PermissionDenied branch adds `(writing <dest>)` parenthetical to ensure filename appears on all platforms including Windows (reconciles P9-001); factory amended @ 7ed8f7f2 |
| CWE-116 display sanitization | — | `display_sanitize_filename` applied to server-supplied filename portion of `<dest>` in all branches |

Closes no issue directly — F5 round-5 for #576 attachment CRUD adversarial surface.