### PR TITLE
docs(test): sync classifier doc-fallout from #649 + tighten EACCES dest assertion (FIX-F5-011, F5 round for #576)

### DIFF
--- a/src/cli/issue/attachments.rs
+++ b/src/cli/issue/attachments.rs
@@ -589,8 +589,8 @@ fn batch_path_is_within_dir(
 
 /// Classify a disk-write `io::Error` into a user-friendly discriminated message.
 ///
-/// **BC-2.7.012 v1.3.102** — used by all four I/O sites in `stream_to_file`
-/// (`File::create`, `write_all`, `rename`) so that single-mode (propagate → exit 1)
+/// **BC-2.7.012 v1.3.104** — used by all four I/O sites in `stream_to_file`
+/// (`File::create`, `write_all`, `flush`, `rename`) so that single-mode (propagate → exit 1)
 /// and batch-mode (per-file fail-soft warning) paths both benefit from one chokepoint.
 ///
 /// # Branch mapping
@@ -677,7 +677,7 @@ fn write_error_display_strings(final_path: &std::path::Path) -> (String, String)
 /// On ANY error after temp-file creation, the temp file is deleted before returning
 /// the error (cleanup guarantee for BC-2.7.007 EC-2.7.007-4).
 ///
-/// **Write-error classification (BC-2.7.012 v1.3.102):** all four I/O sites
+/// **Write-error classification (BC-2.7.012 v1.3.104):** all four I/O sites
 /// (`File::create`, `write_all`, `flush`, `rename`) route through `classify_write_error` to
 /// emit discriminated messages (`Disk full: …`, `Permission denied: …`, generic
 /// fallback) that name the **final destination** (never the internal `tmp_<hex>` path).
@@ -692,7 +692,7 @@ async fn stream_to_file(
     let token: u64 = rand::random();
     let tmp_path = parent.join(format!("tmp_{token:016x}"));
 
-    // BC-2.7.012 v1.3.102: pre-compute display strings shared across all four I/O
+    // BC-2.7.012 v1.3.104: pre-compute display strings shared across all four I/O
     // error sites below. CWE-116 / BC-2.7.011: display-sanitize the server-supplied
     // filename portion; the operator-controlled parent directory is rendered verbatim.
     let (final_dir_display, final_dest_display) = write_error_display_strings(final_path);
@@ -3249,16 +3249,15 @@ mod tests {
     }
 
     // ===========================================================================
-    // BC-2.7.012 v1.3.102 — classify_write_error pure classifier unit tests
-    // FIX-F5-010 RED GATE
+    // BC-2.7.012 v1.3.103+ — classify_write_error pure classifier unit tests
+    // GREEN — implemented in FIX-F5-010 / PR #649
     //
-    // These tests call `classify_write_error`, which does NOT yet exist in this
-    // file. They will FAIL TO COMPILE until the implementer adds the function.
+    // `classify_write_error` is implemented in this file.  These tests pin the
+    // three classifier branches.  The PermissionDenied / ReadOnlyFilesystem
+    // branch uses the v1.3.103 shape that adds the `(writing <dest>)` parenthetical
+    // after `<dir>` — see inline `// BC-2.7.012 v1.3.103` annotations below.
     //
-    // Compile failure IS the RED state — the strongest revert-pin. After the
-    // implementation, all tests in this block must pass without modification.
-    //
-    // Implementer contract (from BC-2.7.012, research doc f5-r5-001):
+    // Function contract (BC-2.7.012, research doc f5-r5-001):
     //   fn classify_write_error(
     //       kind: std::io::ErrorKind,
     //       dest_display: &str,   // final destination path (display-safe)

--- a/tests/attachment_download.rs
+++ b/tests/attachment_download.rs
@@ -3693,21 +3693,16 @@ async fn test_f5_r3_001_download_id_404_canonical_only_no_jira_body() {
 }
 
 // ---------------------------------------------------------------------------
-// FIX-F5-010 — BC-2.7.012 v1.3.102: EACCES permission-denied disk-write error
+// FIX-F5-010 — BC-2.7.012 v1.3.104: EACCES permission-denied disk-write error
 // ---------------------------------------------------------------------------
 
-/// BC-2.7.012 / FIX-F5-010: downloading to a non-writable directory → exit 1
-/// with `Permission denied: cannot write to <dir>: <os_error>. Check directory
-/// permissions and try again.` AND no `tmp_` leak in stderr.
+/// BC-2.7.012 v1.3.103 / FIX-F5-010: downloading to a non-writable directory → exit 1
+/// with `Permission denied: cannot write to <dir> (writing <dest>): <os_error>. Check
+/// directory permissions and try again.` AND no `tmp_` leak in stderr.
 ///
 /// Unix-only (`chmod 0o555` semantics). Skipped cleanly when running as root
 /// (uid 0) because root bypasses directory permission bits — detected by
 /// probing whether a write into the restricted dir actually fails.
-///
-/// RED state: current `stream_to_file` emits
-/// `Error: failed to create temp file /dir/tmp_<hex>: Permission denied (os error 13)`
-/// which fails assertions (b) "Permission denied: cannot write to", (d) remediation
-/// hint, and (e) tmp_-leak pin.
 #[cfg(unix)]
 #[tokio::test]
 async fn test_bc_2_7_012_eacces_permission_denied_error_message() {
@@ -3785,8 +3780,6 @@ async fn test_bc_2_7_012_eacces_permission_denied_error_message() {
     );
 
     // (b) Must contain the "Permission denied: cannot write to" prefix.
-    //
-    // RED: current code emits "Error: failed to create temp file /dir/tmp_<hex>: …"
     assert!(
         stderr.contains("Permission denied: cannot write to "),
         "BC-2.7.012 EACCES: stderr must contain \
@@ -3794,8 +3787,6 @@ async fn test_bc_2_7_012_eacces_permission_denied_error_message() {
     );
 
     // (c) Must name the FINAL destination parent directory (not the tmp_ path).
-    //
-    // RED: current code names the tmp_<hex> file in the path, not the directory alone.
     let dir_str = restricted.path().to_str().unwrap();
     assert!(
         stderr.contains(dir_str),
@@ -3804,8 +3795,6 @@ async fn test_bc_2_7_012_eacces_permission_denied_error_message() {
     );
 
     // (d) Must include the remediation hint (BC-2.7.012 table).
-    //
-    // RED: current code has no remediation hint.
     assert!(
         stderr.contains("Check directory permissions and try again."),
         "BC-2.7.012 EACCES: stderr must contain remediation hint \
@@ -3813,11 +3802,17 @@ async fn test_bc_2_7_012_eacces_permission_denied_error_message() {
     );
 
     // (e) Must NOT leak the internal tmp_<hex> path (tmp-path-leak pin).
-    //
-    // RED: current code leaks "tmp_<16 hex chars>" in the error message.
     assert!(
         !stderr.contains("tmp_"),
         "BC-2.7.012 EACCES: stderr must NOT contain 'tmp_' (internal temp path \
          must not be surfaced to the user); got: {stderr}"
+    );
+
+    // (f) BC-2.7.012 v1.3.103 shape: dest basename must appear in the `(writing <dest>)`
+    //     parenthetical of the PermissionDenied branch.
+    assert!(
+        stderr.contains("eacces_test.bin"),
+        "BC-2.7.012 v1.3.103 EACCES: stderr must contain dest basename 'eacces_test.bin' \
+         in (writing <dest>) parenthetical; got: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary

Three F5 round-7 doc/comment findings from post-#649 review (F5-R7-001/002/003). No production behavior change — doc, comment, and test-strengthening only.

- **F5-R7-001 (`src/cli/issue/attachments.rs` — `classify_write_error` rustdoc):** The four-site enumeration was missing `flush` (listed only `File::create`, `write_all`, `rename`). Added `flush` to match the actual implementation; bumped version cite from v1.3.102 → v1.3.104.
- **F5-R7-002 (`src/cli/issue/attachments.rs` — classifier unit-test block banner):** Banner still read the RED-gate narrative ("does NOT yet exist… FAIL TO COMPILE"). Replaced with a post-GREEN statement noting the function was implemented in FIX-F5-010/PR #649; corrected version cite to v1.3.103+ (where the `(writing <dest>)` parenthetical applies); stripped `// RED:` inline comments from assertions (b)–(e).
- **F5-R7-003 (`tests/attachment_download.rs` — `test_bc_2_7_012_eacces_permission_denied_error_message`):** Docstring still described the v1.3.102 error shape and included a RED-state description of the pre-fix output. Updated docstring to v1.3.103 shape; stripped RED-state narrative; added assertion **(f)** that `stderr.contains("eacces_test.bin")` — verifying the dest basename appears in the `(writing <dest>)` parenthetical introduced by BC-2.7.012 v1.3.103 (the Windows cross-platform fix in commit 30f718d5).
- **Sweep:** Two remaining v1.3.102 version cites in `stream_to_file` rustdoc and inline comment updated to v1.3.104; EACCES section-comment version cite updated from v1.3.102 → v1.3.104.

## Test plan

- [ ] `cargo test --lib` — 1100 unit tests pass (gates green locally)
- [ ] `cargo test --test attachment_download` — 39 tests pass including `test_bc_2_7_012_eacces_permission_denied_error_message` with new assertion (f)
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo fmt --all -- --check` — clean
- [ ] CI: all jobs green, mutation testing 0 missed (doc/comment-only change; no new production code paths)

Closes: FIX-F5-011 (F5 round-7 doc-fallout findings)
Related: #649 (BC-2.7.012 v1.3.102/103 implementation)