### PR TITLE
refactor(issue): remove unreachable single-mode branch from compute_default_output_path (FIX-F5-013, F5 round for #576)

### DIFF
--- a/src/cli/issue/attachments.rs
+++ b/src/cli/issue/attachments.rs
@@ -516,38 +516,34 @@ pub fn sanitize_attachment_filename(name: &str) -> Option<String> {
     Some(stripped.to_string())
 }
 
-/// Compute the default output path for a downloaded attachment (BC-2.7.010).
+/// Compute the default output path for a **batch** downloaded attachment (BC-2.7.010).
 ///
-/// **Batch** (`--all` / `--newest`):
+/// **Batch** (`--all` / `--newest`) only:
 /// `<base_dir>/<sha1_of_id(40 hex)>_<sanitize_attachment_filename(filename) or id>`.
 /// Combined length guaranteed ≤ 255 bytes (41 + 214 = 255 ≤ NAME_MAX; ADV-010).
 /// When `sanitize_attachment_filename` returns `None` (degenerate name), uses
 /// `<sha1_of_id>_<attachment_id>` as the basename.
 ///
-/// **Single** (`--id`):
-/// Bare `sanitize_attachment_filename(filename)` in `base_dir` (no SHA-1 prefix).
-/// When `sanitize_attachment_filename` returns `None`, uses bare `attachment_id`.
+/// # Single-mode path is NOT owned here
+///
+/// Single-mode (`--id`) path construction is INLINE in `handle_single_download` and
+/// includes the SEC-576-001 Windows device-name escape (`_CON`, `_NUL`, …) — do NOT
+/// consolidate it into this fn without moving that escape (F5-R11-001).
 ///
 /// # Arguments
 /// - `base_dir`      — directory for the output file.
 /// - `attachment_id` — numeric attachment ID from the Jira API (trusted per SEC-576-008).
 /// - `filename`      — raw Jira-supplied filename.
-/// - `is_batch`      — `true` → batch path with SHA-1 prefix; `false` → single bare path.
 fn compute_default_output_path(
     base_dir: &std::path::Path,
     attachment_id: &str,
     filename: &str,
-    is_batch: bool,
 ) -> std::path::PathBuf {
     let sanitized =
         sanitize_attachment_filename(filename).unwrap_or_else(|| attachment_id.to_string());
 
-    if is_batch {
-        let hash = sha1_hex(attachment_id);
-        base_dir.join(format!("{hash}_{sanitized}"))
-    } else {
-        base_dir.join(sanitized)
-    }
+    let hash = sha1_hex(attachment_id);
+    base_dir.join(format!("{hash}_{sanitized}"))
 }
 
 /// Defense-in-depth containment check for the batch download loop (BC-2.7.011 / F5-R1-001).
@@ -1028,7 +1024,7 @@ async fn handle_batch_download(
             );
         }
 
-        let final_path = compute_default_output_path(&base_dir, &att.id, &att.filename, true);
+        let final_path = compute_default_output_path(&base_dir, &att.id, &att.filename);
 
         // BC-2.7.011 defense-in-depth: verify the parent directory of final_path equals
         // (or is inside) resolved_dir. sanitize_attachment_filename (VP-576-001 proptest)

--- a/tests/attachment_download.rs
+++ b/tests/attachment_download.rs
@@ -2597,7 +2597,7 @@ async fn test_bc_2_7_stream_to_file_failure_increments_fail_count() {
     let att_filename = "payload.bin";
 
     // Compute the batch output path: {sha1_hex(att_id)}_{sanitized_filename}.
-    // Mirrors compute_default_output_path(is_batch=true) in src/cli/issue/attachments.rs.
+    // Mirrors compute_default_output_path in src/cli/issue/attachments.rs (batch-only).
     let hash: String = sha1::Sha1::new()
         .chain_update(att_id.as_bytes())
         .finalize()


### PR DESCRIPTION
## Summary

**F5-R11-001:** `compute_default_output_path` had a dead `is_batch: bool` parameter and an unreachable `else` branch for single-mode path construction. The only production caller (`handle_batch_download`) always passed `true`; `handle_single_download` computes its path entirely inline (where the SEC-576-001 Windows device-name escape lives). The dead branch was a latent security-regression trap: the rustdoc implied both modes were managed here, which could invite a future consolidation that silently dropped the device-name escape from single-mode downloads.

**Changes (behavior-preserving):**

- `src/cli/issue/attachments.rs` — `compute_default_output_path`:
  - Remove `is_batch: bool` parameter; function is now batch-only.
  - Rewrite rustdoc to batch-only contract.
  - Add explicit **"Single-mode path is NOT owned here"** section naming `handle_single_download` and SEC-576-001 as the consolidation guard (F5-R11-001).
  - Remove the dead `else` branch.
- `src/cli/issue/attachments.rs` — `handle_batch_download` call site: drop `true` argument.
- `tests/attachment_download.rs` — remove stale `is_batch=true` reference from a test comment.

## Security note

The SEC-576-001 Windows device-name escape (`_CON`, `_NUL`, `_COM1`, …) lives inline in `handle_single_download` and is unaffected by this change. The new guard note in the rustdoc prevents a future consolidation from accidentally dropping it.

## Test plan

- [ ] `cargo test --lib` — 1100 unit tests pass
- [ ] `cargo test --test attachment_download` — 39 tests pass
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo fmt --all -- --check` — clean
- [ ] CI: all jobs green; mutation testing catches any inadvertent behavior change

Closes: FIX-F5-013 (F5-R11-001)
Related: #576, SEC-576-001 (Windows device-name escape)