### PR TITLE
chore: release v0.6.0-dev.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to jr will be documented here.
 
 ## [Unreleased]
 
+## [0.6.0-dev.11] - 2026-07-25
+
 ### Fixed
 
 - **`jr issue attachment download` — integer id in metadata response (FIX-576-DL, #576):**
@@ -13,6 +15,56 @@ All notable changes to jr will be documented here.
   validation run (S-576-6, run 30031724733), which produced `invalid type: integer \`10008\`,
   expected a string`. `AttachmentMetadata.id` now uses `deserialize_string_or_int_as_string`
   to accept both forms; `AttachmentObject.id` (list path) is unaffected.
+
+- **`jr issue attachment download` — `--newest` RFC 3339 parser accepts any fractional-second precision (FIX-F5-006, #644):**
+  The `%.3f` strptime specifier in the `--newest` sort path accepted only exactly 0 or 3
+  fractional-second digits; timestamps with 1, 2, or 4+ digits (all valid RFC 3339) failed to
+  parse and sorted last, causing `--newest N` to select older attachments over genuinely-newer
+  ones. The sort path now uses the same relaxed `chrono::DateTime` RFC 3339 parser already
+  used by the `--older-than` path.
+
+- **`jr issue attachment delete` — interactive single-AID 404 surfaces Jira error body (FIX-F5-006, #644):**
+  The interactive confirmation gate (`handle_attachment_delete`) now appends the raw Jira error
+  body to the canonical `"Attachment <AID> not found or not accessible."` prefix (DEC-168
+  body-surfacing contract). The download path (`handle_single_download`) retains
+  canonical-only output per BC-2.7.012.
+
+- **`jr issue attachment upload` — SEC-576-004 Content-Disposition guard extended to `"` (FIX-F5-006, #644):**
+  A double-quote (`"`) in a server-supplied filename was not mapped to `_` before passing to
+  `Part::file_name()`, allowing it to prematurely terminate the `filename=` value and expose
+  subsequent Content-Disposition data to parser misreading. The guard now maps `\r`, `\n`, `\0`,
+  and `"` to `_` in both the platform and JSM upload paths (CWE-93).
+
+- **`jr issue attachment upload` — JSM step-2 transport errors report connectivity hint, not expired-ID hint (FIX-F5-006, #644):**
+  Network errors from `post_request_attachment` (step 2 of the JSM upload flow) previously emitted
+  `ApiError { status: 0 }` and the "Temporary attachment IDs may have expired" retry hint, which
+  misled users on connectivity failures. Transport errors now map to `JrError::NetworkError` with
+  a "Could not reach {host} — check your connection" message; the retry hint is scoped to HTTP
+  error branches only.
+
+- **`jr issue attachment upload` — SEC-576-004 Content-Disposition guard extended to `\` (FIX-F5-007, #646):**
+  A backslash (`\`) in a server-supplied filename was not mapped to `_`. As the RFC 2616
+  quoted-string escape character, a stray `\` in a `filename=` value causes parsers to misread
+  the next character as an escaped sequence. The guard now maps `\r`, `\n`, `\0`, `"`, and `\`
+  to `_` in both the platform and JSM upload paths (CWE-93 symmetry).
+
+- **`jr issue attachment download` — `--id` 404 message is canonical-only; Jira body not leaked (FIX-F5-008, #647):**
+  A prior fix inadvertently moved Jira error body appending into `get_attachment_metadata`
+  itself, causing the download path to include the raw Jira body in its 404 message. The
+  BC-2.7.012 asymmetry is restored: `handle_single_download` emits the canonical-only prefix
+  `"Attachment <id> not found or not accessible."`; the delete interactive gate continues to
+  append `\n{body}` per DEC-168. Also fixed: `batch_path_is_within_dir` now canonicalizes
+  the resolved directory before the containment check, preventing false rejections on paths
+  containing `..` components.
+
+- **`jr issue attachment download` — disk-write errors classified with remediation hints (FIX-F5-010, #649):**
+  All I/O failure sites in the streaming download path (file create, write, flush, rename) now
+  produce user-friendly error messages with remediation hints instead of raw OS error strings:
+  `StorageFull`/`QuotaExceeded` → `"Disk full: not enough space to write <dest>: <os_err>. Free up disk space and try again."`;
+  `PermissionDenied`/`ReadOnlyFilesystem` → `"Permission denied: cannot write to <dir>: <os_err>. Check directory permissions and try again."`;
+  all other errors → `"Failed to write <dest>: <os_err>."`.
+  All three sites now display the final destination path rather than the internal
+  `tmp_<hex>` staging path that was previously leaked in error messages.
 
 ### Added
 
@@ -31,7 +83,6 @@ All notable changes to jr will be documented here.
   (VP-576-005). Cancel → exit 0 + `{"cancelled":true,"uploaded":false}` JSON; EOF → exit 130.
   Step-2 error taxonomy (BC-3.9.006): 401 → exit 2; 403 → exit 1; other 4xx → exit 64; 5xx → exit 1;
   all append retry hint. `--dry-run --public` adds `"visibility":"public"` to `wouldUpload` entries (EC-3.9.020-7).
-  feat(issue): attachment upload --public/--internal JSM visibility + servicedeskapi two-step (#576)
 
 ## [0.6.0-dev.10] - 2026-07-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "jr"
-version = "0.6.0-dev.10"
+version = "0.6.0-dev.11"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jr"
-version = "0.6.0-dev.10"
+version = "0.6.0-dev.11"
 edition = "2024"
 description = "A fast CLI for Jira Cloud"
 repository = "https://github.com/Zious11/jira-cli"


### PR DESCRIPTION
## Release v0.6.0-dev.11

Dev release closing **SOH-ATTACHMENTS-1** wave (F7 APPROVED, DEC-186). Bundles wave PRs #630–#643 (attachment feature, #576/#585) and all seven F5 adversarial-refinement fix PRs (#644–#652).

### What's in this release

**Attachment download** (`jr issue attachment download`):
- `--newest` RFC 3339 parser now accepts any fractional-second precision (was: exactly 0 or 3 digits only); timestamps with 1, 2, or 4+ digits no longer sort last. (FIX-F5-006, #644)
- `--id` 404 message is canonical-only — Jira error body no longer leaked in download path per BC-2.7.012. Also: `batch_path_is_within_dir` canonicalizes the resolved directory before containment check, preventing false rejections on `..`-containing paths. (FIX-F5-008, #647)
- Disk-write errors (file create, write, flush, rename) now produce classified messages with remediation hints (`Disk full: …`, `Permission denied: … (writing <dest>): …`, generic fallback) naming the final destination instead of the internal `tmp_<hex>` staging path. (FIX-F5-010, #649)

**Attachment delete** (`jr issue attachment delete`):
- Interactive single-AID 404 now appends the raw Jira error body to the canonical prefix (DEC-168 body-surfacing contract). (FIX-F5-006, #644)

**Attachment upload** (`jr issue attachment upload`):
- SEC-576-004 Content-Disposition guard extended: `"` (FIX-F5-006, #644) and `\` (FIX-F5-007, #646) now mapped to `_` in both platform and JSM upload paths (CWE-93). Full guard: `\r`, `\n`, `\0`, `"`, `\` → `_`.
- JSM step-2 transport errors now map to `JrError::NetworkError` with connectivity hint; the "IDs may have expired" retry hint is scoped to HTTP error branches only. (FIX-F5-006, #644)

**Fixes, tests, and doc hardening** (F5 rounds 7–11):
- Classifier doc-fallout from #649 synced: four-site enumeration, post-GREEN narratives, v1.3.103+ shapes. (FIX-F5-011, #650)
- EC-3.9.006-7 step-2 429 no-retry asymmetry regression-pinned with exactly-one-POST trip-wire. (FIX-F5-012, #651)
- Dead unreachable single-mode branch removed from `compute_default_output_path`; SEC-576-001 consolidation guard note added. (FIX-F5-013, #652)

### Related issues
- Closes wave: #576 (attachment feature), #585 (attachment upload)
- F5 fix PRs: #644, #645, #646, #647, #648, #649, #650, #651, #652

### CHANGELOG excerpt

```
## [0.6.0-dev.11] - 2026-07-25
```
_(Full entry in CHANGELOG.md)_

## Test plan

- [ ] `cargo test --lib` — 1100 unit tests pass
- [ ] `cargo test --test '*'` — all integration tests pass
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo fmt --all -- --check` — clean
- [ ] CI: all jobs green; version in Cargo.toml matches tag intent