### PR TITLE
ci(e2e): allowlist Atlassian media/CDN egress for attachment content redirect (FIX-E2E-EGRESS)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,12 +37,27 @@ jobs:
           egress-policy: block
           # Allowlist seeded from expected endpoints — confirm/tune on first live run.
           # Fail-closed: an incomplete list fails the job rather than leaking credentials.
-          # No real subdomain is hard-coded; the Atlassian target is matched by wildcard.
           # Includes rust-cache/Actions-cache endpoints (*.actions.githubusercontent.com
           # for the cache service runtime, *.blob.core.windows.net for Azure-backed
-          # artifact blobs). Exact CDN hostnames can vary; block still fail-closes safely
-          # if an unlisted host appears — the non-blocking job fails rather than leaking
-          # the credential.
+          # artifact blobs).
+          #
+          # FIX-E2E-EGRESS (RCA): GET /rest/api/3/attachment/content/{id} returns a
+          # 302/303 redirect whose Location points at a pre-signed media URL on a
+          # different host (api.media.atlassian.com or AWS S3, per research §1b at
+          # .factory/research/issue-576-attachments-api-2026-07-15.md). harden-runner
+          # egress-policy: block killed that cross-host redirect hop, causing
+          # test_e2e_attachment_platform_roundtrip to fail 3/4 runs:
+          #   runs 30043437491, 30132346956, 30164583719 — redirect blocked
+          #   run  30150068145 — nightly passed (Atlassian served bytes directly, no redirect)
+          # Fix: allowlist the two redirect targets explicitly.
+          #   api.media.atlassian.com:443 — Atlassian's media/CDN API (concrete hostname
+          #     from research §1b; preferred over the broader *.atlassian.com wildcard).
+          #   *.amazonaws.com:443 — AWS S3 pre-signed URL targets (wildcard required;
+          #     exact region/bucket subdomain varies, e.g. s3-us-east-1.amazonaws.com,
+          #     bucket.s3.amazonaws.com). May be narrowed to specific regions after
+          #     observing step-security dashboard data on a successful run.
+          # Note: Authorization header is correctly stripped by reqwest on the cross-host
+          # hop (GHSA-9857-6MW7-FQ2M behaviour is correct; CDN authenticates via signed URL).
           allowed-endpoints: >
             github.com:443
             api.github.com:443
@@ -51,6 +66,8 @@ jobs:
             *.actions.githubusercontent.com:443
             *.blob.core.windows.net:443
             *.atlassian.net:443
+            api.media.atlassian.com:443
+            *.amazonaws.com:443
             static.crates.io:443
             index.crates.io:443
             crates.io:443


### PR DESCRIPTION
## Summary

**Root cause (HIGH confidence):** `GET /rest/api/3/attachment/content/{id}` returns a 302/303 redirect to a pre-signed media URL on a different host (`api.media.atlassian.com` or an AWS S3 hostname). The harden-runner `egress-policy: block` in `e2e.yml` killed this cross-host redirect hop, causing `test_e2e_attachment_platform_roundtrip` to fail intermittently.

**Evidence:**
- Failing: runs 30043437491, 30132346956, 30164583719 — harden-runner blocked the redirect target
- Passing: nightly run 30150068145 — Atlassian served attachment bytes directly without redirecting that time (no cross-host hop)

**Fix:** Two entries added to `allowed-endpoints` in `e2e.yml`:
- `api.media.atlassian.com:443` — concrete Atlassian media API hostname; documented redirect target per research `.factory/research/issue-576-attachments-api-2026-07-15.md §1b`; preferred over the broader `*.atlassian.com` wildcard.
- `*.amazonaws.com:443` — AWS S3 pre-signed URL targets; wildcard required because the exact region/bucket subdomain is not predictable (e.g. `s3-us-east-1.amazonaws.com`, `bucket.s3.amazonaws.com`). Narrowable to specific regions after observing step-security dashboard data on a successful run.

**Security posture:** Authorization header is correctly stripped by reqwest on the cross-host redirect hop (GHSA-9857-6MW7-FQ2M behavior is correct and intentional — CDN authenticates via the signed URL, not the original `Authorization` header). The `e2e` job holds live Jira API credentials; the `*.amazonaws.com` wildcard is the widest surface addition and is flagged for future narrowing.

**Verification:** This PR does not itself run the live E2E suite. Verification happens post-merge via a triggered `e2e.yml` workflow re-run against the updated allowlist.

## Changes

`.github/workflows/e2e.yml` only (+21/-4):
- Expanded `allowed-endpoints` with `api.media.atlassian.com:443` and `*.amazonaws.com:443`
- Updated inline comment block to document the RCA, failing run IDs, and narrowing note for `*.amazonaws.com`

## Test plan

- [ ] CI on this PR: all non-E2E jobs green (no live credentials needed; mutation testing 0 mutants for CI-only diff)
- [ ] Post-merge: trigger `e2e.yml` workflow re-run; `test_e2e_attachment_platform_roundtrip` should pass consistently

Related: #576, GHSA-9857-6MW7-FQ2M