### PR TITLE
fix(guard): close false-green gaps in check-spec-counts and claude_md_citations (POL-11)

### DIFF
--- a/scripts/check-spec-counts.sh
+++ b/scripts/check-spec-counts.sh
@@ -16,10 +16,12 @@ set -euo pipefail
 
 FACTORY=".factory/specs/prd"
 ERRORS=0
+BC_FILES_PROCESSED=0
 
 # Check each bc-N-*.md file
 for f in "$FACTORY"/bc-*.md; do
   [ -f "$f" ] || continue
+  BC_FILES_PROCESSED=$((BC_FILES_PROCESSED+1))
   actual=$(grep -c '^#### BC-' "$f" || true)
   declared=$(grep '^definitional_count:' "$f" | awk '{print $2}')
   if [ "$actual" != "$declared" ]; then
@@ -27,6 +29,14 @@ for f in "$FACTORY"/bc-*.md; do
     ERRORS=$((ERRORS+1))
   fi
 done
+
+# POL-11: coverage floor — the guard cannot pass silently when no bc files exist
+# (e.g. misconfigured worktree, wrong working directory, or empty spec directory).
+# Mirrors the behaviour of scripts/check-bc-no-numeric-test-counts.sh, exit 2.
+if [ "$BC_FILES_PROCESSED" -eq 0 ]; then
+  echo "ERROR: no bc-*.md files found in $FACTORY — nothing to validate" >&2
+  exit 2
+fi
 
 # Check nfr-catalog.md
 nfr_file="$FACTORY/nfr-catalog.md"
@@ -58,4 +68,4 @@ if [ "$ERRORS" -gt 0 ]; then
   echo "FAIL: $ERRORS spec count mismatch(es). Fix frontmatter or body before merging."
   exit 1
 fi
-echo "OK: all spec counts verified."
+echo "Check passed: $BC_FILES_PROCESSED bc files validated"

--- a/tests/claude_md_citations.rs
+++ b/tests/claude_md_citations.rs
@@ -405,6 +405,16 @@ fn find_line_ref_suffix(s: &str) -> Option<usize> {
 // Integration tests — VP-CITE-002
 // ---------------------------------------------------------------------------
 
+/// Coverage floor: floor(0.75 × N) where N=99 citations measured 2026-07-28.
+///
+/// If `extract_path_citations` regresses to return fewer paths (e.g. a regex change
+/// or CLAUDE.md's backtick convention shifts), the guard would still pass `dead.is_empty()`
+/// while validating nothing. This floor catches that case.
+///
+/// Recalibrate after intentional bulk removal from CLAUDE.md — increases never fire it.
+/// Mirrors the `FLOOR=231` pattern in `scripts/check-bc-citation-symbols.sh`.
+const CITATION_FLOOR: usize = 74; // floor(0.75 × 99); N=99 measured 2026-07-28
+
 /// BC-X.13.001 postcondition 1: guard is GREEN on develop HEAD.
 /// BC-X.13.001 postcondition 2: failure message is CI-CITE-001 verbatim
 ///   with real 1-based line numbers.
@@ -419,6 +429,19 @@ fn test_claude_md_citations_resolve_to_real_files() {
     let root = env!("CARGO_MANIFEST_DIR");
     // extract_path_citations returns Vec<(String, usize)> — (normalized_path, 1-based line)
     let citations = extract_path_citations(doc);
+
+    // POL-11 coverage floor: if the extractor regresses (e.g. returns []),
+    // `dead.is_empty()` would still pass having validated nothing.
+    // A low count means the extractor regressed, not that CLAUDE.md shrank.
+    assert!(
+        citations.len() >= CITATION_FLOOR,
+        "extract_path_citations returned only {} citations from CLAUDE.md (floor is {}). \
+         A count this low means the extractor regressed — check CLAUDE.md backtick \
+         conventions and the extract_path_citations pipeline.",
+        citations.len(),
+        CITATION_FLOOR
+    );
+
     // No is_off_working_branch_allowlisted call — .factory/ is excluded by
     // extract_path_citations dir-prefix filter (step (c)); no allowlist needed.
     let dead: Vec<(String, usize)> = citations


### PR DESCRIPTION
## Summary

Two pre-existing false-green defects in regression detectors, found by adversarial axis-5 positive-coverage review (POL-11). Both are **pre-existing** and **out-of-delta** relative to the active SOH-DX-1 cycle; this PR is independent of that bundle.

### Defect 1 — `scripts/check-spec-counts.sh` zero-files silent pass

**Root cause:** The loop `for f in "$FACTORY"/bc-*.md; do [ -f "$f" ] || continue` matched nothing on an empty or misconfigured directory, leaving `ERRORS=0`. The script then exited 0 having validated zero files — so if the `factory-artifacts` worktree was ever misconfigured or the bc files were renamed/relocated, CI would go green checking nothing.

**Fix:** Added `BC_FILES_PROCESSED` counter, incremented inside the loop. After the loop, if the counter is zero, the script prints `ERROR: no bc-*.md files found in .factory/specs/prd — nothing to validate` to stderr and exits 2. This mirrors the identical guard in `scripts/check-bc-no-numeric-test-counts.sh`. Updated the success message to include the count: `Check passed: N bc files validated`.

**RED/GREEN evidence:**
- RED (empty dir): old script printed `OK: all spec counts verified.`, exit 0. New script prints the ERROR message, exit 2.
- GREEN (real tree): new script prints `Check passed: 7 bc files validated`, exit 0.

**Note:** The optional-file WARNING/skip behavior for `nfr-catalog.md` and `holdout-scenarios.md` is preserved intentionally — those files may not always exist.

**CI context:** `.github/workflows/ci.yml` mounts `.factory` via `git worktree add .factory origin/factory-artifacts` before running these guards, so the zero-files check cannot fire spuriously in CI on a correctly configured run.

### Defect 2 — `tests/claude_md_citations.rs` vacuous pass on extractor regression

**Root cause:** The test asserted only `dead.is_empty()`, so if `extract_path_citations` ever regressed to returning `[]` (e.g., from a regex change or CLAUDE.md backtick-convention shift), the guard would pass with zero citations validated — a vacuous green.

**Fix:** Added `CITATION_FLOOR = 74` (floor(0.75 × 99), where N=99 was the measured citation count on 2026-07-28), inserted as a pre-check before the dead-path assertion. Mirrors the existing `FLOOR=231` convention in `scripts/check-bc-citation-symbols.sh`. The floor assertion message explicitly diagnoses the failure mode: "A count this low means the extractor regressed — check CLAUDE.md backtick conventions and the extract_path_citations pipeline."

**RED/GREEN evidence:**
- `cargo test --test claude_md_citations` → 61 passed, 0 failed.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (zero warnings)
- [x] `cargo test --test claude_md_citations` → 61 passed, 0 failed
- [ ] CI gate passes on `develop` (pending)