### PR TITLE
fix(ci): repin taiki-e/install-action from orphaned tag snapshots to v2.85.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@c93f4f9c67595668add93d3d6895795ce52d8c2d  # stable
         with:
           components: llvm-tools-preview
-      - uses: taiki-e/install-action@e5de28abeb52d916c5e5875d54b21a9e738b61ec  # cargo-llvm-cov
+      - uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e  # v2.85.4
+        with:
+          tool: cargo-llvm-cov
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v6
@@ -185,7 +187,7 @@ jobs:
           # Need full history so `git diff origin/<base_ref>...HEAD` can resolve the
           # base ref (used by --in-diff to scope mutation testing to changed lines).
           fetch-depth: 0
-      - uses: taiki-e/install-action@aae1387a167f5eee4267fe2946da57ae49a68770  # install-action v2.x
+      - uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e  # v2.85.4
         with:
           # Pin to cargo-mutants major v27 to protect the required gate's schema/exit-code
           # assumptions: v27 outcomes.json top-level summary keys


### PR DESCRIPTION
Both `taiki-e/install-action` pins in `ci.yml` point at commits that exist on no upstream branch, tag, or release: they are frozen snapshots of taiki-e's moving per-tool tags, dependabot cannot update them, and GitHub garbage-collecting the orphaned objects would break CI on a random future day. Full mechanism and evidence in #665; this is the install-action counterpart to the class already identified for dtolnay/rust-toolchain in #626.

## What changed

- Both pins move to the `v2.85.4` release tag SHA (`065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e`), which is reachable from upstream published history, so dependabot resumes managing install-action like the other pinned actions in this file.
- The coverage step gains `with: tool: cargo-llvm-cov`. It previously relied on the orphan snapshot's `default: cargo-llvm-cov`; a release SHA makes `tool:` required again, so without this line the step would fail on a missing input.
- The mutants step keeps `tool: cargo-mutants@27` and its schema/exit-code rationale untouched; the repin is a drop-in there.

## Cost of merge

Two pins and one explicit input; no workflow logic changes. The one behavioral effect: the action's bundled manifests advance from May 2026 to current, so the coverage job installs the current cargo-llvm-cov rather than a year-old one. That is the same effect any dependabot bump of this action would have had, and `cargo-mutants@27` still resolves through the manifest as before.

Closes #665